### PR TITLE
Use dynamic clickhouse-cpp library by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
     steps:
-      - run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev
-      - uses: actions/checkout@v4
+      - name: Start Postgres ${{ matrix.pg }}
+        run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
         with: { submodules: true }
-      - run: pg-build-test
+      - name: Test DSO
+        run: pg-build-test
+      - name: Test Static
+        run: pg-build-test
+        env: { CH_BUILD: static }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,23 @@ sudo apt install \
   make \
   cmake \
   g++
+```
+
+### Compile and Install
+
+To build and install the ClickHouse dynamic library and `clickhouse_fdw`, run:
+
+```sh
 make
 sudo make install
+```
+
+To statically compile the ClickHouse library into `clickhouse_fdw`, pass
+`CH_BUILD=static`:
+
+```sh
+make CH_BUILD=static
+sudo make install CH_BUILD=static
 ```
 
 If your host has several PostgreSQL installations, you might need to specify
@@ -69,14 +84,16 @@ package management system such as RPM to install PostgreSQL, be sure that the
 to find it:
 
 ``` sh
-env PG_CONFIG=/path/to/pg_config make && make installcheck && make install
+export PG_CONFIG=/path/to/pg_config
+make
+sudo make install
 ```
 
 To install the extension in a custom prefix on PostgreSQL 18 or later, pass
 the `prefix` argument to `install` (but no other `make` targets):
 
 ```sh
-make install prefix=/usr/local/extras
+sudo make install prefix=/usr/local/extras
 ```
 
 Then ensure that the prefix is included in the following [`postgresql.conf`


### PR DESCRIPTION
Previously we statically compiled clickhouse-cpp into the extension. But in general, dynamic libraries are preferred. So build clickhouse-cpp as a DSO by default, and install it into the package library directory along with the extension module itself. Compile an `rpath` into the module so that the OS can find the clickhouse-cpp DSO.

Add the `CH_BUILD` variable that, when set to "static", triggers statically compiling clickhouse-cpp into the extension module. Update the CI test to test both configurations.