### PR TITLE
Rejigger the `Makefile` to build clickhouse-cpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ jobs:
   build:
     strategy:
       matrix:
-        pg: [18, 17, 16, 15, 14, 13, 12, 11]
+        pg: [18, 17, 16, 15, 14, 13]
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
     steps:
-      - run: pg-start ${{ matrix.pg }}
+      - run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev
       - uses: actions/checkout@v4
+        with: { submodules: true }
       - run: pg-build-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,19 @@ jobs:
       PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
       PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
     steps:
-    - name: Check out the repo
-      uses: actions/checkout@v4
-    - name: Bundle the Release
-      id: bundle
-      run: pgxn-bundle
-    - name: Release on PGXN
-      run: pgxn-release
-    - name: Generate Release Changes
-      run: make latest-changes.md
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        name: "Release ${{ github.ref_name }}"
-        body_path: latest-changes.md
-        files: ${{ steps.bundle.outputs.bundle }}
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with: { submodules: true }
+      - name: Bundle the Release
+        id: bundle
+        run: pgxn-bundle
+      - name: Release on PGXN
+        run: pgxn-release
+      - name: Generate Release Changes
+        run: make latest-changes.md
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Release ${{ github.ref_name }}"
+          body_path: latest-changes.md
+          files: ${{ steps.bundle.outputs.bundle }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ regression.out
 /clickhouse_fdw-*
 .vscode/
 /build/
+/latest-changes.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "clickhouse-cpp"]
-	path = clickhouse-cpp
+	path = vendor/clickhouse-cpp
 	url = https://github.com/ClickHouse/clickhouse-cpp.git

--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,28 @@ TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 PG_CONFIG   ?= pg_config
-
-MODULE_big = $(EXTENSION)
+MODULE_big   = $(EXTENSION)
 
 # Collect all the C++ and C files to compile into MODULE_big.
 OBJS = $(subst .cpp,.o, $(wildcard src/*.cpp src/*/*.cpp))
 OBJS += $(subst .c,.o, $(wildcard src/*.c src/*/*.c))
 
-# Find all the clickhouse-cpp static libraries we need.
-SHLIB_LINK = $(shell find build -name '*.a')
+# clickhouse-cpp source and build directories.
+CH_CPP_DIR = vendor/clickhouse-cpp
+CH_CPP_BUILD_DIR = $(CH_CPP_DIR)/build
+
+# List the clickhouse-cpp libraries we require.
+CH_CPP_LIBS = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib.a \
+  $(CH_CPP_BUILD_DIR)/contrib/cityhash/cityhash/libcityhash.a \
+  $(CH_CPP_BUILD_DIR)/contrib/absl/absl/libabsl_int128.a \
+  $(CH_CPP_BUILD_DIR)/contrib/lz4/lz4/liblz4.a \
+  $(CH_CPP_BUILD_DIR)/contrib/zstd/zstd/libzstdstatic.a
+
+# We'll need the clickhouse-cpp libraries.
+SHLIB_LINK = $(CH_CPP_LIBS)
 
 # Add include directories.
-PG_CPPFLAGS = -I./src/include -I./clickhouse-cpp -I./clickhouse-cpp/contrib/absl
+PG_CPPFLAGS = -I./src/include -I$(CH_CPP_DIR) -I$(CH_CPP_DIR)/contrib/absl
 
 # Include other libraries compiled into clickhouse-cpp.
 PG_LDFLAGS = -lstdc++ -lssl -lcrypto
@@ -33,24 +43,46 @@ PG_CXXFLAGS = -std=c++17
 # Suppress annoying pre-c99 warning.
 PG_CFLAGS = -Wno-declaration-after-statement
 
-EXTRA_CLEAN = build
+# Clean up the clickhouse-cpp build directory.
+EXTRA_CLEAN = $(CH_CPP_BUILD_DIR)
 
