### PR TITLE
Generate `fdw.c` with version & remove envvar code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ regression.out
 .vscode/
 /build/
 /latest-changes.md
+/src/fdw.c
+/sql/*--*.sql
+!/sql/*--*--*.sql

--- a/sql/clickhouse_fdw--2.0.sql
+++ b/sql/clickhouse_fdw--2.0.sql
@@ -1,2 +1,0 @@
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION clickhouse_fdw" to load this file. \quit

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -12,31 +12,11 @@
 #include "varatt.h"
 #endif
 
-#ifdef PG_MODULE_MAGIC
+#ifdef PG_MODULE_MAGIC_EXT
+PG_MODULE_MAGIC_EXT(.name = "clickhouse_fdw", .version = "__VERSION__");
+#else
 PG_MODULE_MAGIC;
 #endif
-
-PG_FUNCTION_INFO_V1( get_env );
-
-Datum get_env( PG_FUNCTION_ARGS );
-
-Datum get_env( PG_FUNCTION_ARGS ) {
-	const char* val = NULL;
-	size_t length = 0;
-	text *t = NULL;
-
-	text* name = PG_GETARG_TEXT_PP(0);
-
-	val = getenv(text_to_cstring(name));
-	if (!val) PG_RETURN_NULL();
-
-    /* Return text. */
-	length = strlen( val );
-	t = (text *) palloc(VARHDRSZ + length );
-	SET_VARSIZE( t, VARHDRSZ + length );
-	memcpy( VARDATA(t), val, length );
-	PG_RETURN_TEXT_P( t );
-}
 
 ch_connection
 chfdw_binary_connect(ch_connection_details *details)


### PR DESCRIPTION
Rename `src/fdw.c` to `src/fdw.c.in` and add a `Makefile` target to generate the former. It replaces `__VERSION__` with the version. Teach `.gitignore` to ignore the generated file. Inspired by the addition of `PG_MODULE_MAGIC_EXT` in PostgreSQL 18; see [this post] for details.

Also delete the generated `sql/clickhouse_fdw--2.0.sql` file, and make sure it and `src/fdw.c` are included in the `clean` target. Teach `.gitignore` to ignore the generated file, but to keep any files with two sets of `--` in them, as will be true of upgrade scripts.

While at it, delete code left over from the original experiment using the envvar extension.

  [this post]: https://justatheory.com/2025/05/pg_module_magic_ext/
    "Postgres Extensions: Use `PG_MODULE_MAGIC_EXT`"