### PR TITLE
Always compile with `rpath`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         with: { submodules: true }
       - name: Test DSO
         run: pg-build-test
+      - name: Clean
+        run: make clean
       - name: Test Static
         run: pg-build-test
         env: { CH_BUILD: static }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo apt install \
   g++
 ```
 
-### Compile and Install
+#### Compile and Install
 
 To build and install the ClickHouse dynamic library and `clickhouse_fdw`, run:
 
@@ -104,7 +104,7 @@ extension_control_path = '/usr/local/extras/postgresql/share:$system'
 dynamic_library_path   = '/usr/local/extras/postgresql/lib:$libdir'
 ```
 
-### Testing
+#### Testing
 
 To run the test suite, once the extension has been installed, run
 


### PR DESCRIPTION
Update `ci.yaml` to properly clean up the dynamic build before compiling the static build. This revealed a compile failure on Linux, which doesn't like `-Wl` without a comma-separated list.

So initially set `SHLIB_LINK` only to the static library or the `-L` and `-l` values that differ between the dynamic and static builds. Then, set the rest of the `SHLIB_LINK` list after importing PGXS, and user `$(pkgconfig)` instead of `pg_config --pkglibdir` to always set the `rpath`. The static build doesn't need it to find the `clickhouse-cpp` library, but it's harmless and becoming fairly common among Postgres extensions.

While at it, add the `$(OBJS)` target to require the vendored `clickhouse-cpp` submodule, so that it will automatically be initialized if it hasn't already been. This simplifies building from a fresh clone of the repository.

In passing, fix a couple of incorrect header levels in the README.