+# Import PGXS.
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
+# PostgresSQL 15 and earlier violate a C++ v17 storage specifier error.
+ifeq ($(shell test $(MAJORVERSION) -lt 16; echo $$?),0)
+	PG_CXXFLAGS += -Wno-register
+endif
+
+# Add the flags to the bitcode compiler variables.
+COMPILE.cc.bc += $(PG_CPPFLAGS)
+COMPILE.cxx.bc += $(PG_CXXFLAGS)
+
+# shlib is the final output product: clickhouse-cpp and all .o dependencies.
+$(shlib): $(CH_CPP_LIBS) $(OBJS)
+
+# Clone clickhouse-cpp submodule.
+$(CH_CPP_DIR)/CMakeLists.txt:
+	git submodule update --init
+
+# Build the clickhouse-cpp libraries.
+$(CH_CPP_LIBS): export CXXFLAGS=-fPIC
+$(CH_CPP_LIBS): export CFLAGS=-fPIC
+$(CH_CPP_LIBS): $(CH_CPP_DIR)/CMakeLists.txt
+	cmake -B $(CH_CPP_BUILD_DIR) -S $(CH_CPP_DIR) -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
+	cmake --build $(CH_CPP_BUILD_DIR) --parallel $(nproc) --target all
+
+# Require the versioned SQL script.
 all: sql/$(EXTENSION)--$(EXTVERSION).sql
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-clickhouse: build/clickhouse/libclickhouse-cpp-lib.a
-
-build/clickhouse/libclickhouse-cpp-lib.a:
-	cmake -B build -S clickhouse-cpp -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
-	cmake --build build --target all
-
+# Build a PGXN distribution bundle.
 dist:
 	git archive --format zip --prefix=$(EXTENSION)-$(DISTVERSION)/ -o $(EXTENSION)-$(DISTVERSION).zip HEAD
 
+# Generate a list of the changes just for the current version.
 latest-changes.md: Changes
 	perl -e 'while (<>) {last if /^(v?\Q${DISTVERSION}\E)/; } print "Changes for v${DISTVERSION}:\n"; while (<>) { last if /^\s*$$/; s/^\s+//; print }' Changes > $@

--- a/README.md
+++ b/README.md
@@ -7,13 +7,39 @@ clickhouse_fdw Postgres Extension
 This library contains the PostgreSQL extension `clickhouse_fdw` a foreign data
 wrapper for ClickHouse databases.
 
-To build `clickhouse_fdw`, just do this:
+## Installation
 
-``` sh
-make clickhouse
+### Compile From Source
+
+#### General Unix
+
+If you have PostgreSQL devel packages and curl devel packages installed, you
+should have `pg_config` and `curl-config` on your path, so you should be able
+to just run `make` (or `gmake`), then `make install`, then in your database
+`CREATE EXTENSION http`.
+
+#### Debian / Ubuntu / APT
+
+See [PostgreSQL Apt] for details on pulling from the PostgreSQL Apt repository.
+
+```sh
+sudo apt install \
+  postgresql-server-17 \
+  libcurl4-openssl-dev \
+  make \
+  cmake \
+  g++
 make
-make installcheck
-make install
+sudo make install
+```
+
+If your host has several PostgreSQL installations, you might need to specify
+the appropriate version of `pg_config`:
+
+```sh
+export PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config
+make
+sudo make install
 ```
 
 If you encounter an error such as:
@@ -46,19 +72,6 @@ to find it:
 env PG_CONFIG=/path/to/pg_config make && make installcheck && make install
 ```
 
-If you encounter an error such as:
-
-```
-ERROR:  must be owner of database regression
-```
-
-You need to run the test suite using a super user, such as the default
-"postgres" super user:
-
-``` sh
-make installcheck PGUSER=postgres
-```
-
 To install the extension in a custom prefix on PostgreSQL 18 or later, pass
 the `prefix` argument to `install` (but no other `make` targets):
 
@@ -73,6 +86,29 @@ parameters]:
 extension_control_path = '/usr/local/extras/postgresql/share:$system'
 dynamic_library_path   = '/usr/local/extras/postgresql/lib:$libdir'
 ```
+
+### Testing
+
+To run the test suite, once the extension has been installed, run
+
+```sh
+make installcheck
+```
+
+If you encounter an error such as:
+
+```
+ERROR:  must be owner of database regression
+```
+
+You need to run the test suite using a super user, such as the default
+"postgres" super user:
+
+``` sh
+make installcheck PGUSER=postgres
+```
+
+### Loading
 
 Once `clickhouse_fdw` is installed, you can add it to a database by connecting
 to a database as a super user and running:
@@ -89,17 +125,16 @@ CREATE SCHEMA env;
 CREATE EXTENSION clickhouse_fdw SCHEMA env;
 ```
 
-Dependencies
------------
+## Dependencies
 
 The `clickhouse_fdw` extension requires PostgreSQL 11 or higher and [libcurl]. Building the
 extension requires a compiler, GNU `make`, and [CMake].
 
-Copyright and License
----------------------
+## Copyright and License
 
 Copyright (c) 2025 ClickHouse.
 
   [`postgresql.conf` parameters]: https://www.postgresql.org/docs/devel/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-OTHER
   [libcurl]: https://curl.se/libcurl/ "libcurl — your network transfer library"
   [CMake]: https://cmake.org/ "CMake: A Powerful Software Build System"
+  [PostgreSQL Apt]: https://wiki.postgresql.org/wiki/Apt


### PR DESCRIPTION
And adjust `ci.yml` to clone submodules, install libcurl-dev, and only test on current stable releases of PostgreSQL.