### PR TITLE
Copy and port old FDW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     strategy:
       matrix:
-        pg: [18, 17, 16, 15, 14, 13]
+        pg: [17, 16, 15, 14, 13]
     name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
     steps:
       - name: Start Postgres ${{ matrix.pg }}
-        run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev
+        run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev uuid-dev
       - name: Checkout the Repository
         uses: actions/checkout@v4
         with: { submodules: true }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See [PostgreSQL Apt] for details on pulling from the PostgreSQL Apt repository.
 sudo apt install \
   postgresql-server-17 \
   libcurl4-openssl-dev \
+  uuid-dev \
   make \
   cmake \
   g++
@@ -53,6 +54,15 @@ the appropriate version of `pg_config`:
 
 ```sh
 export PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config
+make
+sudo make install
+```
+
+If `curl-config` is not in the path on you host, you can specify the path
+explicitly:
+
+```sh
+export CURL_CONFIG=/opt/homebrew/opt/curl/bin/curl-config
 make
 sudo make install
 ```
@@ -144,8 +154,9 @@ CREATE EXTENSION clickhouse_fdw SCHEMA env;
 
 ## Dependencies
 
-The `clickhouse_fdw` extension requires PostgreSQL 11 or higher and [libcurl]. Building the
-extension requires a compiler, GNU `make`, and [CMake].
+The `clickhouse_fdw` extension requires PostgreSQL 11 or higher, [libcurl],
+and [libuuid]. Building the extension requires a compiler, GNU `make`, and
+[CMake].
 
 ## Copyright and License
 
@@ -153,5 +164,6 @@ Copyright (c) 2025 ClickHouse.
 
   [`postgresql.conf` parameters]: https://www.postgresql.org/docs/devel/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-OTHER
   [libcurl]: https://curl.se/libcurl/ "libcurl — your network transfer library"
+  [libuuid]: https://linux.die.net/man/3/libuuid "libuuid - DCE compatible Universally Unique Identifier library"
   [CMake]: https://cmake.org/ "CMake: A Powerful Software Build System"
   [PostgreSQL Apt]: https://wiki.postgresql.org/wiki/Apt

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -1,57 +1,1020 @@
 #include <iostream>
+#include <cassert>
+#include <stdexcept>
+
+#include "clickhouse/columns/date.h"
+#include "clickhouse/columns/ip4.h"
+#include "clickhouse/columns/lowcardinality.h"
+#include "clickhouse/columns/nullable.h"
+#include "clickhouse/columns/factory.h"
 #include <clickhouse/client.h>
-#include "include/binary.hh"
-#include "include/internal.h"
+#include <clickhouse/query.h>
+#include <clickhouse/types/types.h>
+
+#if __cplusplus > 199711L
+#define register // Deprecated in C++11.
+#endif // #if __cplusplus > 199711L
+
+extern "C" {
+
 #include "postgres.h"
 #include "pgtime.h"
 #include "funcapi.h"
 #include "fmgr.h"
+#include "access/htup_details.h"
+#include "access/tupdesc.h"
+#include "catalog/pg_type_d.h"
+#include "utils/array.h"
+#include "utils/builtins.h"
+#include "utils/date.h"
+#include "utils/elog.h"
+#include "utils/lsyscache.h"
+#include "utils/memdebug.h"
+#include "utils/palloc.h"
+#include "utils/timestamp.h"
+#include "utils/uuid.h"
+#include "binary.hh"
+#include "internal.h"
 
 using namespace clickhouse;
 
-extern "C" {
-    ch_binary_connection_t * ch_binary_connect(
-        char * host, int port, char * database, char * user, char * password, char ** error)
-    {
-        ClientOptions * options = NULL;
-        ch_binary_connection_t * conn = NULL;
+#if defined(__APPLE__) // Byte ordering on macOS
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define HOST_TO_BIG_ENDIAN_64(x) OSSwapHostToBigInt64(x)
+#else
+#include <endian.h>
+#define HOST_TO_BIG_ENDIAN_64(x) htobe64(x)
+#endif
 
-        try
-        {
-            options = new ClientOptions();
-            options->SetPingBeforeQuery(true);
+/* palloc which will throw exceptions */
+static void * exc_palloc(Size size)
+{
+	/* duplicates MemoryContextAlloc to avoid increased overhead */
+	void * ret;
+	MemoryContext context = CurrentMemoryContext;
 
-            if (host)
-                options->SetHost(std::string(host));
-            if (port)
-                options->SetPort(port);
-            if (database)
-                options->SetDefaultDatabase(std::string(database));
-            if (user)
-                options->SetUser(std::string(user));
-            if (password)
-                options->SetPassword(std::string(password));
+	Assert(MemoryContextIsValid(context));
 
-            //options->SetRethrowException(false);
-            conn = new ch_binary_connection_t();
+	if (!AllocSizeIsValid(size))
+		throw std::bad_alloc();
 
-            Client * client = new Client(*options);
-            conn->client = client;
-            conn->options = options;
+	context->isReset = false;
+
+#if PG_VERSION_NUM >= 170000
+	ret = context->methods->alloc(context, size, 0);
+#else
+	ret = context->methods->alloc(context, size);
+#endif
+	if (unlikely(ret == NULL))
+		throw std::bad_alloc();
+
+	VALGRIND_MEMPOOL_ALLOC(context, ret, size);
+
+	return ret;
+}
+
+void * exc_palloc0(Size size)
+{
+	/* duplicates MemoryContextAllocZero to avoid increased overhead */
+	void * ret;
+	MemoryContext context = CurrentMemoryContext;
+
+	Assert(MemoryContextIsValid(context));
+
+	if (!AllocSizeIsValid(size))
+		throw std::bad_alloc();
+
+	context->isReset = false;
+
+#if PG_VERSION_NUM >= 170000
+	ret = context->methods->alloc(context, size, 0);
+#else
+	ret = context->methods->alloc(context, size);
+#endif
+	if (unlikely(ret == NULL))
+		throw std::bad_alloc();
+
+	VALGRIND_MEMPOOL_ALLOC(context, ret, size);
+
+	MemSetAligned(ret, 0, size);
+
+	return ret;
+}
+
+ch_binary_connection_t * ch_binary_connect(
+	char * host, int port, char * database, char * user, char * password, char ** error)
+{
+	ClientOptions * options = NULL;
+	ch_binary_connection_t * conn = NULL;
+
+	try
+	{
+		options = new ClientOptions();
+		options->SetPingBeforeQuery(true);
+
+		if (host)
+			options->SetHost(std::string(host));
+		if (port)
+			options->SetPort(port);
+		if (database)
+			options->SetDefaultDatabase(std::string(database));
+		if (user)
+			options->SetUser(std::string(user));
+		if (password)
+			options->SetPassword(std::string(password));
+
+		//options->SetRethrowException(false);
+		conn = new ch_binary_connection_t();
+
+		Client * client = new Client(*options);
+		conn->client = client;
+		conn->options = options;
+	}
+	catch (const std::exception & e)
+	{
+		if (error)
+			*error = strdup(e.what());
+
+		if (conn != NULL)
+			delete conn;
+
+		if (options != NULL)
+			delete options;
+
+		conn = NULL;
+	}
+	return conn;
+}
+
+static void set_resp_error(ch_binary_response_t * resp, const char * str)
+{
+	if (resp->error)
+		return;
+
+	resp->error = (char *)malloc(strlen(str) + 1);
+	strcpy(resp->error, str);
+}
+
+static void set_state_error(ch_binary_read_state_t * state, const char * str)
+{
+	assert(state->error == NULL);
+	state->error = (char *)malloc(strlen(str) + 1);
+	strcpy(state->error, str);
+}
+
+ch_binary_response_t * ch_binary_simple_query(
+	ch_binary_connection_t * conn, const char * query, bool (*check_cancel)(void))
+{
+	Client * client = (Client *)conn->client;
+	ch_binary_response_t * resp;
+	std::vector<std::vector<clickhouse::ColumnRef>> * values;
+
+	try
+	{
+		resp = new ch_binary_response_t();
+		values = new std::vector<std::vector<clickhouse::ColumnRef>>();
+
+		client->SelectCancelable(
+			std::string(query), [&resp, &values, &check_cancel](const Block & block) {
+				if (check_cancel && check_cancel())
+				{
+					set_resp_error(resp, "query was canceled");
+					return false;
+				}
+
+				/* some empty block */
+				if (block.GetColumnCount() == 0)
+					return true;
+
+				auto vec = std::vector<clickhouse::ColumnRef>();
+
+				if (resp->columns_count && block.GetColumnCount() != resp->columns_count)
+				{
+					set_resp_error(resp, "columns mismatch in blocks");
+					return false;
+				}
+
+				resp->columns_count = block.GetColumnCount();
+				resp->blocks_count++;
+
+				for (size_t i = 0; i < resp->columns_count; ++i)
+					vec.push_back(block[i]);
+
+				values->push_back(std::move(vec));
+				return true;
+			});
+
+		resp->values = (void *)values;
+	}
+	catch (const std::exception & e)
+	{
+        client->ResetConnection();
+
+		values->clear();
+		set_resp_error(resp, e.what());
+		delete values;
+		values = NULL;
+	}
+
+	resp->success = (resp->error == NULL);
+	return resp;
+}
+
+static Oid get_corr_postgres_type(const TypeRef & type)
+{
+	switch (type->GetCode())
+	{
+		case Type::Code::Int8:
+		case Type::Code::Int16:
+		case Type::Code::UInt8:
+			return INT2OID;
+		case Type::Code::Int32:
+		case Type::Code::UInt16:
+			return INT4OID;
+		case Type::Code::Int64:
+		case Type::Code::UInt64:
+		case Type::Code::UInt32:
+			return INT8OID;
+		case Type::Code::Float32:
+			return FLOAT4OID;
+		case Type::Code::Float64:
+			return FLOAT8OID;
+		case Type::Code::FixedString:
+		case Type::Code::Enum8:
+		case Type::Code::Enum16:
+		case Type::Code::String:
+			return TEXTOID;
+		case Type::Code::LowCardinality:
+			return get_corr_postgres_type(type->As<LowCardinalityType>()->GetNestedType());
+		case Type::Code::Date:
+			return DATEOID;
+		case Type::Code::DateTime:
+			return TIMESTAMPOID;
+		case Type::Code::DateTime64:
+			return TIMESTAMPOID;
+		case Type::Code::UUID:
+			return UUIDOID;
+		case Type::Code::Array: {
+			Oid array_type = get_array_type(
+				get_corr_postgres_type(type->As<clickhouse::ArrayType>()->GetItemType()));
+			if (array_type == InvalidOid)
+				throw std::runtime_error(
+					"clickhouse_fdw: could not find array "
+					" type for column type "
+					+ type->GetName());
+
+			return array_type;
+		}
+		case Type::Code::Tuple:
+			return RECORDOID;
+		case Type::Code::Nullable:
+			return get_corr_postgres_type(type->As<NullableType>()->GetNestedType());
+		default:
+			throw std::runtime_error("clickhouse_fdw: unsupported column type " + type->GetName());
+	}
+}
+
+void ch_binary_insert_state_free(void * c)
+{
+	auto * state = (ch_binary_insert_state *)c;
+	if (state->columns)
+	{
+		/* try to send empty block that sets proper ClickHouse state */
+		if (!state->success)
+		{
+			try
+			{
+				Client * client = (Client *)state->conn->client;
+				client->Insert(state->table_name, Block());
+			}
+			catch (const std::exception & e)
+			{
+				// just ignore, next query will fail
+				elog(NOTICE, "clickhouse_fdw: could not send empty packet");
+			}
+		}
+
+		delete (std::vector<clickhouse::ColumnRef> *)state->columns;
+	}
+}
+
+void ch_binary_prepare_insert(void * conn, char * query, ch_binary_insert_state * state)
+{
+	throw std::runtime_error("clickhouse_fdw: XXX ch_binary_prepare_insert not implemented");
+
+// 	std::vector<clickhouse::ColumnRef> * vec = nullptr;
+// 	Client * client = (Client *)((ch_binary_connection_t *)conn)->client;
+
+// 	try
+// 	{
+// 		client->PrepareInsert(
+// 			std::string(query) + " VALUES", [&state, &vec](const Block & sample_block) {
+// 				if (sample_block.GetColumnCount() == 0)
+// 					return true;
+
+// 				vec = new std::vector<clickhouse::ColumnRef>();
+
+// 				state->len = sample_block.GetColumnCount();
+
+// #if PG_VERSION_NUM < 120000
+// 				state->outdesc = CreateTemplateTupleDesc(state->len, false);
+// #else
+// 			    state->outdesc = CreateTemplateTupleDesc(state->len);
+// #endif
+
+// 				for (size_t i = 0; i < state->len; i++)
+// 				{
+// 					bool error = false;
+// 					clickhouse::ColumnRef col = sample_block[i];
+
+// 					auto chtype = col->Type();
+// 					if (chtype->GetCode() == Type::LowCardinality)
+// 					{
+// 						chtype = col->As<ColumnLowCardinality>()->GetNestedType();
+// 					}
+
+// 					Oid pgtype = get_corr_postgres_type(chtype);
+
+// 					vec->push_back(clickhouse::CreateColumnByType(col->Type()->GetName()));
+// 					const char * colname = sample_block.GetColumnName(i).c_str();
+
+// 					/* we can't afford long jumps outside of this function */
+// 					PG_TRY();
+// 					{
+// 						TupleDescInitEntry(
+// 							state->outdesc, (AttrNumber)i + 1, colname, pgtype, -1, 0);
+// 					}
+// 					PG_CATCH();
+// 					{
+// 						error = true;
+// 					}
+// 					PG_END_TRY();
+
+// 					if (error)
+// 						throw std::runtime_error("could not init tuple descriptor");
+// 				}
+
+// 				return true;
+// 			});
+// 	}
+// 	catch (const std::exception & e)
+// 	{
+//         client->ResetConnection();
+
+// 		if (vec != nullptr)
+// 			delete vec;
+
+// 		elog(ERROR, "clickhouse_fdw: error while insert preparation - %s", e.what());
+// 	}
+
+// 	if (vec != nullptr)
+// 		state->columns = (void *)vec;
+}
+
+static void column_append(clickhouse::ColumnRef col, Datum val, Oid valtype, bool isnull)
+{
+	bool nullable = false;
+
+	if (col->Type()->GetCode() == Type::Code::Nullable)
+		nullable = true;
+
+	if (isnull && !nullable)
+		throw std::runtime_error(
+			"unexpected column "
+			"type for NULL: "
+			+ col->Type()->GetName());
+
+	if (nullable)
+	{
+		auto nullable = col->As<ColumnNullable>();
+		nullable->Append(isnull);
+		col = nullable->Nested();
+	}
+
+	switch (valtype)
+	{
+		case INT2OID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::UInt8:
+					col->As<ColumnUInt8>()->Append((uint8_t)val);
+					break;
+				case Type::Code::Int8:
+					col->As<ColumnInt8>()->Append((int8_t)val);
+					break;
+				case Type::Code::Int16:
+					col->As<ColumnInt16>()->Append((int16_t)val);
+					break;
+				default:
+					throw std::runtime_error(
+						"clickhouse_fdw: unexpected column "
+						"type for INT2: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case INT4OID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::Int32:
+					col->As<ColumnInt32>()->Append((int32_t)val);
+					break;
+				case Type::Code::UInt16:
+					col->As<ColumnUInt16>()->Append((uint16_t)val);
+					break;
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for INT4: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case INT8OID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::Int64:
+					col->As<ColumnInt64>()->Append((int64_t)val);
+					break;
+				case Type::Code::UInt32:
+					col->As<ColumnUInt32>()->Append((uint32_t)val);
+					break;
+				case Type::Code::UInt64:
+					col->As<ColumnUInt64>()->Append((uint64_t)val);
+					break;
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for INT8: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case FLOAT4OID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::Float32:
+					col->As<ColumnFloat32>()->Append(DatumGetFloat4(val));
+					break;
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for FLOAT4: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case FLOAT8OID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::Float64:
+					col->As<ColumnFloat64>()->Append(DatumGetFloat8(val));
+					break;
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for FLOAT8: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case TEXTOID: {
+			char * s = TextDatumGetCString(val);
+
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::FixedString:
+					col->As<ColumnFixedString>()->Append(s);
+					break;
+				case Type::Code::String:
+					col->As<ColumnString>()->Append(s);
+					break;
+				case Type::Code::Enum8:
+					col->As<ColumnEnum8>()->Append(s);
+					break;
+				case Type::Code::Enum16:
+					col->As<ColumnEnum16>()->Append(s);
+					break;
+				case Type::Code::LowCardinality: {
+					// XXX Figure out proper value to create and pass to
+					// Append.
+					throw std::runtime_error(
+						"clickhouse_fdw: XXX unsupported column type "
+						+ col->Type()->GetName()
+					);
+					// auto item = ItemView{Type::String, std::string_view(s)};
+					// col->As<ColumnLowCardinality>()->Append(item);
+					break;
+				}
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for TEXT: "
+						+ col->Type()->GetName());
+			}
+
+			break;
+		}
+		case DATEOID: {
+			Timestamp t = date2timestamp_no_overflow(DatumGetDateADT(val));
+			pg_time_t d = timestamptz_to_time_t(t);
+
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::Date:
+					col->As<ColumnDate>()->Append(d);
+					break;
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for DATE: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case TIMESTAMPOID: {
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::DateTime: {
+					pg_time_t d = timestamptz_to_time_t(DatumGetTimestamp(val));
+					col->As<ColumnDateTime>()->Append(d);
+					break;
+				}
+				case Type::Code::DateTime64: {
+					auto dt64_col = col->As<ColumnDateTime64>();
+					Timestamp t = DatumGetTimestamp(val);
+					Int64 dt64 = ((1.0 * t) / USECS_PER_SEC
+								  + ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * SECS_PER_DAY))
+						* pow(10.0, dt64_col->GetPrecision());
+
+					dt64_col->Append(dt64);
+					break;
+				}
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for TIMESTAMPOID: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		case ANYARRAYOID: {
+			// auto arr = (ch_binary_array_t *)DatumGetPointer(val);
+
+			switch (col->Type()->GetCode())
+			{
+				case Type::Array: {
+					// XXX Figure out proper value to create and pass to
+					// Append.
+					throw std::runtime_error(
+						"clickhouse_fdw: XXX unsupported column type "
+						+ col->Type()->GetName()
+					);
+					// auto arrcol = col->As<ColumnArray>();
+
+					// arrcol->OffsetsIncrease(arr->len);
+					// for (size_t i = 0; i < arr->len; i++)
+					// 	column_append(
+					// 		arrcol->Nested(), arr->datums[i], arr->item_type, arr->nulls[i]);
+
+					// break;
+				}
+				default:
+					throw std::runtime_error(
+						"unexpected column "
+						"type for array: "
+						+ col->Type()->GetName());
+			}
+			break;
+		}
+		default: {
+			throw std::runtime_error(
+				"unexpected type " + std::to_string(valtype)
+				+ " type for : " + col->Type()->GetName());
+		}
+	}
+}
+
+void ch_binary_column_append_data(ch_binary_insert_state * state, size_t colidx)
+{
+	try
+	{
+		auto columns = *(std::vector<clickhouse::ColumnRef> *)state->columns;
+		auto col = columns[colidx];
+
+		Datum val = state->values[colidx];
+		Oid valtype = state->outdesc->attrs[colidx].atttypid;
+		bool isnull = state->nulls[colidx];
+
+		column_append(col, val, valtype, isnull);
+	}
+	catch (const std::exception & e)
+	{
+		elog(ERROR, "clickhouse_fdw: could not append data to column - %s", e.what());
+	}
+}
+
+void ch_binary_insert_columns(ch_binary_insert_state * state)
+{
+	try
+	{
+		Block block;
+		auto columns = *(std::vector<clickhouse::ColumnRef> *)state->columns;
+		for (int i = 0; i < state->outdesc->natts; ++i)
+		{
+			Form_pg_attribute att = TupleDescAttr(state->outdesc, i);
+			block.AppendColumn(NameStr(att->attname), columns[i]);
+		}
+
+		Client * client = (Client *)state->conn->client;
+		client->Insert(state->table_name, block);
+	}
+	catch (const std::exception & e)
+	{
+		elog(ERROR, "clickhouse_fdw: could not insert columns - %s", e.what());
+	}
+}
+
+void ch_binary_close(ch_binary_connection_t * conn)
+{
+	delete (Client *)conn->client;
+	delete (ClientOptions *)conn->options;
+}
+
+void ch_binary_response_free(ch_binary_response_t * resp)
+{
+	if (resp->values)
+	{
+		auto values = (std::vector<std::vector<clickhouse::ColumnRef>> *)resp->values;
+		values->clear();
+		delete values;
+	}
+
+	if (resp->error)
+		free(resp->error);
+
+	delete resp;
+}
+
+void ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_response_t * resp)
+{
+	state->resp = resp;
+	state->block = 0;
+	state->row = 0;
+	state->done = false;
+	state->error = NULL;
+	state->coltypes = NULL;
+	state->values = NULL;
+	state->nulls = NULL;
+
+	/* it response was errored just set error in state too */
+	if (resp->error)
+	{
+		state->done = true;
+		set_state_error(state, resp->error);
+		return;
+	}
+
+	try
+	{
+		assert(resp->values);
+		auto & values = *((std::vector<std::vector<clickhouse::ColumnRef>> *)resp->values);
+
+		if (resp->columns_count && values.size() > 0)
+		{
+			state->coltypes = new Oid[resp->columns_count];
+			state->values = new Datum[resp->columns_count];
+			state->nulls = new bool[resp->columns_count];
+		}
+	}
+	catch (const std::exception & e)
+	{
+		set_state_error(state, e.what());
+	}
+}
+
+/*
+ * This function is preparing values for `convert_datum` which is called in upper
+ * code.
+ *
+ * This function calls postgres functions, which can call `palloc` so we can end up
+ * with elog(ERROR) and longjmp to upper postgres code with leaking c++ memory.
+ *
+ * There is no an adequate (without huge overheads) solution, we just consider
+ * this state unfixable.
+ */
+static Datum make_datum(clickhouse::ColumnRef col, size_t row, Oid * valtype, bool * is_null)
+{
+	Datum ret = (Datum)0;
+
+nested_col:
+	auto type_code = col->Type()->GetCode();
+
+	*valtype = InvalidOid;
+	*is_null = false;
+
+	switch (type_code)
+	{
+		case Type::Code::UInt8: {
+			int16 val = col->As<ColumnUInt8>()->At(row);
+			ret = (Datum)val;
+			*valtype = INT2OID;
+		}
+		break;
+		case Type::Code::UInt16: {
+			int16 val = col->As<ColumnUInt16>()->At(row);
+			ret = (Datum)val;
+			*valtype = INT4OID;
+		}
+		break;
+		case Type::Code::UInt32: {
+			int64 val = col->As<ColumnUInt32>()->At(row);
+			ret = Int64GetDatum(val);
+			*valtype = INT8OID;
+		}
+		break;
+		case Type::Code::UInt64: {
+			uint64 val = col->As<ColumnUInt64>()->At(row);
+			if (val > LONG_MAX)
+				throw std::overflow_error("clickhouse_fdw: int64 overflow");
+
+			ret = Int64GetDatum((int64)val);
+			*valtype = INT8OID;
+		}
+		break;
+		case Type::Code::Int8: {
+			int16 val = col->As<ColumnInt8>()->At(row);
+			ret = (Datum)val;
+			*valtype = INT2OID;
+		}
+		break;
+		case Type::Code::Int16: {
+			int16 val = col->As<ColumnInt16>()->At(row);
+			ret = (Datum)val;
+			*valtype = INT2OID;
+		}
+		break;
+		case Type::Code::Int32: {
+			int val = col->As<ColumnInt32>()->At(row);
+			ret = (Datum)val;
+			*valtype = INT4OID;
+		}
+		break;
+		case Type::Code::Int64: {
+			int64 val = col->As<ColumnInt64>()->At(row);
+			ret = Int64GetDatum(val);
+			*valtype = INT8OID;
+		}
+		break;
+		case Type::Code::Float32: {
+			float val = col->As<ColumnFloat32>()->At(row);
+			ret = Float4GetDatum(val);
+			*valtype = FLOAT4OID;
+		}
+		break;
+		case Type::Code::Float64: {
+			double val = col->As<ColumnFloat64>()->At(row);
+			ret = Float8GetDatum(val);
+			*valtype = FLOAT8OID;
+		}
+		break;
+		case Type::Code::FixedString: {
+			auto s = std::string(col->As<ColumnFixedString>()->At(row));
+			ret = CStringGetTextDatum(s.c_str());
+			*valtype = TEXTOID;
+		}
+		break;
+		case Type::Code::String: {
+			auto s = std::string(col->As<ColumnString>()->At(row));
+			ret = CStringGetTextDatum(s.c_str());
+			*valtype = TEXTOID;
+		}
+		break;
+		case Type::Code::Enum8: {
+			auto s = std::string(col->As<ColumnEnum8>()->NameAt(row));
+			ret = CStringGetTextDatum(s.c_str());
+			*valtype = TEXTOID;
+		}
+		break;
+		case Type::Code::Enum16: {
+			auto s = std::string(col->As<ColumnEnum16>()->NameAt(row));
+			ret = CStringGetTextDatum(s.c_str());
+			*valtype = TEXTOID;
+		}
+		break;
+		case Type::Code::Date: {
+			auto val = static_cast<pg_time_t>(col->As<ColumnDate>()->At(row));
+			*valtype = DATEOID;
+
+			if (val == 0)
+				/* clickhouse special case */
+				*is_null = true;
+			else
+			{
+				Timestamp t = (Timestamp)time_t_to_timestamptz(val);
+				ret = TimestampGetDatum(t);
+			}
+		}
+		break;
+		case Type::Code::DateTime: {
+			auto val = static_cast<pg_time_t>(col->As<ColumnDateTime>()->At(row));
+			*valtype = TIMESTAMPOID;
+
+			if (val == 0)
+				*is_null = true;
+			else
+			{
+				Timestamp t = (Timestamp)time_t_to_timestamptz(val);
+				ret = TimestampGetDatum(t);
+			}
+		}
+		break;
+		case Type::Code::DateTime64: {
+			auto dt_col = col->As<ColumnDateTime64>();
+			auto val = dt_col->At(row);
+
+			*valtype = TIMESTAMPOID;
+
+			if (val == 0)
+				*is_null = true;
+			else
+			{
+				ret = ((1.0 * val) / pow(10, dt_col->GetPrecision())
+					   - (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * SECS_PER_DAY)
+					* USECS_PER_SEC;
+			}
+		}
+		break;
+		// case Type::Code::UUID: {
+		// 	/* we form char[16] from two uint64 numbers, and they should
+		// 	 * be big endian */
+		// 	UInt128 val = col->As<ColumnUUID>()->At(row);
+		// 	pg_uuid_t * uuid_val = (pg_uuid_t *)exc_palloc(sizeof(pg_uuid_t));
+
+		// 	val.first = HOST_TO_BIG_ENDIAN_64(val.first);
+		// 	val.second = HOST_TO_BIG_ENDIAN_64(val.second);
+		// 	memcpy(uuid_val->data, &val.first, 8);
+		// 	memcpy(uuid_val->data + 8, &val.second, 8);
+
+		// 	ret = UUIDPGetDatum(uuid_val);
+		// 	*valtype = UUIDOID;
+		// }
+		break;
+		case Type::Code::Nullable: {
+			auto nullable = col->As<ColumnNullable>();
+			if (nullable->IsNull(row))
+			{
+				*is_null = true;
+			}
+			else
+			{
+				col = nullable->Nested();
+				goto nested_col;
+			}
+		}
+		break;
+		case Type::Code::Array: {
+			auto arr = col->As<ColumnArray>()->GetAsColumn(row);
+			size_t len = arr->Size();
+			auto slot = (ch_binary_array_t *)exc_palloc(sizeof(ch_binary_array_t));
+
+			Oid item_type = get_corr_postgres_type(arr->Type());
+			Oid array_type = get_array_type(item_type);
+
+			if (array_type == InvalidOid)
+				throw std::runtime_error(
+					std::string("clickhouse_fdw: could not") + " find array type for "
+					+ std::to_string(item_type));
+
+			slot->len = len;
+			slot->array_type = array_type;
+			slot->item_type = item_type;
+
+			if (len > 0)
+			{
+				slot->datums = (Datum *)exc_palloc0(sizeof(Datum) * len);
+				slot->nulls = (bool *)exc_palloc0(sizeof(bool) * len);
+
+				for (size_t i = 0; i < len; ++i)
+					slot->datums[i] = make_datum(arr, i, &slot->item_type, &slot->nulls[i]);
+			}
+
+			/* this one will need additional work, since we just return raw slot */
+			ret = PointerGetDatum(slot);
+			*valtype = ANYARRAYOID;
+		}
+		break;
+		case Type::Code::Tuple: {
+			auto tuple = col->As<ColumnTuple>();
+			auto len = tuple->TupleSize();
+
+			if (len == 0)
+				throw std::runtime_error("clickhouse_fdw: returned tuple is empty");
+
+			auto slot = (ch_binary_tuple_t *)exc_palloc(sizeof(ch_binary_tuple_t));
+
+			slot->datums = (Datum *)exc_palloc(sizeof(Datum) * len);
+			slot->nulls = (bool *)exc_palloc0(sizeof(bool) * len);
+			slot->types = (Oid *)exc_palloc0(sizeof(Oid) * len);
+			slot->len = len;
+
+			for (size_t i = 0; i < len; ++i)
+			{
+				auto tuple_col = (*tuple)[i];
+
+				slot->datums[i] = make_datum(tuple_col, row, &slot->types[i], &slot->nulls[i]);
+			}
+
+			/* this one will need additional work, since we just return raw slot */
+			ret = PointerGetDatum(slot);
+			*valtype = RECORDOID;
+		}
+		break;
+		case Type::Code::LowCardinality: {
+			auto item = col->As<ColumnLowCardinality>()->GetItem(row);
+			auto data = item.AsBinaryData();
+			ret = PointerGetDatum(cstring_to_text_with_len(data.data(), data.size()));
+			*valtype = TEXTOID;
+		}
+		break;
+        case Type::Code::IPv4: {
+			auto item = col->As<ColumnIPv4>()->AsString(row);
+            ret = DirectFunctionCall1(inet_in, CStringGetDatum(item.c_str()));
+            *valtype = INETOID;
         }
-        catch (const std::exception & e)
-        {
-            if (error)
-                *error = strdup(e.what());
-
-            if (conn != NULL)
-                delete conn;
-
-            if (options != NULL)
-                delete options;
-
-            conn = NULL;
+        break;
+        case Type::Code::IPv6: {
+			auto item = col->As<ColumnIPv6>()->AsString(row);
+            ret = DirectFunctionCall1(inet_in, CStringGetDatum(item.c_str()));
+            *valtype = INETOID;
         }
-        return conn;
-        }
+        break;
+		default:
+			throw std::runtime_error("unsupported type in binary protocol");
+	}
+
+	return ret;
+}
+
+bool ch_binary_read_row(ch_binary_read_state_t * state)
+{
+	/* coltypes is NULL means there are no blocks */
+	bool res = false;
+
+	if (state->done || state->coltypes == NULL || state->error)
+		return false;
+
+	assert(state->resp->values);
+	auto & values = *((std::vector<std::vector<clickhouse::ColumnRef>> *)state->resp->values);
+	try
+	{
+	again:
+		assert(state->block < state->resp->blocks_count);
+		auto & block = values[state->block];
+		size_t row_count = block[0]->Size();
+
+		if (row_count == 0)
+			goto next_row;
+
+		for (size_t i = 0; i < state->resp->columns_count; i++)
+		{
+			/* fill value and null arrays */
+			state->values[i]
+				= make_datum(block[i], state->row, &state->coltypes[i], &state->nulls[i]);
+		}
+		res = true;
+
+	next_row:
+		state->row++;
+		if (state->row >= row_count)
+		{
+			state->row = 0;
+			state->block++;
+			if (state->block >= state->resp->blocks_count)
+				state->done = true;
+			else if (row_count == 0)
+				goto again;
+		}
+	}
+	catch (const std::exception & e)
+	{
+		set_state_error(state, e.what());
+	}
+
+	return res;
+}
+
+void ch_binary_read_state_free(ch_binary_read_state_t * state)
+{
+	if (state->coltypes)
+	{
+		delete[] state->coltypes;
+		delete[] state->values;
+		delete[] state->nulls;
+	}
+
+	if (state->error)
+		free(state->error);
+}
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -1,0 +1,408 @@
+/*-------------------------------------------------------------------------
+ *
+ * connection,c
+ *		  Connection management functions for clickhouse_fdw
+ *
+ * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2019-2022, Adjust GmbH
+ * Copyright (c) 2025, ClickHouse, Inc.
+ *
+ * IDENTIFICATION
+ *		  github.com/clickhouse/clickhouse_fdw/src/connection.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "catalog/pg_user_mapping.h"
+#include "common/int.h"
+#include "access/xact.h"
+#include "mb/pg_wchar.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "storage/latch.h"
+#include "utils/builtins.h"
+#include "utils/hsearch.h"
+#include "utils/inval.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+
+#include "fdw.h"
+
+/*
+ * Connection cache (initialized on first use)
+ */
+static HTAB *ConnectionHash = NULL;
+static void chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue);
+static int32 strtoint32(const char *s);
+
+
+static ch_connection
+clickhouse_connect(ForeignServer *server, UserMapping *user)
+{
+	char	   *driver = "http";
+
+	/* default settings */
+	ch_connection_details	details = {"127.0.0.1", 8123, NULL, NULL, "default"};
+
+	chfdw_extract_options(server->options, &driver, &details.host,
+		&details.port, &details.dbname, &details.username, &details.password);
+	chfdw_extract_options(user->options, &driver, &details.host,
+		&details.port, &details.dbname, &details.username, &details.password);
+
+	if (strcmp(driver, "http") == 0)
+	{
+		return chfdw_http_connect(&details);
+	}
+	else if (strcmp(driver, "binary") == 0)
+	{
+		if (details.port == 8123)
+			details.port = 9000;
+
+		return chfdw_binary_connect(&details);
+	}
+	else
+		elog(ERROR, "invalid ClickHouse connection driver");
+}
+
+ch_connection
+chfdw_get_connection(UserMapping *user)
+{
+	bool		found;
+	ConnCacheEntry *entry;
+	ConnCacheKey key;
+
+	/* First time through, initialize connection cache hashtable */
+	if (ConnectionHash == NULL)
+	{
+		HASHCTL		ctl;
+
+		MemSet(&ctl, 0, sizeof(ctl));
+		ctl.keysize = sizeof(ConnCacheKey);
+		ctl.entrysize = sizeof(ConnCacheEntry);
+		/* allocate ConnectionHash in the cache context */
+		ctl.hcxt = CacheMemoryContext;
+		ConnectionHash = hash_create("clickhouse_fdw connections", 8,
+									 &ctl,
+									 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+		/*
+		 * Register some callback functions that manage connection cleanup.
+		 * This should be done just once in each backend.
+		 */
+		CacheRegisterSyscacheCallback(FOREIGNSERVEROID,
+									  chfdw_inval_callback, (Datum) 0);
+		CacheRegisterSyscacheCallback(USERMAPPINGOID,
+									  chfdw_inval_callback, (Datum) 0);
+	}
+
+	/* Create hash key for the entry.  Assume no pad bytes in key struct */
+	key.userid = user->umid;
+
+	/*
+	 * Find or create cached entry for requested connection.
+	 */
+	entry = hash_search(ConnectionHash, &key, HASH_ENTER, &found);
+	if (!found)
+	{
+		/*
+		 * We need only clear "conn" here; remaining fields will be filled
+		 * later when "conn" is set.
+		 */
+		entry->gate.conn = NULL;
+	}
+
+	/*
+	 * If the connection needs to be remade due to invalidation, disconnect as
+	 * soon as we're out of all transactions.
+	 */
+	if (entry->gate.conn != NULL && entry->invalidated)
+	{
+		elog(LOG, "closing connection to ClickHouse due to invalidation");
+		entry->gate.methods->disconnect(entry->gate.conn);
+		entry->gate.conn = NULL;
+	}
+
+	/*
+	 * We don't check the health of cached connection here, because it would
+	 * require some overhead.  Broken connection will be detected when the
+	 * connection is actually used.
+	 */
+
+	/*
+	 * If cache entry doesn't have a connection, we have to establish a new
+	 * connection.  (If clickhouse_connect throws an error, the cache entry
+	 * will remain in a valid empty state, ie conn == NULL.)
+	 */
+	if (entry->gate.conn == NULL)
+	{
+		ForeignServer *server = GetForeignServer(user->serverid);
+
+		/* Reset all transient state fields, to be sure all are clean */
+		entry->invalidated = false;
+		entry->server_hashvalue =
+			GetSysCacheHashValue1(FOREIGNSERVEROID,
+								  ObjectIdGetDatum(server->serverid));
+		entry->mapping_hashvalue =
+			GetSysCacheHashValue1(USERMAPPINGOID,
+								  ObjectIdGetDatum(user->umid));
+
+		/* Now try to make the connection */
+		entry->gate = clickhouse_connect(server, user);
+
+		elog(DEBUG3,
+			 "new clickhouse_fdw connection %p for server \"%s\" (user mapping oid %u, userid %u)",
+			 entry->gate.conn, server->servername, user->umid, user->userid);
+	}
+
+	return entry->gate;
+}
+
+/*
+ * Connection invalidation callback function
+ *
+ * After a change to a pg_foreign_server or pg_user_mapping catalog entry,
+ * mark connections depending on that entry as needing to be remade.
+ * We can't immediately destroy them, since they might be in the midst of
+ * a transaction, but we'll remake them at the next opportunity.
+ *
+ * Although most cache invalidation callbacks blow away all the related stuff
+ * regardless of the given hashvalue, connections are expensive enough that
+ * it's worth trying to avoid that.
+ *
+ * NB: We could avoid unnecessary disconnection more strictly by examining
+ * individual option values, but it seems too much effort for the gain.
+ */
+static void
+chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue)
+{
+	HASH_SEQ_STATUS scan;
+	ConnCacheEntry *entry;
+
+	Assert(cacheid == FOREIGNSERVEROID || cacheid == USERMAPPINGOID);
+
+	/* ConnectionHash must exist already, if we're registered */
+	hash_seq_init(&scan, ConnectionHash);
+	while ((entry = (ConnCacheEntry *) hash_seq_search(&scan)))
+	{
+		/* Ignore empty entries */
+		if (entry->gate.conn == NULL)
+			continue;
+
+		/* hashvalue == 0 means a cache reset, must clear all state */
+		if (hashvalue == 0 ||
+				(cacheid == FOREIGNSERVEROID &&
+				 entry->server_hashvalue == hashvalue) ||
+				(cacheid == USERMAPPINGOID &&
+				 entry->mapping_hashvalue == hashvalue))
+		{
+			entry->invalidated = true;
+		}
+	}
+}
+
+
+ch_connection_details *
+connstring_parse(const char *connstring)
+{
+	char	   *pname;
+	char	   *pval;
+	char	   *buf;
+	char	   *cp;
+	char	   *cp2;
+    ch_connection_details *details = palloc0(sizeof(ch_connection_details));
+
+	/* Need a modifiable copy of the input string */
+	if ((buf = pstrdup(connstring)) == NULL)
+		return NULL;
+
+	cp = buf;
+
+	while (*cp)
+	{
+		/* Skip blanks before the parameter name */
+		if (isspace((unsigned char) *cp))
+		{
+			cp++;
+			continue;
+		}
+
+		/* Get the parameter name */
+		pname = cp;
+		while (*cp)
+		{
+			if (*cp == '=')
+				break;
+			if (isspace((unsigned char) *cp))
+			{
+				*cp++ = '\0';
+				while (*cp)
+				{
+					if (!isspace((unsigned char) *cp))
+						break;
+					cp++;
+				}
+				break;
+			}
+			cp++;
+		}
+
+		/* Check that there is a following '=' */
+		if (*cp != '=')
+			elog(ERROR, "missing \"=\" after \"%s\" in connection info string", pname);
+
+		*cp++ = '\0';
+
+		/* Skip blanks after the '=' */
+		while (*cp)
+		{
+			if (!isspace((unsigned char) *cp))
+				break;
+			cp++;
+		}
+
+		/* Get the parameter value */
+		pval = cp;
+
+		if (*cp != '\'')
+		{
+			cp2 = pval;
+			while (*cp)
+			{
+				if (isspace((unsigned char) *cp))
+				{
+					*cp++ = '\0';
+					break;
+				}
+				if (*cp == '\\')
+				{
+					cp++;
+					if (*cp != '\0')
+						*cp2++ = *cp++;
+				}
+				else
+					*cp2++ = *cp++;
+			}
+			*cp2 = '\0';
+		}
+		else
+		{
+			cp2 = pval;
+			cp++;
+			for (;;)
+			{
+				if (*cp == '\0')
+					elog(ERROR, "unterminated quoted string in connection info string");
+
+				if (*cp == '\\')
+				{
+					cp++;
+					if (*cp != '\0')
+						*cp2++ = *cp++;
+					continue;
+				}
+				if (*cp == '\'')
+				{
+					*cp2 = '\0';
+					cp++;
+					break;
+				}
+				*cp2++ = *cp++;
+			}
+		}
+
+		if (strcmp(pname, "host") == 0) {
+			details->host = pstrdup(pval);
+		} else if (strcmp(pname, "port") == 0) {
+			details->port = strtoint32(pval);
+		} else if (strcmp(pname, "username") == 0) {
+			details->username = pstrdup(pval);
+		} else if (strcmp(pname, "password") == 0) {
+			details->password = pstrdup(pval);
+		}
+	}
+
+    pfree(buf);
+    return details;
+}
+
+/*
+ * Convert input string to a signed 32 bit integer.
+ *
+ * Allows any number of leading or trailing whitespace characters. Will throw
+ * ereport() upon bad input format or overflow.
+ *
+ * NB: Accumulate input as a negative number, to deal with two's complement
+ * representation of the most negative number, which can't be represented as a
+ * positive number.
+ *
+ * ---
+ * Copied from postgresql source.
+ */
+static int32
+strtoint32(const char *s)
+{
+	const char *ptr = s;
+	int32		tmp = 0;
+	bool		neg = false;
+
+	/* skip leading spaces */
+	while (likely(*ptr) && isspace((unsigned char) *ptr))
+		ptr++;
+
+	/* handle sign */
+	if (*ptr == '-')
+	{
+		ptr++;
+		neg = true;
+	}
+	else if (*ptr == '+')
+		ptr++;
+
+	/* require at least one digit */
+	if (unlikely(!isdigit((unsigned char) *ptr)))
+		goto invalid_syntax;
+
+	/* process digits */
+	while (*ptr && isdigit((unsigned char) *ptr))
+	{
+		int8		digit = (*ptr++ - '0');
+
+		if (unlikely(pg_mul_s32_overflow(tmp, 10, &tmp)) ||
+			unlikely(pg_sub_s32_overflow(tmp, digit, &tmp)))
+			goto out_of_range;
+	}
+
+	/* allow trailing whitespace, but not other trailing chars */
+	while (*ptr != '\0' && isspace((unsigned char) *ptr))
+		ptr++;
+
+	if (unlikely(*ptr != '\0'))
+		goto invalid_syntax;
+
+	if (!neg)
+	{
+		/* could fail if input is most negative number */
+		if (unlikely(tmp == PG_INT32_MIN))
+			goto out_of_range;
+		tmp = -tmp;
+	}
+
+	return tmp;
+
+out_of_range:
+	ereport(ERROR,
+			(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+			 errmsg("value \"%s\" is out of range for type %s",
+					s, "integer")));
+
+invalid_syntax:
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+			 errmsg("invalid input syntax for type %s: \"%s\"",
+					"integer", s)));
+
+	return 0;					/* keep compiler quiet */
+}

--- a/src/convert.c
+++ b/src/convert.c
@@ -1,0 +1,483 @@
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "access/tupdesc.h"
+#include "catalog/pg_type_d.h"
+#include "catalog/pg_type.h"
+#include "utils/typcache.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/arrayaccess.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_type.h"
+#include "executor/tuptable.h"
+
+#include "fdw.h"
+#include "binary.hh"
+#include <stdint.h>
+
+typedef struct ch_convert_state ch_convert_state;
+typedef struct ch_convert_output_state ch_convert_output_state;
+typedef Datum (*convert_func)(ch_convert_state *, Datum);
+typedef Datum (*out_convert_func)(ch_convert_output_state *, Datum);
+
+typedef struct ch_convert_state {
+	Oid				intype;
+	Oid				outtype;
+	convert_func	func;
+
+	// record
+	TupleConversionMap	*tupmap;
+	CustomObjectDef	*cdef;
+	TupleDesc		indesc;		/* for RECORD */
+	TupleDesc		outdesc;	/* for RECORD */
+	ch_convert_state **conversion_states;
+
+	// array
+	int16		typlen;
+	bool		typbyval;
+	char		typalign;
+
+	// text
+	int32		typmod;
+	Oid			typinput;
+	Oid			typioparam;
+
+	// generic
+	CoercionPathType	ctype;
+	Oid					castfunc;
+} ch_convert_state;
+
+typedef struct ch_convert_output_state {
+	Oid				intype;
+	Oid				outtype;
+	AttrNumber		attnum;
+	out_convert_func	func;
+
+	// array
+	Oid			innertype; /* if intype is array */
+	int16		typlen;
+	bool		typbyval;
+	char		typalign;
+
+	// generic
+	CoercionPathType	ctype;
+	Oid					castfunc;
+} ch_convert_output_state;
+
+static Datum
+convert_record(ch_convert_state *state, Datum val)
+{
+	HeapTuple		temptup;
+	HeapTuple		htup;
+	ch_binary_tuple_t	*slot = (ch_binary_tuple_t *) DatumGetPointer(val);
+
+	for (size_t i = 0; i < slot->len; i++)
+	{
+		ch_convert_state *s = state->conversion_states[i];
+		if (s)
+			slot->datums[i] = s->func(s, slot->datums[i]);
+	}
+
+	htup = heap_form_tuple(state->indesc, slot->datums, slot->nulls);
+	if (!state->outdesc)
+	{
+		val = heap_copy_tuple_as_datum(htup, state->indesc);
+
+		if (state->cdef && state->cdef->rowfunc != InvalidOid)
+		{
+			/* there is convertor from row to outtype */
+			val = OidFunctionCall1(state->cdef->rowfunc, val);
+		}
+		else if (state->outtype == TEXTOID)
+		{
+			/* a lot of allocations, not so efficient */
+			val = CStringGetTextDatum(DatumGetCString(
+						OidFunctionCall1(F_RECORD_OUT, val)));
+		}
+	}
+	else
+	{
+		if (state->tupmap)
+			temptup = execute_attr_map_tuple(htup, state->tupmap);
+		else
+			temptup = htup;
+
+		val = heap_copy_tuple_as_datum(temptup, state->outdesc);
+	}
+
+	return val;
+}
+
+inline static Datum
+convert_generic(ch_convert_state *state, Datum val)
+{
+	if (state->ctype == COERCION_PATH_FUNC)
+	{
+		Assert(state->castfunc != InvalidOid);
+		val = OidFunctionCall1(state->castfunc, val);
+	}
+
+	return val;
+}
+
+inline static Datum
+convert_out_generic(ch_convert_output_state *state, Datum val)
+{
+	if (state->ctype == COERCION_PATH_FUNC)
+	{
+		Assert(state->castfunc != InvalidOid);
+		val = OidFunctionCall1(state->castfunc, val);
+	}
+
+	return val;
+}
+
+static Datum
+convert_array(ch_convert_state *state, Datum val)
+{
+	ch_binary_array_t	*slot = (ch_binary_array_t *) DatumGetPointer(val);
+
+	if (slot->len == 0)
+		val = PointerGetDatum(construct_empty_array(state->intype));
+	else
+	{
+		void *arrout = construct_array(slot->datums, slot->len, slot->item_type,
+			state->typlen, state->typbyval, state->typalign);
+
+		val = PointerGetDatum(arrout);
+	}
+
+	return convert_generic(state, val);
+}
+
+static Datum
+convert_remote_text(ch_convert_state *state, Datum val)
+{
+	return OidInputFunctionCall(state->typinput, TextDatumGetCString(val),
+			state->typioparam, state->typmod);
+}
+
+/*
+ * We imply that corresponding type for UInt8 (bool in ClickHouse) is
+ * SMALLINT and this function covers this case
+ */
+static Datum
+convert_bool(ch_convert_state *state, Datum val)
+{
+	int16 dat = DatumGetInt16(val);
+	return BoolGetDatum(dat);
+}
+
+static Datum
+convert_date(ch_convert_state *state, Datum val)
+{
+	val = DirectFunctionCall1(timestamp_date, val);
+	return convert_generic(state, val);
+}
+
+Datum
+ch_binary_convert_datum(void *state, Datum val)
+{
+	return state ? ((ch_convert_state *) state)->func(state, val) : val;
+}
+
+/* input */
+void *
+ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype)
+{
+	ch_convert_state *state = palloc0(sizeof(ch_convert_state));
+
+	state->intype = intype;
+	state->outtype = outtype;
+	state->cdef = chfdw_check_for_custom_type(outtype);
+	state->typmod = -1;
+	state->ctype = COERCION_PATH_NONE;
+
+	if (intype == DATEOID)
+		state->func = convert_date;
+	else if (intype == ANYARRAYOID)
+	{
+		ch_binary_array_t	*slot = (ch_binary_array_t *) DatumGetPointer(val);
+		get_typlenbyvalalign(slot->item_type, &state->typlen, &state->typbyval,
+				&state->typalign);
+
+		/* restore intype */
+		state->intype = slot->array_type;
+		intype = slot->array_type;
+		state->func = convert_array;
+	}
+
+	if (intype == RECORDOID)
+	{
+		ch_binary_tuple_t	*slot = (ch_binary_tuple_t *) DatumGetPointer(val);
+
+		state->func = convert_record;
+
+#if PG_VERSION_NUM < 120000
+		state->indesc = CreateTemplateTupleDesc(slot->len, false);
+#else
+		state->indesc = CreateTemplateTupleDesc(slot->len);
+#endif
+		state->conversion_states = palloc(sizeof(void *) * slot->len);
+
+		for (size_t i = 0; i < slot->len; ++i)
+		{
+			Oid item_type = slot->types[i];
+
+			if (slot->types[i] == ANYARRAYOID)
+			{
+				ch_binary_array_t	*arr = (ch_binary_array_t *) DatumGetPointer(slot->datums[i]);
+				item_type = arr->array_type;
+			}
+			state->conversion_states[i] = ch_binary_init_convert_state(slot->datums[i],
+					slot->types[i], item_type);
+
+			TupleDescInitEntry(state->indesc, (AttrNumber) i + 1, "",
+				item_type, -1, 0);
+		}
+
+		state->indesc = BlessTupleDesc(state->indesc);
+
+		if (!(state->cdef || outtype == RECORDOID || outtype == TEXTOID))
+		{
+			TypeCacheEntry	   *typentry;
+			TupleDesc			tupdesc;
+
+			typentry = lookup_type_cache(outtype,
+										 TYPECACHE_TUPDESC |
+										 TYPECACHE_DOMAIN_BASE_INFO);
+
+			if (typentry->typtype == TYPTYPE_DOMAIN)
+				tupdesc = lookup_rowtype_tupdesc_noerror(typentry->domainBaseType,
+													  typentry->domainBaseTypmod,
+													  false);
+			else
+			{
+				if (typentry->tupDesc == NULL)
+					ereport(ERROR,
+							(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+							 errmsg("type %s is not composite",
+									format_type_be(outtype))));
+
+				tupdesc = typentry->tupDesc;
+				PinTupleDesc(tupdesc);
+			}
+			state->outdesc = CreateTupleDescCopy(tupdesc);
+			state->tupmap = convert_tuples_by_position(state->indesc, state->outdesc,
+				"clickhouse_fdw: could not map tuple to returned type");
+			ReleaseTupleDesc(tupdesc);
+		}
+	}
+	else if (intype != outtype)
+	{
+		if (!state->func)
+			state->func = convert_generic;
+
+		if (intype == TEXTOID)
+		{
+			Type		baseType;
+			Oid			baseTypeId;
+			Form_pg_type typform;
+
+			baseTypeId = getBaseTypeAndTypmod(outtype, &state->typmod);
+			if (baseTypeId != INTERVALOID)
+				state->typmod = -1;
+
+			baseType = typeidType(baseTypeId);
+			typform = (Form_pg_type) GETSTRUCT(baseType);
+			state->typinput = typform->typinput;
+			state->typioparam = getTypeIOParam(baseType);
+			state->func = convert_remote_text;
+			ReleaseSysCache(baseType);
+		}
+		else if (outtype == BOOLOID && intype == INT2OID)
+		{
+			val = BoolGetDatum(val);
+			state->func = convert_bool;
+		}
+		else
+		{
+			/* try to convert */
+			state->ctype = find_coercion_pathway(outtype, intype,
+										  COERCION_EXPLICIT,
+										  &state->castfunc);
+			switch (state->ctype)
+			{
+				case COERCION_PATH_FUNC:
+					break;
+				case COERCION_PATH_RELABELTYPE:
+					/* if the conversion func was not previously set,
+					 * then no conversion needed */
+					if (state->func == NULL)
+						goto no_conversion;
+
+					/* all good */
+					break;
+				default:
+					elog(ERROR, "clickhouse_fdw: could not cast value from %s to %s",
+							format_type_be(intype), format_type_be(outtype));
+			}
+		}
+	}
+	else if (!state->func)
+	{
+no_conversion:
+		/* no conversion needed */
+		pfree(state);
+		state = NULL;
+	}
+
+	return state;
+}
+
+void
+ch_binary_free_convert_state(void *s)
+{
+	ch_convert_state *state = s;
+	pfree(state);
+}
+
+/* output */
+
+static void
+init_output_convert_state(ch_convert_output_state *state)
+{
+	if (state->outtype == state->intype)
+		return;
+
+	state->func = convert_out_generic;
+	state->ctype = find_coercion_pathway(state->outtype, state->intype,
+		COERCION_EXPLICIT, &state->castfunc);
+
+	switch (state->ctype)
+	{
+		case COERCION_PATH_FUNC:
+			break;
+		case COERCION_PATH_RELABELTYPE:
+			state->func = NULL;
+			return;
+		default:
+			elog(ERROR, "clickhouse_fdw: could not find a casting path from %s to %s",
+					format_type_be(state->intype), format_type_be(state->outtype));
+	}
+}
+
+void *
+ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc)
+{
+	ch_convert_output_state	 *states;
+	int			n;
+	int			i;
+
+	n = outdesc->natts;
+	states = (ch_convert_output_state *) palloc0(n * sizeof(ch_convert_output_state));
+
+	for (i = 0; i < n; i++)
+	{
+		ch_convert_output_state *curstate = &states[i];
+
+		Form_pg_attribute attout = TupleDescAttr(outdesc, i);
+		char	   *outattname;
+		int			j;
+
+		outattname = NameStr(attout->attname);
+		curstate->outtype = attout->atttypid;
+
+		if (NameStr(indesc->attrs[0].attname)[0] == '\0')
+		{
+			Form_pg_attribute attin = TupleDescAttr(indesc, i);
+			curstate->intype = attin->atttypid;
+			init_output_convert_state(curstate);
+			curstate->attnum = (AttrNumber) (i + 1);
+		}
+		else
+		{
+			for (j = 0; j < indesc->natts; j++)
+			{
+				Form_pg_attribute attin = TupleDescAttr(indesc, j);
+				char	   *inattname = NameStr(attin->attname);
+
+				if (attin->attisdropped)
+					continue;
+
+				curstate->intype = attin->atttypid;
+
+				if (strcmp(outattname, inattname) == 0)
+				{
+					init_output_convert_state(curstate);
+					curstate->attnum = (AttrNumber) (j + 1);
+					break;
+				}
+			}
+		}
+
+		curstate->innertype = get_element_type(curstate->outtype);
+		if (curstate->innertype != InvalidOid)
+		{
+			curstate->outtype = ANYARRAYOID;
+			get_typlenbyvalalign(curstate->innertype, &curstate->typlen,
+					&curstate->typbyval, &curstate->typalign);
+		}
+
+
+		if (curstate->attnum == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATATYPE_MISMATCH),
+					 errmsg_internal("clickhouse_fdw: could not create conversion map"),
+					 errdetail("Attribute \"%s\" of type %s does not exist in type %s.",
+							   outattname,
+							   format_type_be(indesc->tdtypeid),
+							   format_type_be(outdesc->tdtypeid))));
+	}
+
+	return states;
+}
+
+void
+ch_binary_do_output_convertion(ch_binary_insert_state *insert_state,
+		TupleTableSlot *slot)
+{
+	Datum *out_values = insert_state->values;
+	bool *out_nulls = insert_state->nulls;
+
+	for (size_t i = 0; i < insert_state->outdesc->natts; i++)
+	{
+		ch_convert_output_state *cstate = &((ch_convert_output_state *) insert_state->conversion_states)[i];
+		AttrNumber attnum = cstate->attnum;
+		out_values[i] = slot_getattr(slot, attnum, &out_nulls[i]);
+		if (!out_nulls[i])
+		{
+			if (cstate->func)
+				out_values[i] = cstate->func(cstate, out_values[i]);
+			else if (cstate->outtype == ANYARRAYOID)
+			{
+				AnyArrayType *v = DatumGetAnyArrayP(out_values[i]);
+				ch_binary_array_t	*arr;
+				array_iter	iter;
+
+				if (AARR_NDIM(v) != 1)
+					elog(ERROR, "clickhouse_fdw: inserted array should have one dimension");
+
+				arr = palloc(sizeof(ch_binary_array_t));
+				arr->len = ArrayGetNItems(AARR_NDIM(v), AARR_DIMS(v));
+				arr->datums = palloc(sizeof(Datum) * arr->len);
+				arr->nulls = palloc(sizeof(bool) * arr->len);
+				arr->item_type = cstate->innertype;
+
+				array_iter_setup(&iter, v);
+				for (size_t j = 0; j < arr->len; j++)
+				{
+					arr->datums[j] = array_iter_next(&iter, &arr->nulls[j], i,
+						cstate->typlen, cstate->typbyval, cstate->typalign);
+				}
+				out_values[i] = PointerGetDatum(arr);
+
+				/* hack: mark as unified array */
+				TupleDescAttr(insert_state->outdesc, i)->atttypid = ANYARRAYOID;
+			}
+		}
+	}
+}

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -1,0 +1,561 @@
+#include "postgres.h"
+#include "strings.h"
+#include "access/heapam.h"
+#include "access/htup.h"
+#include "access/htup_details.h"
+#include "catalog/dependency.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
+#include "commands/defrem.h"
+#include "commands/extension.h"
+#include "parser/parse_func.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/hsearch.h"
+#include "utils/inval.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
+
+#include "fdw.h"
+
+// in PostgreSQL 14 source code those variables has other names,
+// see postgres/src/backend/utils/fmgroids.h
+#define F_TIMESTAMP_TRUNC 2020
+#define F_TIMESTAMP_PART 2021
+#define F_TIMESTAMPTZ_TRUNC 1217
+#define F_TIMESTAMP_ZONE 2069
+#define F_TIMESTAMPTZ_ZONE 1159
+#define F_TIMESTAMPTZ_PART 1171
+#define F_ARRAY_POSITION 3277
+#define F_STRPOS 868
+#define F_BTRIM 884
+#define F_BTRIM1 885
+
+static HTAB *custom_objects_cache = NULL;
+static HTAB *custom_columns_cache = NULL;
+
+static HTAB *
+create_custom_objects_cache(void)
+{
+	HASHCTL		ctl;
+
+	ctl.keysize = sizeof(Oid);
+	ctl.entrysize = sizeof(CustomObjectDef);
+
+	return hash_create("clickhouse_fdw custom functions", 20, &ctl, HASH_ELEM | HASH_BLOBS);
+}
+
+static void
+invalidate_custom_columns_cache(Datum arg, int cacheid, uint32 hashvalue)
+{
+	HASH_SEQ_STATUS status;
+	CustomColumnInfo *entry;
+
+	hash_seq_init(&status, custom_columns_cache);
+	while ((entry = (CustomColumnInfo *) hash_seq_search(&status)) != NULL)
+	{
+		if (hash_search(custom_columns_cache,
+						(void *) &entry->relid,
+						HASH_REMOVE,
+						NULL) == NULL)
+			elog(ERROR, "hash table corrupted");
+	}
+}
+
+static HTAB *
+create_custom_columns_cache(void)
+{
+	HASHCTL		ctl;
+
+	ctl.keysize = sizeof(Oid) + sizeof(int);
+	ctl.entrysize = sizeof(CustomColumnInfo);
+
+	CacheRegisterSyscacheCallback(ATTNUM,
+								  invalidate_custom_columns_cache,
+								  (Datum) 0);
+
+	return hash_create("clickhouse_fdw custom functions", 20, &ctl, HASH_ELEM | HASH_BLOBS);
+}
+
+inline static void
+init_custom_entry(CustomObjectDef *entry)
+{
+	entry->cf_type = CF_USUAL;
+	entry->custom_name[0] = '\0';
+	entry->cf_context = NULL;
+	entry->rowfunc = InvalidOid;
+}
+
+CustomObjectDef *chfdw_check_for_custom_function(Oid funcid)
+{
+	bool special_builtin = false;
+	CustomObjectDef	*entry;
+
+	if (chfdw_is_builtin(funcid))
+	{
+		switch (funcid)
+		{
+			case F_TIMESTAMP_TRUNC:
+			case F_TIMESTAMPTZ_TRUNC:
+			case F_TIMESTAMP_ZONE:
+			case F_TIMESTAMPTZ_ZONE:
+			case F_TIMESTAMP_PART:
+			case F_TIMESTAMPTZ_PART:
+			case F_ARRAY_POSITION:
+			case F_STRPOS:
+			case F_BTRIM:
+			case F_BTRIM1:
+				special_builtin = true;
+				break;
+			default:
+				return NULL;
+		}
+	}
+
+	if (!custom_objects_cache)
+		custom_objects_cache = create_custom_objects_cache();
+
+	entry = hash_search(custom_objects_cache, (void *) &funcid, HASH_FIND, NULL);
+	if (!entry)
+	{
+		Oid			extoid;
+		char	   *extname;
+
+		entry = hash_search(custom_objects_cache, (void *) &funcid, HASH_ENTER, NULL);
+		entry->cf_oid = funcid;
+		init_custom_entry(entry);
+
+		switch (funcid)
+		{
+			case F_TIMESTAMPTZ_TRUNC:
+			case F_TIMESTAMP_TRUNC:
+			{
+				entry->cf_type = CF_DATE_TRUNC;
+				entry->custom_name[0] = '\1';
+				break;
+			}
+			case F_TIMESTAMPTZ_PART:
+			case F_TIMESTAMP_PART:
+			{
+				entry->cf_type = CF_DATE_PART;
+				entry->custom_name[0] = '\1';
+				break;
+			}
+			case F_TIMESTAMP_ZONE:
+			case F_TIMESTAMPTZ_ZONE:
+			{
+				entry->cf_type = CF_TIMEZONE;
+				strcpy(entry->custom_name, "toTimeZone");
+				break;
+			}
+			case F_ARRAY_POSITION:
+			{
+				strcpy(entry->custom_name, "indexOf");
+				break;
+			}
+			case F_BTRIM:
+			case F_BTRIM1:
+			{
+				strcpy(entry->custom_name, "trimBoth");
+				break;
+			}
+			case F_STRPOS:
+			{
+				strcpy(entry->custom_name, "position");
+				break;
+			}
+		}
+
+		if (special_builtin)
+			return entry;
+
+		extoid = getExtensionOfObject(ProcedureRelationId, funcid);
+		extname = get_extension_name(extoid);
+		if (extname)
+		{
+			HeapTuple	proctup;
+			Form_pg_proc procform;
+			char		*proname;
+
+			proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+			if (!HeapTupleIsValid(proctup))
+				elog(ERROR, "cache lookup failed for function %u", funcid);
+
+			procform = (Form_pg_proc) GETSTRUCT(proctup);
+			proname = NameStr(procform->proname);
+
+			if (strcmp(extname, "istore") == 0)
+			{
+				if (strcmp(NameStr(procform->proname), "sum") == 0)
+				{
+					entry->cf_type = CF_ISTORE_SUM;
+					strcpy(entry->custom_name, "sumMap");
+				}
+				if (strcmp(NameStr(procform->proname), "sum_up") == 0)
+				{
+					entry->cf_type = CF_ISTORE_SUM_UP;
+					strcpy(entry->custom_name, "arraySum");
+				}
+				else if (strcmp(NameStr(procform->proname), "istore_seed") == 0)
+				{
+					entry->cf_type = CF_ISTORE_SEED;
+					entry->custom_name[0] = '\1';	/* complex */
+				}
+				else if (strcmp(NameStr(procform->proname), "accumulate") == 0)
+				{
+					entry->cf_type = CF_ISTORE_ACCUMULATE;
+					entry->custom_name[0] = '\1';	/* complex */
+				}
+				else if (strcmp(NameStr(procform->proname), "slice") == 0)
+				{
+					entry->cf_type = CF_UNSHIPPABLE;
+					entry->custom_name[0] = '\0';	/* complex */
+				}
+			}
+			else if (strcmp(extname, "country") == 0)
+			{
+				if (strcmp(NameStr(procform->proname), "country_common_name") == 0)
+				{
+					entry->cf_type = CF_UNSHIPPABLE;
+					entry->custom_name[0] = '\0';	/* complex */
+				}
+			}
+			else if (strcmp(extname, "ajtime") == 0)
+			{
+				if (strcmp(NameStr(procform->proname), "ajtime_to_timestamp") == 0)
+				{
+					entry->cf_type = CF_AJTIME_TO_TIMESTAMP;
+					strcpy(entry->custom_name, "");
+				}
+				else if (strcmp(NameStr(procform->proname), "ajtime_pl_interval") == 0)
+				{
+					entry->cf_type = CF_AJTIME_PL_INTERVAL;
+					strcpy(entry->custom_name, "addSeconds");
+				}
+				else if (strcmp(NameStr(procform->proname), "ajtime_mi_interval") == 0)
+				{
+					entry->cf_type = CF_AJTIME_MI_INTERVAL;
+					strcpy(entry->custom_name, "subtractSeconds");
+				}
+				else if (strcmp(NameStr(procform->proname), "day_diff") == 0)
+				{
+					entry->cf_type = CF_AJTIME_DAY_DIFF;
+					strcpy(entry->custom_name, "toInt32");
+				}
+				else if (strcmp(NameStr(procform->proname), "ajdate") == 0)
+				{
+					entry->cf_type = CF_AJTIME_AJDATE;
+					strcpy(entry->custom_name, "toDate");
+				}
+				else if (strcmp(NameStr(procform->proname), "ajtime_out") == 0)
+				{
+					entry->cf_type = CF_AJTIME_OUT;
+				}
+			}
+			else if (strcmp(extname, "ajbool") == 0)
+			{
+				if (strcmp(NameStr(procform->proname), "ajbool_out") == 0)
+					entry->cf_type = CF_AJBOOL_OUT;
+			}
+			else if (strcmp(extname, "intarray") == 0)
+			{
+				if (strcmp(NameStr(procform->proname), "idx") == 0)
+				{
+					entry->cf_type = CF_INTARRAY_IDX;
+					strcpy(entry->custom_name, "indexOf");
+				}
+			}
+			else if (strcmp(extname, "clickhouse_fdw") == 0)
+			{
+				entry->cf_type = CF_CH_FUNCTION;
+				if (strcmp(proname, "argmax") == 0)
+					strcpy(entry->custom_name, "argMax");
+				else if (strcmp(proname, "argmin") == 0)
+					strcpy(entry->custom_name, "argMin");
+				else if (strcmp(proname, "dictget") == 0)
+					strcpy(entry->custom_name, "dictGet");
+				else if (strcmp(proname, "uniq_exact") == 0)
+					strcpy(entry->custom_name, "uniqExact");
+				else
+					strcpy(entry->custom_name, proname);
+			}
+			ReleaseSysCache(proctup);
+			pfree(extname);
+		}
+	}
+
+	return entry;
+}
+
+static Oid
+find_rowfunc(char *procname, Oid rettype)
+{
+	Oid		argtypes[1] = {RECORDOID};
+	Oid		procOid;
+	List   *funcname = NIL;
+
+	funcname = list_make1(makeString(procname));
+	procOid = LookupFuncName(funcname, 1, argtypes, false);
+	if (!OidIsValid(procOid))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION),
+				 errmsg("function %s does not exist",
+						func_signature_string(funcname, 1, NIL, argtypes))));
+
+
+	if (get_func_rettype(procOid) != rettype)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("typmod_in function %s must return type %s",
+						procname, format_type_be(rettype))));
+
+	list_free_deep(funcname);
+	return procOid;
+}
+
+CustomObjectDef *chfdw_check_for_custom_type(Oid typeoid)
+{
+	CustomObjectDef	*entry;
+	if (!custom_objects_cache)
+		custom_objects_cache = create_custom_objects_cache();
+
+	if (chfdw_is_builtin(typeoid))
+		return NULL;
+
+	entry = hash_search(custom_objects_cache, (void *) &typeoid, HASH_FIND, NULL);
+	if (!entry)
+	{
+		HeapTuple	tp;
+
+		entry = hash_search(custom_objects_cache, (void *) &typeoid, HASH_ENTER, NULL);
+		init_custom_entry(entry);
+
+		tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typeoid));
+		if (HeapTupleIsValid(tp))
+		{
+			Form_pg_type typtup = (Form_pg_type) GETSTRUCT(tp);
+			char *name = NameStr(typtup->typname);
+			if (strcmp(name, "istore") == 0)
+			{
+				entry->cf_type = CF_ISTORE_TYPE; /* bigistore or istore */
+				strcpy(entry->custom_name, "Tuple(Array(Int32), Array(Int64))");
+				entry->rowfunc = find_rowfunc("row_to_istore", typeoid);
+			}
+			else if (strcmp(name, "bigistore") == 0)
+			{
+				entry->cf_type = CF_ISTORE_TYPE; /* bigistore or istore */
+				strcpy(entry->custom_name, "Tuple(Array(Int32), Array(Int64))");
+				entry->rowfunc = find_rowfunc("row_to_bigistore", typeoid);
+			}
+			else if (strcmp(name, "ajtime") == 0)
+			{
+				entry->cf_type = CF_AJTIME_TYPE; /* ajtime */
+				strcpy(entry->custom_name, "timestamp");
+			}
+			else if (strcmp(name, "country") == 0)
+			{
+				entry->cf_type = CF_COUNTRY_TYPE; /* country type */
+				strcpy(entry->custom_name, "text");
+			}
+			ReleaseSysCache(tp);
+		}
+	}
+
+	return entry;
+}
+
+CustomObjectDef *chfdw_check_for_custom_operator(Oid opoid, Form_pg_operator form)
+{
+	HeapTuple	tuple = NULL;
+
+	CustomObjectDef	*entry;
+	if (!custom_objects_cache)
+		custom_objects_cache = create_custom_objects_cache();
+
+	if (chfdw_is_builtin(opoid))
+	{
+		switch (opoid) {
+			/* timestamptz + interval */
+			case F_TIMESTAMPTZ_PL_INTERVAL:
+				break;
+			default:
+				return NULL;
+		}
+	}
+
+	if (!form)
+	{
+		tuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(opoid));
+		if (!HeapTupleIsValid(tuple))
+			elog(ERROR, "cache lookup failed for operator %u", opoid);
+		form = (Form_pg_operator) GETSTRUCT(tuple);
+	}
+
+	entry = hash_search(custom_objects_cache, (void *) &opoid, HASH_FIND, NULL);
+	if (!entry)
+	{
+		entry = hash_search(custom_objects_cache, (void *) &opoid, HASH_ENTER, NULL);
+		init_custom_entry(entry);
+
+		if (opoid == F_TIMESTAMPTZ_PL_INTERVAL)
+			entry->cf_type = CF_TIMESTAMPTZ_PL_INTERVAL;
+		else
+		{
+			Oid		extoid = getExtensionOfObject(OperatorRelationId, opoid);
+			char   *extname = get_extension_name(extoid);
+
+			if (extname)
+			{
+				if (strcmp(extname, "ajtime") == 0)
+					entry->cf_type = CF_AJTIME_OPERATOR;
+				else if (strcmp(extname, "istore") == 0)
+				{
+					if (form && strcmp(NameStr(form->oprname), "->") == 0)
+						entry->cf_type = CF_ISTORE_FETCHVAL;
+				}
+				else if (strcmp(extname, "hstore") == 0)
+				{
+					if (form && strcmp(NameStr(form->oprname), "->") == 0)
+						entry->cf_type = CF_HSTORE_FETCHVAL;
+				}
+				pfree(extname);
+			}
+		}
+	}
+
+	if (tuple)
+		ReleaseSysCache(tuple);
+
+	return entry;
+}
+
+/*
+ * Parse options from foreign table and apply them to fpinfo.
+ *
+ * New options might also require tweaking merge_fdw_options().
+ */
+void
+chfdw_apply_custom_table_options(CHFdwRelationInfo *fpinfo, Oid relid)
+{
+	ListCell	*lc;
+	TupleDesc	tupdesc;
+	int			attnum;
+	Relation	rel;
+	List	   *options;
+
+	foreach(lc, fpinfo->table->options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+		if (strcmp(def->defname, "engine") == 0)
+		{
+			static char *collapsing_text = "collapsingmergetree",
+						*aggregating_text = "aggregatingmergetree";
+
+			char *val = defGetString(def);
+			if (strncasecmp(val, collapsing_text, strlen(collapsing_text)) == 0)
+			{
+				char   *start = index(val, '('),
+					   *end = rindex(val, ')');
+
+				fpinfo->ch_table_engine = CH_COLLAPSING_MERGE_TREE;
+				if (start == end)
+				{
+					strcpy(fpinfo->ch_table_sign_field, "sign");
+					continue;
+				}
+
+				if (end - start > NAMEDATALEN)
+					elog(ERROR, "invalid format of ClickHouse engine");
+
+				strncpy(fpinfo->ch_table_sign_field, start + 1, end - start - 1);
+				fpinfo->ch_table_sign_field[end - start] = '\0';
+			}
+			else if (strncasecmp(val, aggregating_text, strlen(aggregating_text)) == 0)
+			{
+				fpinfo->ch_table_engine = CH_AGGREGATING_MERGE_TREE;
+			}
+		}
+	}
+
+	if (custom_columns_cache == NULL)
+		custom_columns_cache = create_custom_columns_cache();
+
+	rel = table_open_compat(relid, NoLock);
+	tupdesc = RelationGetDescr(rel);
+
+	for (attnum = 1; attnum <= tupdesc->natts; attnum++)
+	{
+		bool				found;
+		CustomObjectDef	   *cdef;
+		CustomColumnInfo	entry_key,
+						   *entry;
+		custom_object_type	cf_type = CF_ISTORE_ARR;
+
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
+		entry_key.relid = relid;
+		entry_key.varattno = attnum;
+
+		entry = hash_search(custom_columns_cache,
+				(void *) &entry_key.relid, HASH_ENTER, &found);
+		if (found)
+			continue;
+
+		entry->relid = relid;
+		entry->varattno = attnum;
+		entry->table_engine = fpinfo->ch_table_engine;
+		entry->coltype = CF_USUAL;
+		entry->is_AggregateFunction = CF_AGGR_USUAL;
+		strcpy(entry->colname, NameStr(attr->attname));
+		strcpy(entry->signfield, fpinfo->ch_table_sign_field);
+
+		/* If a column has the column_name FDW option, use that value */
+		options = GetForeignColumnOptions(relid, attnum);
+		foreach (lc, options)
+		{
+			DefElem    *def = (DefElem *) lfirst(lc);
+
+			if (strcmp(def->defname, "column_name") == 0)
+			{
+				strncpy(entry->colname, defGetString(def), NAMEDATALEN);
+				entry->colname[NAMEDATALEN - 1] = '\0';
+			}
+			else if (strcmp(def->defname, "aggregatefunction") == 0)
+			{
+				entry->is_AggregateFunction = CF_AGGR_FUNC;
+				cf_type = CF_ISTORE_COL;
+			}
+			else if (strcmp(def->defname, "simpleaggregatefunction") == 0)
+			{
+				entry->is_AggregateFunction = CF_AGGR_SIMPLE;
+				cf_type = CF_ISTORE_COL;
+			}
+			else if (strcmp(def->defname, "arrays") == 0)
+				cf_type = CF_ISTORE_ARR;
+		}
+
+		cdef = chfdw_check_for_custom_type(attr->atttypid);
+		if (cdef && cdef->cf_type == CF_ISTORE_TYPE)
+			entry->coltype = cf_type;
+	}
+	table_close_compat(rel, NoLock);
+}
+
+/* Get foreign relation options */
+CustomColumnInfo *
+chfdw_get_custom_column_info(Oid relid, uint16 varattno)
+{
+	CustomColumnInfo	entry_key,
+					   *entry;
+
+	entry_key.relid = relid;
+	entry_key.varattno = varattno;
+
+	if (custom_columns_cache == NULL)
+		custom_columns_cache = create_custom_columns_cache();
+
+	entry = hash_search(custom_columns_cache,
+			(void *) &entry_key.relid, HASH_FIND, NULL);
+
+	return entry;
+}

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1,0 +1,3903 @@
+/*-------------------------------------------------------------------------
+ *
+ * deparse.c
+ *		  Query deparser for clickhouse_fdw
+ *
+ * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2019-2022, Adjust GmbH
+ * Copyright (c) 2025, ClickHouse, Inc.
+ *
+ * IDENTIFICATION
+ *		  github.com/clickhouse/clickhouse_fdw/src/deparse.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/heapam.h"
+#include "access/htup_details.h"
+#include "access/sysattr.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
+#include "commands/defrem.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/nodes.h"
+#include "nodes/primnodes.h"
+#include "optimizer/tlist.h"
+#include "parser/parsetree.h"
+#include "utils/arrayaccess.h"
+#include "utils/builtins.h"
+#include "utils/catcache.h"
+#include "utils/date.h"
+#include "utils/datetime.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+#include "utils/syscache.h"
+#include "utils/typcache.h"
+#include "lib/stringinfo.h"
+
+#if PG_VERSION_NUM >= 120000
+#include "access/table.h"
+#endif
+
+#include "fdw.h"
+
+#ifndef MAXINT8LEN
+#define MAXINT8LEN		25
+#endif
+
+/* variable counter */
+static uint32 var_counter = 0;
+
+/*
+ * Global context for foreign_expr_walker's search of an expression tree.
+ */
+typedef struct foreign_glob_cxt
+{
+	PlannerInfo *root;			/* global planner state */
+	RelOptInfo *foreignrel;		/* the foreign relation we are planning for */
+	Relids		relids;			/* relids of base relations in the underlying
+								 * scan */
+} foreign_glob_cxt;
+
+typedef struct foreign_loc_cxt
+{
+	bool	found_AggregateFunction;	/* indicator or CH AggregateFunction fields */
+} foreign_loc_cxt;
+
+/*
+ * Context for deparseExpr
+ */
+typedef struct deparse_expr_cxt
+{
+	PlannerInfo *root;			/* global planner state */
+	RelOptInfo *foreignrel;		/* the foreign relation we are planning for */
+	RelOptInfo *scanrel;		/* the underlying scan relation. Same as
+								 * foreignrel, when that represents a join or
+								 * a base relation. */
+	StringInfo	buf;			/* output buffer to append to */
+	List	  **params_list;	/* exprs that will become remote Params */
+	CustomObjectDef	*func;		/* custom function deparse */
+	void		*func_arg;		/* custom function context args */
+	CHFdwRelationInfo *fpinfo;	/* fdw relation info */
+	bool		interval_op;
+	bool		array_as_tuple;
+} deparse_expr_cxt;
+
+#define REL_ALIAS_PREFIX	"r"
+/* Handy macro to add relation name qualification */
+#define ADD_REL_QUALIFIER(buf, varno)	\
+		appendStringInfo((buf), "%s%d.", REL_ALIAS_PREFIX, (varno))
+#define SUBQUERY_REL_ALIAS_PREFIX	"s"
+#define SUBQUERY_COL_ALIAS_PREFIX	"c"
+
+#define CSTRING_TOLOWER(str) \
+do { \
+	for (int i = 0; str[i]; i++) { \
+	  str[i] = tolower(str[i]); \
+	} \
+} while (0)
+
+/*
+ * Functions to determine whether an expression can be evaluated safely on
+ * remote server.
+ */
+static bool foreign_expr_walker(Node *node,
+					foreign_glob_cxt *glob_cxt,
+					foreign_loc_cxt *outer_cxt);
+static char *deparse_type_name(Oid type_oid, int32 typemod);
+
+/*
+ * Functions to construct string representation of a node tree.
+ */
+static void deparseTargetList(StringInfo buf,
+				  RangeTblEntry *rte,
+				  Index rtindex,
+				  Relation rel,
+				  Bitmapset *attrs_used,
+				  bool qualify_col,
+				  List **retrieved_attrs);
+static void deparseExplicitTargetList(List *tlist,
+						  List **retrieved_attrs,
+						  deparse_expr_cxt *context);
+static void deparseSubqueryTargetList(deparse_expr_cxt *context);
+static void deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
+	int varno, int varattno, RangeTblEntry *rte, bool qualify_col);
+static void deparseRelation(StringInfo buf, Relation rel);
+static void deparseExpr(Expr *expr, deparse_expr_cxt *context);
+static void deparseVar(Var *node, deparse_expr_cxt *context);
+static void deparseConst(Const *node, deparse_expr_cxt *context, int showtype);
+static void deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context);
+static void deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context);
+static void deparseOpExpr(OpExpr *node, deparse_expr_cxt *context);
+static void deparseOperatorName(StringInfo buf, Form_pg_operator opform);
+static void deparseDistinctExpr(DistinctExpr *node, deparse_expr_cxt *context);
+static void deparseScalarArrayOpExpr(ScalarArrayOpExpr *node,
+                                     deparse_expr_cxt *context);
+static void deparseCaseExpr(CaseExpr *node, deparse_expr_cxt *context);
+static void deparseCaseWhen(CaseWhen *node, deparse_expr_cxt *context);
+static void deparseRelabelType(RelabelType *node, deparse_expr_cxt *context);
+static void deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context);
+static void deparseNullTest(NullTest *node, deparse_expr_cxt *context);
+static void deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context);
+static void deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
+				 deparse_expr_cxt *context);
+static void appendOrderByClause(List *pathkeys, bool has_final_sort,
+					deparse_expr_cxt *context);
+static void appendLimitClause(deparse_expr_cxt *context);
+static void appendConditions(List *exprs, deparse_expr_cxt *context);
+static void deparseFromExprForRel(StringInfo buf, PlannerInfo *root,
+					  RelOptInfo *foreignrel, bool use_alias,
+					  Index ignore_rel, List **ignore_conds,
+					  List **params_list);
+static void deparseFromExpr(List *quals, deparse_expr_cxt *context);
+static void deparseRangeTblRef(StringInfo buf, PlannerInfo *root,
+				   RelOptInfo *foreignrel, bool make_subquery,
+				   Index ignore_rel, List **ignore_conds, List **params_list);
+static void deparseAggref(Aggref *node, deparse_expr_cxt *context);
+static void appendGroupByClause(List *tlist, deparse_expr_cxt *context);
+static CustomObjectDef *appendFunctionName(Oid funcid, deparse_expr_cxt *context);
+static Node *deparseSortGroupClause(Index ref, List *tlist, bool force_colno,
+					   deparse_expr_cxt *context);
+static void deparseCoerceViaIO(CoerceViaIO *node, deparse_expr_cxt *context);
+static void deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context);
+static void deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context);
+static void deparseRowExpr(RowExpr *node, deparse_expr_cxt *context);
+static void deparseNullIfExpr(NullIfExpr *node, deparse_expr_cxt *context);
+
+/*
+ * Helper functions
+ */
+static bool is_subquery_var(Var *node, RelOptInfo *foreignrel,
+				int *relno, int *colno);
+static void get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel,
+							  int *relno, int *colno);
+
+static char *
+get_alias_name()
+{
+	var_counter++;
+	return psprintf("_tmp%d", var_counter++);
+}
+
+/*
+ * Examine each qual clause in input_conds, and classify them into two groups,
+ * which are returned as two lists:
+ *	- remote_conds contains expressions that can be evaluated remotely
+ *	- local_conds contains expressions that can't be evaluated remotely
+ */
+void
+chfdw_classify_conditions(PlannerInfo *root,
+				   RelOptInfo *baserel,
+				   List *input_conds,
+				   List **remote_conds,
+				   List **local_conds)
+{
+	ListCell   *lc;
+
+	*remote_conds = NIL;
+	*local_conds = NIL;
+
+	foreach(lc, input_conds)
+	{
+		RestrictInfo *ri = lfirst_node(RestrictInfo, lc);
+
+		if (chfdw_is_foreign_expr(root, baserel, ri->clause))
+			*remote_conds = lappend(*remote_conds, ri);
+		else
+			*local_conds = lappend(*local_conds, ri);
+	}
+}
+
+/*
+ * Returns true if given expr is safe to evaluate on the foreign server.
+ */
+bool
+chfdw_is_foreign_expr(PlannerInfo *root,
+				RelOptInfo *baserel,
+				Expr *expr)
+{
+	foreign_glob_cxt glob_cxt;
+	foreign_loc_cxt loc_cxt = {false};
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *)(baserel->fdw_private);
+
+	/*
+	 * Check that the expression consists of nodes that are safe to execute
+	 * remotely.
+	 */
+	glob_cxt.root = root;
+	glob_cxt.foreignrel = baserel;
+
+	/*
+	 * For an upper relation, use relids from its underneath scan relation,
+	 * because the upperrel's own relids currently aren't set to anything
+	 * meaningful by the core code.  For other relation, use their own relids.
+	 */
+	if (IS_UPPER_REL(baserel))
+		glob_cxt.relids = fpinfo->outerrel->relids;
+	else
+		glob_cxt.relids = baserel->relids;
+
+	if (!foreign_expr_walker((Node *) expr, &glob_cxt, &loc_cxt))
+		return false;
+
+	/* OK to evaluate on the remote server */
+	return true;
+}
+
+/* 1: '=', 2: '<>', 0 - false */
+int
+chfdw_is_equal_op(Oid opno)
+{
+	Form_pg_operator	operform;
+	HeapTuple			opertup;
+	int					res = 0;
+
+	opertup = SearchSysCache1(OPEROID, ObjectIdGetDatum(opno));
+	if (!HeapTupleIsValid(opertup))
+		elog(ERROR, "cache lookup failed for operator %u", opno);
+
+	operform = (Form_pg_operator) GETSTRUCT(opertup);
+
+	if (NameStr(operform->oprname)[0] == '=' && NameStr(operform->oprname)[1] == '\0')
+		res = 1;
+	else if (NameStr(operform->oprname)[0] == '<' && NameStr(operform->oprname)[1] == '>')
+		res = 2;
+
+	ReleaseSysCache(opertup);
+	return res;
+}
+
+/*
+ * Check if expression is safe to execute remotely, and return true if so.
+ *
+ * In addition, *outer_cxt is updated with collation information.
+ *
+ * We must check that the expression contains only node types we can deparse,
+ * that all types/functions/operators are safe to send (they are "shippable"),
+ * and that all collations used in the expression derive from Vars of the
+ * foreign table.  Because of the latter, the logic is pretty close to
+ * assign_collations_walker() in parse_collate.c, though we can assume here
+ * that the given expression is valid.  Note function mutability is not
+ * currently considered here.
+ */
+static bool
+foreign_expr_walker(Node *node,
+                    foreign_glob_cxt *glob_cxt,
+                    foreign_loc_cxt *outer_cxt)
+{
+	bool		check_type = true;
+	CHFdwRelationInfo *fpinfo;
+	foreign_loc_cxt inner_cxt;
+
+	/* Need do nothing for empty subexpressions */
+	if (node == NULL)
+		return true;
+
+	/* May need server info from baserel's fdw_private struct */
+	fpinfo = (CHFdwRelationInfo *)(glob_cxt->foreignrel->fdw_private);
+
+	switch (nodeTag(node))
+	{
+	case T_Var:
+	{
+		Var		   *var = (Var *) node;
+
+		/*
+		 * If the Var is from the foreign table, we consider its
+		 * collation (if any) safe to use.  If it is from another
+		 * table, we treat its collation the same way as we would a
+		 * Param's collation, ie it's not safe for it to have a
+		 * non-default collation.
+		 */
+		if (bms_is_member(var->varno, glob_cxt->relids) &&
+				var->varlevelsup == 0)
+		{
+			RangeTblEntry		*rte;
+			CustomColumnInfo	*cinfo;
+
+			/* Var belongs to foreign table */
+
+			/*
+			 * System columns other than ctid and oid should not be
+			 * sent to the remote, since we don't make any effort to
+			 * ensure that local and remote values match (tableoid, in
+			 * particular, almost certainly doesn't match).
+			 */
+			if (var->varattno < 0)
+				return false;
+
+			rte = planner_rt_fetch(var->varno, glob_cxt->root);
+			cinfo = chfdw_get_custom_column_info(rte->relid, var->varattno);
+
+			if (cinfo && cinfo->is_AggregateFunction == CF_AGGR_FUNC)
+				outer_cxt->found_AggregateFunction = true;
+		}
+	}
+	break;
+	case T_Const:
+	break;
+	case T_Param:
+	{
+		/* We are not supporting param push down*/
+		return false;
+	}
+	break;
+	case T_SubscriptingRef:
+	{
+		SubscriptingRef   *ar = (SubscriptingRef *) node;
+
+		/* Assignment should not be in restrictions. */
+		if (ar->refassgnexpr != NULL)
+			return false;
+
+		/*
+		 * Recurse to remaining subexpressions.  Since the array
+		 * subscripts must yield (noncollatable) integers, they won't
+		 * affect the inner_cxt state.
+		 */
+		if (!foreign_expr_walker((Node *) ar->refupperindexpr,
+								 glob_cxt, &inner_cxt))
+			return false;
+
+		if (!foreign_expr_walker((Node *) ar->reflowerindexpr,
+								 glob_cxt, &inner_cxt))
+			return false;
+
+		if (!foreign_expr_walker((Node *) ar->refexpr,
+								 glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_FuncExpr:
+	{
+		CustomObjectDef	*cdef = NULL;
+		FuncExpr   *fe = (FuncExpr *) node;
+
+		/* not in ClickHouse */
+		if (fe->funcvariadic)
+			return false;
+
+		/*
+		 * If function used by the expression is not shippable, it
+		 * can't be sent to remote because it might have incompatible
+		 * semantics on remote side.
+		 */
+		if (!chfdw_is_shippable(fe->funcid, ProcedureRelationId, fpinfo, &cdef))
+			return false;
+
+		/* only simple Var as first argument for accumulate */
+		if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE && (!IsA(linitial(fe->args), Var)))
+			return false;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) fe->args,
+								 glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_OpExpr:
+	case T_NullIfExpr:
+	case T_DistinctExpr:	/* struct-equivalent to OpExpr */
+	{
+		OpExpr	   *oe = (OpExpr *) node;
+
+		/*
+		 * Similarly, only shippable operators can be sent to remote.
+		 * (If the operator is shippable, we assume its underlying
+		 * function is too.)
+		 */
+		if (!chfdw_is_shippable(oe->opno, OperatorRelationId, fpinfo, NULL))
+			return false;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) oe->args,
+								 glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_ScalarArrayOpExpr:
+	{
+		ScalarArrayOpExpr *oe = (ScalarArrayOpExpr *) node;
+
+		if (!chfdw_is_equal_op(oe->opno))
+			return false;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) oe->args,
+								 glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_RelabelType:
+	{
+		RelabelType *r = (RelabelType *) node;
+
+		/*
+		 * Recurse to input subexpression.
+		 */
+		if (!foreign_expr_walker((Node *) r->arg,
+								 glob_cxt, &inner_cxt))
+		{
+			return false;
+		}
+	}
+	break;
+	case T_BoolExpr:
+	{
+		BoolExpr   *b = (BoolExpr *) node;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) b->args,
+								 glob_cxt, &inner_cxt))
+		{
+			return false;
+		}
+	}
+	break;
+	case T_NullTest:
+	{
+		NullTest   *nt = (NullTest *) node;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) nt->arg,
+								 glob_cxt, &inner_cxt))
+		{
+			return false;
+		}
+	}
+	break;
+	case T_ArrayExpr:
+	{
+		ArrayExpr  *a = (ArrayExpr *) node;
+
+		/*
+		 * Recurse to input subexpressions.
+		 */
+		if (!foreign_expr_walker((Node *) a->elements,
+								 glob_cxt, &inner_cxt))
+		{
+			return false;
+		}
+	}
+	break;
+	case T_List:
+	{
+		List	   *l = (List *) node;
+		ListCell   *lc;
+
+		/*
+		 * Recurse to component subexpressions.
+		 */
+		foreach (lc, l)
+		{
+			if (!foreign_expr_walker((Node *) lfirst(lc),
+									 glob_cxt, &inner_cxt))
+			{
+				return false;
+			}
+		}
+
+		/* Don't apply exprType() to the list. */
+		check_type = false;
+	}
+	break;
+	case T_Aggref:
+	{
+		Aggref	   *agg = (Aggref *) node;
+		ListCell   *lc;
+
+		/* Not safe to pushdown when not in grouping context */
+		if (!IS_UPPER_REL(glob_cxt->foreignrel))
+			return false;
+
+		/* Only non-split aggregates are pushable. */
+		if (agg->aggsplit != AGGSPLIT_SIMPLE)
+			return false;
+
+		/* As usual, it must be shippable. */
+		if (!chfdw_is_shippable(agg->aggfnoid, ProcedureRelationId, fpinfo, NULL))
+			return false;
+
+		/* Features that ClickHouse doesn't support */
+		if (agg->aggorder)
+			return false;
+
+		if (agg->aggdistinct && agg->aggfilter)
+			return false;
+
+		if (agg->aggvariadic)
+			return false;
+
+		/*
+		 * Recurse to input args. aggdirectargs, aggorder and
+		 * aggdistinct are all present in args, so no need to check
+		 * their shippability explicitly.
+		 */
+		foreach (lc, agg->args)
+		{
+			Node	   *n = (Node *) lfirst(lc);
+
+			/* If TargetEntry, extract the expression from it */
+			if (IsA(n, TargetEntry))
+			{
+				TargetEntry *tle = (TargetEntry *) n;
+
+				n = (Node *) tle->expr;
+			}
+
+			inner_cxt.found_AggregateFunction = false;
+			if (!foreign_expr_walker(n, glob_cxt, &inner_cxt))
+				return false;
+
+			if (inner_cxt.found_AggregateFunction)
+				agg->location = -2;
+		}
+
+		/* Check aggregate filter */
+		if (!foreign_expr_walker((Node *) agg->aggfilter,
+								 glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_CaseExpr:
+	{
+		CaseExpr   *caseexpr = (CaseExpr *) node;
+		ListCell   *lc;
+
+		if (!foreign_expr_walker((Node *) caseexpr->arg, glob_cxt, &inner_cxt))
+			return true;
+
+		foreach(lc, caseexpr->args)
+		{
+			CaseWhen   *when = lfirst_node(CaseWhen, lc);
+
+			if (!foreign_expr_walker((Node *) when->expr, glob_cxt, &inner_cxt))
+				return false;
+			if (!foreign_expr_walker((Node *) when->result, glob_cxt, &inner_cxt))
+				return false;
+		}
+		if (!foreign_expr_walker((Node *) caseexpr->defresult, glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_CoalesceExpr:
+	{
+		CoalesceExpr   *ce = (CoalesceExpr *) node;
+
+		if (!foreign_expr_walker((Node *) ce->args, glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_MinMaxExpr:
+	{
+		MinMaxExpr	*me = (MinMaxExpr *) node;
+		if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_CoerceViaIO:
+	{
+		CoerceViaIO	*me = (CoerceViaIO *) node;
+		if (!foreign_expr_walker((Node *) me->arg, glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_RowExpr:
+	{
+		RowExpr	*me = (RowExpr *) node;
+		if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
+			return false;
+	}
+	break;
+	case T_CaseTestExpr:
+	break;
+	default:
+
+		/*
+		 * If it's anything else, assume it's unsafe.  This list can be
+		 * expanded later, but don't forget to add deparse support below.
+		 */
+		return false;
+	}
+
+	/*
+	 * If result type of given expression is not shippable, it can't be sent
+	 * to remote because it might have incompatible semantics on remote side.
+	 */
+	if (check_type && !chfdw_is_shippable(exprType(node), TypeRelationId, fpinfo, NULL))
+	{
+		return false;
+	}
+
+	/* It looks OK */
+	return true;
+}
+
+/*
+ * Add typmod decoration to the basic type name
+ */
+static char *
+printTypmod(const char *typname, int32 typmod, Oid typmodout)
+{
+	char	   *res;
+
+	/* Shouldn't be called if typmod is -1 */
+	Assert(typmod >= 0);
+
+	if (typmodout == InvalidOid)
+	{
+		/* Default behavior: just print the integer typmod with parens */
+		res = psprintf("%s(%d)", typname, (int) typmod);
+	}
+	else
+	{
+		/* Use the type-specific typmodout procedure */
+		char	   *tmstr;
+
+		tmstr = DatumGetCString(OidFunctionCall1(typmodout,
+												 Int32GetDatum(typmod)));
+		res = psprintf("%s%s", typname, tmstr);
+	}
+
+	return res;
+}
+
+static char *
+ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
+{
+	HeapTuple	tuple;
+	Form_pg_type typeform;
+	Oid			array_base_type;
+	bool		is_array;
+	char	   *buf;
+	bool		with_typemod;
+
+	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(type_oid));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "clickhouse_fdw: cache lookup failed for type %u", type_oid);
+
+	typeform = (Form_pg_type) GETSTRUCT(tuple);
+
+	/*
+	 * Check if it's a regular (variable length) array type.  Fixed-length
+	 * array types such as "name" shouldn't get deconstructed.  As of Postgres
+	 * 8.1, rather than checking typlen we check the toast property, and don't
+	 * deconstruct "plain storage" array types --- this is because we don't
+	 * want to show oidvector as oid[].
+	 */
+	array_base_type = typeform->typelem;
+
+	if (array_base_type != InvalidOid && typeform->typstorage != 'p')
+	{
+		/* Switch our attention to the array element type */
+		ReleaseSysCache(tuple);
+		tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(array_base_type));
+		if (!HeapTupleIsValid(tuple))
+			elog(ERROR, "clickhouse_fdw: cache lookup failed for type %u", type_oid);
+
+		typeform = (Form_pg_type) GETSTRUCT(tuple);
+		type_oid = array_base_type;
+		is_array = true;
+	}
+	else
+		is_array = false;
+
+	with_typemod = (flags & FORMAT_TYPE_TYPEMOD_GIVEN) != 0 && (typemod >= 0);
+
+	/*
+	 * See if we want to special-case the output for certain built-in types.
+	 * Note that these special cases should all correspond to special
+	 * productions in gram.y, to ensure that the type name will be taken as a
+	 * system type, not a user type of the same name.
+	 *
+	 * If we do not provide a special-case output here, the type name will be
+	 * handled the same way as a user type name --- in particular, it will be
+	 * double-quoted if it matches any lexer keyword.  This behavior is
+	 * essential for some cases, such as types "bit" and "char".
+	 */
+	buf = NULL;					/* flag for no special case */
+
+	switch (type_oid)
+	{
+		case BOOLOID:
+			buf = pstrdup("Boolean");
+			break;
+
+		case BPCHAROID:
+			if (with_typemod)
+				buf = printTypmod("FixedString", typemod, typeform->typmodout);
+			else if ((flags & FORMAT_TYPE_TYPEMOD_GIVEN) != 0)
+			{
+				/*
+				 * bpchar with typmod -1 is not the same as CHARACTER, which
+				 * means CHARACTER(1) per SQL spec.  Report it as bpchar so
+				 * that parser will not assign a bogus typmod.
+				 */
+			}
+			else
+				buf = pstrdup("String");
+			break;
+
+		case FLOAT4OID:
+			buf = pstrdup("Float32");
+			break;
+
+		case FLOAT8OID:
+			buf = pstrdup("Float64");
+			break;
+
+		case INT2OID:
+			buf = pstrdup("Int16");
+			break;
+
+		case INT4OID:
+			buf = pstrdup("Int32");
+			break;
+
+		case INT8OID:
+			buf = pstrdup("Int64");
+			break;
+
+		case NUMERICOID:
+			if (with_typemod)
+				buf = printTypmod("Decimal", typemod, typeform->typmodout);
+			else
+				buf = pstrdup("Decimal");
+			break;
+
+		case INTERVALOID:
+			if (with_typemod)
+				buf = printTypmod("UInt64", typemod, typeform->typmodout);
+			else
+				buf = pstrdup("UInt64");
+			break;
+
+		case TIMESTAMPTZOID:
+		case TIMESTAMPOID:
+			buf = pstrdup("DateTime");
+			break;
+		case DATEOID:
+			buf = pstrdup("Date");
+			break;
+
+		case VARCHAROID:
+			if (with_typemod)
+				buf = printTypmod("FixedString", typemod, typeform->typmodout);
+			else
+				buf = pstrdup("String");
+			break;
+		case TEXTOID:
+			buf = pstrdup("String");
+			break;
+	}
+
+	if (buf == NULL)
+	{
+		CustomObjectDef	*cdef;
+		char	   *typname;
+
+		cdef = chfdw_check_for_custom_type(type_oid);
+		if (cdef && cdef->custom_name[0] != '\0')
+			buf = pstrdup(cdef->custom_name);
+		else
+		{
+			typname = NameStr(typeform->typname);
+			buf = quote_qualified_identifier(NULL, typname);
+
+			if (with_typemod)
+				buf = printTypmod(buf, typemod, typeform->typmodout);
+		}
+	}
+
+	if (is_array)
+		buf = psprintf("Array(%s)", buf);
+
+	ReleaseSysCache(tuple);
+
+	return buf;
+}
+
+/*
+ * Convert type OID + typmod info into a type name we can ship to the remote
+ * server.  Someplace else had better have verified that this type name is
+ * expected to be known on the remote end.
+ *
+ * This is almost just format_type_with_typemod(), except that if left to its
+ * own devices, that function will make schema-qualification decisions based
+ * on the local search_path, which is wrong.  We must schema-qualify all
+ * type names that are not in pg_catalog.  We assume here that built-in types
+ * are all in pg_catalog and need not be qualified; otherwise, qualify.
+ */
+static char *
+deparse_type_name(Oid type_oid, int32 typemod)
+{
+	bits16		flags = FORMAT_TYPE_TYPEMOD_GIVEN;
+
+	if (!chfdw_is_builtin(type_oid))
+		flags |= FORMAT_TYPE_FORCE_QUALIFY;
+
+	return ch_format_type_extended(type_oid, typemod, flags);
+}
+
+/*
+ * Build the targetlist for given relation to be deparsed as SELECT clause.
+ *
+ * The output targetlist contains the columns that need to be fetched from the
+ * foreign server for the given relation.  If foreignrel is an upper relation,
+ * then the output targetlist can also contain expressions to be evaluated on
+ * foreign server.
+ */
+List *
+chfdw_build_tlist_to_deparse(RelOptInfo *foreignrel)
+{
+	List	   *tlist = NIL;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+	ListCell   *lc;
+
+	/*
+	 * For an upper relation, we have already built the target list while
+	 * checking shippability, so just return that.
+	 */
+	if (IS_UPPER_REL(foreignrel))
+		return fpinfo->grouped_tlist;
+
+	/*
+	 * We require columns specified in foreignrel->reltarget->exprs and those
+	 * required for evaluating the local conditions.
+	 */
+	tlist = add_to_flat_tlist(tlist,
+							  pull_var_clause((Node *) foreignrel->reltarget->exprs,
+											  PVC_RECURSE_PLACEHOLDERS));
+	foreach(lc, fpinfo->local_conds)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+		tlist = add_to_flat_tlist(tlist,
+								  pull_var_clause((Node *) rinfo->clause,
+												  PVC_RECURSE_PLACEHOLDERS));
+	}
+
+	return tlist;
+}
+
+/*
+ * Deparse SELECT statement for given relation into buf.
+ *
+ * tlist contains the list of desired columns to be fetched from foreign server.
+ * For a base relation fpinfo->attrs_used is used to construct SELECT clause,
+ * hence the tlist is ignored for a base relation.
+ *
+ * remote_conds is the list of conditions to be deparsed into the WHERE clause
+ * (or, in the case of upper relations, into the HAVING clause).
+ *
+ * If params_list is not NULL, it receives a list of Params and other-relation
+ * Vars used in the clauses; these values must be transmitted to the remote
+ * server as parameter values.
+ *
+ * If params_list is NULL, we're generating the query for EXPLAIN purposes,
+ * so Params and other-relation Vars should be replaced by dummy values.
+ *
+ * pathkeys is the list of pathkeys to order the result by.
+ *
+ * is_subquery is the flag to indicate whether to deparse the specified
+ * relation as a subquery.
+ *
+ * List of columns selected is returned in retrieved_attrs.
+ */
+void
+chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
+						List *tlist, List *remote_conds, List *pathkeys,
+						bool has_final_sort, bool has_limit, bool is_subquery,
+						List **retrieved_attrs, List **params_list)
+{
+	deparse_expr_cxt context;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) rel->fdw_private;
+	List	   *quals;
+
+	elog(DEBUG2, "> %s:%d", __FUNCTION__, __LINE__);
+	/*
+	 * We handle relations for foreign tables, joins between those and upper
+	 * relations.
+	 */
+	Assert(IS_JOIN_REL(rel) || IS_SIMPLE_REL(rel) || IS_UPPER_REL(rel));
+
+	/* Fill portions of context common to upper, join and base relation */
+	context.buf = buf;
+	context.root = root;
+	context.foreignrel = rel;
+	context.scanrel = IS_UPPER_REL(rel) ? fpinfo->outerrel : rel;
+	context.params_list = params_list;
+	context.func = NULL;
+	context.interval_op = false;
+	context.array_as_tuple = false;
+
+	/* Construct SELECT clause */
+	deparseSelectSql(tlist, is_subquery, retrieved_attrs, &context);
+
+	/*
+	 * For upper relations, the WHERE clause is built from the remote
+	 * conditions of the underlying scan relation; otherwise, we can use the
+	 * supplied list of remote conditions directly.
+	 */
+	if (IS_UPPER_REL(rel))
+	{
+		CHFdwRelationInfo *ofpinfo;
+
+		ofpinfo = (CHFdwRelationInfo *) fpinfo->outerrel->fdw_private;
+		quals = ofpinfo->remote_conds;
+	}
+	else
+		quals = remote_conds;
+
+	/* Construct FROM and WHERE clauses */
+	deparseFromExpr(quals, &context);
+
+	if (IS_UPPER_REL(rel))
+	{
+		/* Append GROUP BY clause */
+		appendGroupByClause(tlist, &context);
+
+		/* Append HAVING clause */
+		if (remote_conds)
+		{
+			appendStringInfoString(buf, " HAVING ");
+			appendConditions(remote_conds, &context);
+		}
+	}
+
+	/* Add ORDER BY clause if we found any useful pathkeys */
+	if (pathkeys)
+		appendOrderByClause(pathkeys, has_final_sort, &context);
+
+	/* Add LIMIT clause if necessary */
+	if (has_limit)
+		appendLimitClause(&context);
+}
+
+/*
+ * Construct a simple SELECT statement that retrieves desired columns
+ * of the specified foreign table, and append it to "buf".  The output
+ * contains just "SELECT ... ".
+ *
+ * We also create an integer List of the columns being retrieved, which is
+ * returned to *retrieved_attrs, unless we deparse the specified relation
+ * as a subquery.
+ *
+ * tlist is the list of desired columns.  is_subquery is the flag to
+ * indicate whether to deparse the specified relation as a subquery.
+ * Read prologue of chfdw_deparse_select_stmt_for_rel() for details.
+ */
+static void
+deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
+				 deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	RelOptInfo *foreignrel = context->foreignrel;
+	PlannerInfo *root = context->root;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+
+	/* reset var counter */
+	var_counter = 0;
+	elog(DEBUG2, "> %s:%d", __FUNCTION__, __LINE__);
+	/*
+	 * Construct SELECT list
+	 */
+	appendStringInfoString(buf, "SELECT ");
+
+	if (is_subquery)
+	{
+		/*
+		 * For a relation that is deparsed as a subquery, emit expressions
+		 * specified in the relation's reltarget.  Note that since this is for
+		 * the subquery, no need to care about *retrieved_attrs.
+		 */
+		deparseSubqueryTargetList(context);
+	}
+	else if (IS_JOIN_REL(foreignrel) || IS_UPPER_REL(foreignrel))
+	{
+		/*
+		 * For a join or upper relation the input tlist gives the list of
+		 * columns required to be fetched from the foreign server.
+		 */
+		deparseExplicitTargetList(tlist, retrieved_attrs, context);
+	}
+	else
+	{
+		/*
+		 * For a base relation fpinfo->attrs_used gives the list of columns
+		 * required to be fetched from the foreign server.
+		 */
+		RangeTblEntry *rte = planner_rt_fetch(foreignrel->relid, root);
+
+		/*
+		 * Core code already has some lock on each rel being planned, so we
+		 * can use NoLock here.
+		 */
+		Relation	rel = table_open_compat(rte->relid, NoLock);
+
+		deparseTargetList(buf, rte, foreignrel->relid, rel,
+						  fpinfo->attrs_used, false, retrieved_attrs);
+		table_close_compat(rel, NoLock);
+	}
+	elog(DEBUG2, "< %s:%d", __FUNCTION__, __LINE__);
+}
+
+/*
+ * Construct a FROM clause and, if needed, a WHERE clause, and append those to
+ * "buf".
+ *
+ * quals is the list of clauses to be included in the WHERE clause.
+ * (These may or may not include RestrictInfo decoration.)
+ */
+static void
+deparseFromExpr(List *quals, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	RelOptInfo *scanrel = context->scanrel;
+
+	/* For upper relations, scanrel must be either a joinrel or a baserel */
+	Assert(!IS_UPPER_REL(context->foreignrel) ||
+		   IS_JOIN_REL(scanrel) || IS_SIMPLE_REL(scanrel));
+
+	/* Construct FROM clause */
+	appendStringInfoString(buf, " FROM ");
+	deparseFromExprForRel(buf, context->root, scanrel,
+						  (bms_num_members(scanrel->relids) > 1),
+						  (Index) 0, NULL, context->params_list);
+
+	/* Construct WHERE clause */
+	if (quals != NIL)
+	{
+		appendStringInfoString(buf, " WHERE ");
+		appendConditions(quals, context);
+	}
+}
+
+/*
+ * Emit a target list that retrieves the columns specified in attrs_used.
+ * This is used for both SELECT and RETURNING targetlists; the is_returning
+ * parameter is true only for a RETURNING targetlist.
+ *
+ * The tlist text is appended to buf, and we also create an integer List
+ * of the columns being retrieved, which is returned to *retrieved_attrs.
+ *
+ * If qualify_col is true, add relation alias before the column name.
+ */
+static void
+deparseTargetList(StringInfo buf,
+				  RangeTblEntry *rte,
+				  Index rtindex,
+				  Relation rel,
+				  Bitmapset *attrs_used,
+				  bool qualify_col,
+				  List **retrieved_attrs)
+{
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	bool		have_wholerow;
+	bool		first;
+	int			i;
+
+	*retrieved_attrs = NIL;
+
+	/* If there's a whole-row reference, we'll need all the columns. */
+	have_wholerow = bms_is_member(0 - FirstLowInvalidHeapAttributeNumber,
+								  attrs_used);
+
+	first = true;
+	for (i = 1; i <= tupdesc->natts; i++)
+	{
+		CustomObjectDef	*cdef;
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i - 1);
+
+		/* Ignore dropped attributes. */
+		if (attr->attisdropped)
+			continue;
+
+		if (have_wholerow ||
+			bms_is_member(i - FirstLowInvalidHeapAttributeNumber,
+						  attrs_used))
+		{
+			if (!first)
+				appendStringInfoString(buf, ", ");
+
+			first = false;
+
+			cdef = chfdw_check_for_custom_type(attr->atttypid);
+			deparseColumnRef(buf, cdef, rtindex, i, rte, qualify_col);
+
+			*retrieved_attrs = lappend_int(*retrieved_attrs, i);
+		}
+	}
+
+	/*
+	 * check for ctid and oid
+	 */
+	if (bms_is_member(SelfItemPointerAttributeNumber -
+					  FirstLowInvalidHeapAttributeNumber,
+					  attrs_used))
+		elog(ERROR, "clickhouse does not support system columns");
+
+	/* Don't generate bad syntax if no undropped columns */
+	if (first)
+	{
+		appendStringInfoString(buf, "NULL");
+	}
+}
+
+/*
+ * Deparse conditions from the provided list and append them to buf.
+ *
+ * The conditions in the list are assumed to be ANDed. This function is used to
+ * deparse WHERE clauses, JOIN .. ON clauses and HAVING clauses.
+ *
+ * Depending on the caller, the list elements might be either RestrictInfos
+ * or bare clauses.
+ */
+static void
+appendConditions(List *exprs, deparse_expr_cxt *context)
+{
+	ListCell   *lc;
+	bool		is_first = true;
+	StringInfo	buf = context->buf;
+
+	foreach (lc, exprs)
+	{
+		Expr	   *expr = (Expr *) lfirst(lc);
+
+		/* Extract clause from RestrictInfo, if required */
+		if (IsA(expr, RestrictInfo))
+		{
+			expr = ((RestrictInfo *) expr)->clause;
+		}
+
+		/* Connect expressions with "AND" and parenthesize each condition. */
+		if (!is_first)
+		{
+			appendStringInfoString(buf, " AND ");
+		}
+
+		appendStringInfoChar(buf, '(');
+		deparseExpr(expr, context);
+		appendStringInfoChar(buf, ')');
+
+		is_first = false;
+	}
+}
+
+/* Output join name for given join type */
+const char *
+chfdw_get_jointype_name(JoinType jointype)
+{
+	switch (jointype)
+	{
+	case JOIN_INNER:
+		return "INNER";
+
+	case JOIN_LEFT:
+		return "LEFT";
+
+	case JOIN_RIGHT:
+		return "RIGHT";
+
+	case JOIN_FULL:
+		return "FULL";
+
+	default:
+		/* Shouldn't come here, but protect from buggy code. */
+		elog(ERROR, "unsupported join type %d", jointype);
+	}
+
+	/* Keep compiler happy */
+	return NULL;
+}
+
+/*
+ * Deparse given targetlist and append it to context->buf.
+ *
+ * tlist is list of TargetEntry's which in turn contain Var nodes.
+ *
+ * retrieved_attrs is the list of continuously increasing integers starting
+ * from 1. It has same number of entries as tlist.
+ */
+static void
+deparseExplicitTargetList(List *tlist,
+                          List **retrieved_attrs,
+                          deparse_expr_cxt *context)
+{
+	ListCell   *lc;
+	StringInfo	buf = context->buf;
+	int			i = 0;
+
+	*retrieved_attrs = NIL;
+
+	foreach (lc, tlist)
+	{
+		TargetEntry *tle = lfirst_node(TargetEntry, lc);
+
+		if (i > 0)
+			appendStringInfoString(buf, ", ");
+
+		deparseExpr((Expr *) tle->expr, context);
+
+		*retrieved_attrs = lappend_int(*retrieved_attrs, i + 1);
+		i++;
+	}
+
+	if (i == 0)
+		appendStringInfoString(buf, "NULL");
+}
+
+/*
+ * Emit expressions specified in the given relation's reltarget.
+ *
+ * This is used for deparsing the given relation as a subquery.
+ */
+static void
+deparseSubqueryTargetList(deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	RelOptInfo *foreignrel = context->foreignrel;
+	bool		first;
+	ListCell   *lc;
+
+	/* Should only be called in these cases. */
+	Assert(IS_SIMPLE_REL(foreignrel) || IS_JOIN_REL(foreignrel));
+
+	first = true;
+	foreach(lc, foreignrel->reltarget->exprs)
+	{
+		Node	   *node = (Node *) lfirst(lc);
+
+		if (!first)
+			appendStringInfoString(buf, ", ");
+
+		first = false;
+
+		deparseExpr((Expr *) node, context);
+	}
+
+	/* Don't generate bad syntax if no expressions */
+	if (first)
+		appendStringInfoString(buf, "NULL");
+}
+
+/*
+ * Construct FROM clause for given relation
+ *
+ * The function constructs ... JOIN ... ON ... for join relation. For a base
+ * relation it just returns schema-qualified tablename, with the appropriate
+ * alias if so requested.
+ *
+ * 'ignore_rel' is either zero or the RT index of a target relation.  In the
+ * latter case the function constructs FROM clause of UPDATE or USING clause
+ * of DELETE; it deparses the join relation as if the relation never contained
+ * the target relation, and creates a List of conditions to be deparsed into
+ * the top-level WHERE clause, which is returned to *ignore_conds.
+ */
+static void
+deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
+                      bool use_alias, Index ignore_rel, List **ignore_conds,
+                      List **params_list)
+{
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+
+	if (IS_JOIN_REL(foreignrel))
+	{
+		StringInfoData join_sql_o;
+		StringInfoData join_sql_i;
+		RelOptInfo *outerrel = fpinfo->outerrel;
+		RelOptInfo *innerrel = fpinfo->innerrel;
+		bool		outerrel_is_target = false;
+		bool		innerrel_is_target = false;
+
+		if (ignore_rel > 0 && bms_is_member(ignore_rel, foreignrel->relids))
+		{
+			/*
+			 * If this is an inner join, add joinclauses to *ignore_conds and
+			 * set it to empty so that those can be deparsed into the WHERE
+			 * clause.  Note that since the target relation can never be
+			 * within the nullable side of an outer join, those could safely
+			 * be pulled up into the WHERE clause (see foreign_join_ok()).
+			 * Note also that since the target relation is only inner-joined
+			 * to any other relation in the query, all conditions in the join
+			 * tree mentioning the target relation could be deparsed into the
+			 * WHERE clause by doing this recursively.
+			 */
+			if (fpinfo->jointype == JOIN_INNER)
+			{
+				*ignore_conds = list_concat(*ignore_conds,
+											list_copy(fpinfo->joinclauses));
+				fpinfo->joinclauses = NIL;
+			}
+
+			/*
+			 * Check if either of the input relations is the target relation.
+			 */
+			if (outerrel->relid == ignore_rel)
+			{
+				outerrel_is_target = true;
+			}
+			else if (innerrel->relid == ignore_rel)
+			{
+				innerrel_is_target = true;
+			}
+		}
+
+		/* Deparse outer relation if not the target relation. */
+		if (!outerrel_is_target)
+		{
+			initStringInfo(&join_sql_o);
+			deparseRangeTblRef(&join_sql_o, root, outerrel,
+							   fpinfo->make_outerrel_subquery,
+							   ignore_rel, ignore_conds, params_list);
+
+			/*
+			 * If inner relation is the target relation, skip deparsing it.
+			 * Note that since the join of the target relation with any other
+			 * relation in the query is an inner join and can never be within
+			 * the nullable side of an outer join, the join could be
+			 * interchanged with higher-level joins (cf. identity 1 on outer
+			 * join reordering shown in src/backend/optimizer/README), which
+			 * means it's safe to skip the target-relation deparsing here.
+			 */
+			if (innerrel_is_target)
+			{
+				Assert(fpinfo->jointype == JOIN_INNER);
+				Assert(fpinfo->joinclauses == NIL);
+				appendStringInfo(buf, "%s", join_sql_o.data);
+				return;
+			}
+		}
+
+		/* Deparse inner relation if not the target relation. */
+		if (!innerrel_is_target)
+		{
+			initStringInfo(&join_sql_i);
+			deparseRangeTblRef(&join_sql_i, root, innerrel,
+							   fpinfo->make_innerrel_subquery,
+							   ignore_rel, ignore_conds, params_list);
+
+			/*
+			 * If outer relation is the target relation, skip deparsing it.
+			 * See the above note about safety.
+			 */
+			if (outerrel_is_target)
+			{
+				Assert(fpinfo->jointype == JOIN_INNER);
+				Assert(fpinfo->joinclauses == NIL);
+				appendStringInfo(buf, "%s", join_sql_i.data);
+				return;
+			}
+		}
+
+		/* Neither of the relations is the target relation. */
+		Assert(!outerrel_is_target && !innerrel_is_target);
+
+		/*
+		 * For a join relation FROM clause entry is deparsed as
+		 *
+		 * ((outer relation) <join type> (inner relation) ON (joinclauses))
+		 */
+		appendStringInfo(buf, " %s ALL %s JOIN %s ON ", join_sql_o.data,
+						 chfdw_get_jointype_name(fpinfo->jointype), join_sql_i.data);
+
+		/* Append join clause; (TRUE) if no join clause */
+		if (fpinfo->joinclauses)
+		{
+			deparse_expr_cxt context;
+
+			context.buf = buf;
+			context.foreignrel = foreignrel;
+			context.scanrel = foreignrel;
+			context.root = root;
+			context.params_list = params_list;
+			context.func = NULL;
+			context.interval_op = false;
+			context.array_as_tuple = false;
+
+			appendStringInfoChar(buf, '(');
+			appendConditions(fpinfo->joinclauses, &context);
+			appendStringInfoChar(buf, ')');
+		}
+		else
+		{
+			appendStringInfoString(buf, "(TRUE)");
+		}
+	}
+	else
+	{
+		RangeTblEntry *rte = planner_rt_fetch(foreignrel->relid, root);
+
+		/*
+		 * Core code already has some lock on each rel being planned, so we
+		 * can use NoLock here.
+		 */
+		Relation	rel = table_open_compat(rte->relid, NoLock);
+
+		deparseRelation(buf, rel);
+
+		/*
+		 * Add a unique alias to avoid any conflict in relation names due to
+		 * pulled up subqueries in the query being built for a pushed down
+		 * join.
+		 */
+		if (use_alias)
+		{
+			appendStringInfo(buf, " %s%d", REL_ALIAS_PREFIX, foreignrel->relid);
+		}
+
+		table_close_compat(rel, NoLock);
+	}
+}
+
+/*
+ * Append FROM clause entry for the given relation into buf.
+ */
+static void
+deparseRangeTblRef(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
+                   bool make_subquery, Index ignore_rel, List **ignore_conds,
+                   List **params_list)
+{
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+
+	/* Should only be called in these cases. */
+	Assert(IS_SIMPLE_REL(foreignrel) || IS_JOIN_REL(foreignrel));
+
+	Assert(fpinfo->local_conds == NIL);
+
+	/* If make_subquery is true, deparse the relation as a subquery. */
+	if (make_subquery)
+	{
+		List	   *retrieved_attrs;
+		int			ncols;
+
+		/*
+		 * The given relation shouldn't contain the target relation, because
+		 * this should only happen for input relations for a full join, and
+		 * such relations can never contain an UPDATE/DELETE target.
+		 */
+		Assert(ignore_rel == 0 ||
+			   !bms_is_member(ignore_rel, foreignrel->relids));
+
+		/* Deparse the subquery representing the relation. */
+		appendStringInfoChar(buf, '(');
+		chfdw_deparse_select_stmt_for_rel(buf, root, foreignrel, NIL,
+								fpinfo->remote_conds, NIL,
+                                false, false, true,
+								&retrieved_attrs, params_list);
+		appendStringInfoChar(buf, ')');
+
+		/* Append the relation alias. */
+		appendStringInfo(buf, " %s%d", SUBQUERY_REL_ALIAS_PREFIX,
+						 fpinfo->relation_index);
+
+		/*
+		 * Append the column aliases if needed.  Note that the subquery emits
+		 * expressions specified in the relation's reltarget (see
+		 * deparseSubqueryTargetList).
+		 */
+		ncols = list_length(foreignrel->reltarget->exprs);
+		if (ncols > 0)
+		{
+			int			i;
+
+			appendStringInfoChar(buf, '(');
+			for (i = 1; i <= ncols; i++)
+			{
+				if (i > 1)
+				{
+					appendStringInfoString(buf, ", ");
+				}
+
+				appendStringInfo(buf, "%s%d", SUBQUERY_COL_ALIAS_PREFIX, i);
+			}
+			appendStringInfoChar(buf, ')');
+		}
+	}
+	else
+		deparseFromExprForRel(buf, root, foreignrel, true, ignore_rel,
+							  ignore_conds, params_list);
+}
+
+/*
+ * deparse remote INSERT statement
+ */
+char *
+chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry *rte,
+                 Index rtindex, Relation rel,
+                 List *targetAttrs)
+{
+	bool    first;
+	ListCell   *lc;
+	StringInfoData	table_name;
+
+	initStringInfo(&table_name);
+	appendStringInfoString(buf, "INSERT INTO ");
+	deparseRelation(&table_name, rel);
+	appendStringInfoString(buf, table_name.data);
+
+	if (targetAttrs)
+	{
+		appendStringInfoChar(buf, '(');
+
+		first = true;
+		foreach (lc, targetAttrs)
+		{
+			int			attnum = lfirst_int(lc);
+
+			if (!first)
+				appendStringInfoString(buf, ", ");
+
+			first = false;
+
+			deparseColumnRef(buf, NULL, rtindex, attnum, rte, false);
+		}
+		appendStringInfoChar(buf, ')');
+	}
+
+	return table_name.data;
+}
+
+/*
+ * Construct name to use for given column, and emit it into buf.
+ * If it has a column_name FDW option, use that instead of attribute name.
+ *
+ * If qualify_col is true, qualify column name with the alias of relation.
+ */
+static void
+deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
+				 int varno, int varattno, RangeTblEntry *rte,
+                 bool qualify_col)
+{
+	char	   *colname = NULL;
+	CustomColumnInfo	*cinfo;
+
+	/* varno must not be any of OUTER_VAR, INNER_VAR and INDEX_VAR. */
+	Assert(!IS_SPECIAL_VARNO(varno));
+
+	if (varattno <= 0)
+		elog(ERROR, "ClickHouse does not support system attributes");
+
+	/* Get FDW specific options for this column */
+	cinfo = chfdw_get_custom_column_info(rte->relid, varattno);
+	if (cinfo)
+		colname = cinfo->colname;
+
+	/*
+	 * If it's a column of a regular table or it doesn't have column_name
+	 * FDW option, use attribute name.
+	 */
+	if (colname == NULL)
+		colname = get_attname(rte->relid, varattno, false);
+
+	if (cinfo && cinfo->coltype == CF_ISTORE_ARR)
+	{
+		char *colkey = psprintf("%s_keys", colname);
+		char *colval = psprintf("%s_values", colname);
+
+		if (cdef && cdef->cf_type == CF_ISTORE_SUM)
+		{
+			/* SUM context */
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colkey));
+			appendStringInfoChar(buf, ',');
+
+			if (cinfo->table_engine == CH_COLLAPSING_MERGE_TREE)
+			{
+				appendStringInfoString(buf, "arrayMap(x -> x * ");
+				appendStringInfoString(buf, cinfo->signfield);
+				appendStringInfoChar(buf, ',');
+				if (qualify_col)
+					ADD_REL_QUALIFIER(buf, varno);
+				appendStringInfoString(buf, quote_identifier(colval));
+				appendStringInfoChar(buf, ')');
+			}
+			else
+			{
+				if (qualify_col)
+					ADD_REL_QUALIFIER(buf, varno);
+				appendStringInfoString(buf, quote_identifier(colval));
+			}
+		}
+		else if (cdef && cdef->cf_type == CF_ISTORE_FETCHVAL)
+		{
+			/* values[indexOf(ids, */
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colval));
+			appendStringInfoString(buf, "[nullif(indexOf(");
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colkey));
+			appendStringInfoChar(buf, ',');
+		}
+		else if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
+		{
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colval));
+
+			if (cdef->cf_context && list_length(cdef->cf_context) == 2)
+			{
+				appendStringInfoChar(buf, ',');
+				if (qualify_col)
+					ADD_REL_QUALIFIER(buf, varno);
+				appendStringInfoString(buf, quote_identifier(colkey));
+			}
+		}
+		else
+		{
+			appendStringInfoChar(buf, '(');
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colkey));
+			appendStringInfoChar(buf, ',');
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colval));
+			appendStringInfoChar(buf, ')');
+		}
+
+		pfree(colkey);
+		pfree(colval);
+	}
+	else if (cinfo && cinfo->coltype == CF_ISTORE_COL)
+	{
+		char *alias_name = get_alias_name();
+
+		if (cdef && cdef->cf_type == CF_ISTORE_FETCHVAL)
+		{
+			/* ((finalizeAggregation(colname) as _tmp).2)[indexOf(_tmp.1, - we fill this part
+			 * <key>)] - should be filled later */
+
+			appendStringInfoString(buf, "((");
+
+			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
+				appendStringInfoString(buf, "finalizeAggregation(");
+			else
+				appendStringInfoChar(buf, '(');
+
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+
+			appendStringInfoString(buf, quote_identifier(colname));
+			appendStringInfo(buf, ") as %s).2)[nullif(indexOf(%s.1, ", alias_name, alias_name);
+		}
+		else if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
+		{
+			appendStringInfoChar(buf, '(');
+
+			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
+				appendStringInfoString(buf, "finalizeAggregation(");
+			else
+				appendStringInfoChar(buf, '(');
+
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colname));
+			appendStringInfo(buf, ") as %s).2", alias_name);
+
+			if (cdef->cf_context && list_length(cdef->cf_context) == 2)
+				appendStringInfo(buf, ", %s.1", alias_name);
+		}
+		else
+		{
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, varno);
+			appendStringInfoString(buf, quote_identifier(colname));
+		}
+
+		pfree(alias_name);
+	}
+	else
+	{
+		if (qualify_col)
+			ADD_REL_QUALIFIER(buf, varno);
+		appendStringInfoString(buf, quote_identifier(colname));
+	}
+}
+
+/*
+ * Append remote name of specified foreign table to buf.
+ * Use value of table_name FDW option (if any) instead of relation's name.
+ * Similarly, schema_name FDW option overrides schema name.
+ */
+static void
+deparseRelation(StringInfo buf, Relation rel)
+{
+	ForeignTable *table;
+	const char *relname = NULL;
+	char       *dbname = "default";
+	ForeignServer *server = chfdw_get_foreign_server(rel);
+	ListCell    *lc;
+
+	chfdw_extract_options(server->options, NULL, NULL, NULL, &dbname, NULL, NULL);
+
+	/* obtain additional catalog information. */
+	table = GetForeignTable(RelationGetRelid(rel));
+
+	/*
+	 * Use value of FDW options if any, instead of the name of object itself.
+	 */
+	foreach (lc, table->options)
+	{
+		DefElem    *def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "table_name") == 0)
+		{
+			relname = defGetString(def);
+		}
+		else if (strcmp(def->defname, "database") == 0)
+        {
+			dbname = defGetString(def);
+        }
+	}
+	if (relname == NULL)
+	{
+		relname = RelationGetRelationName(rel);
+	}
+
+	appendStringInfo(buf, "%s.%s", quote_identifier(dbname),
+					 quote_identifier(relname));
+}
+
+/*
+ * Append a SQL string literal representing "val" to buf.
+ */
+static void
+deparseStringLiteral(StringInfo buf, const char *val, bool quote)
+{
+	const char *valptr;
+
+	/*
+	 * Rather than making assumptions about the remote server's value of
+	 * standard_conforming_strings, always use E'foo' syntax if there are any
+	 * backslashes.  This will fail on remote servers before 8.1, but those
+	 * are long out of support.
+	 */
+	if (strchr(val, '\\') != NULL)
+	{
+		appendStringInfoChar(buf, ESCAPE_STRING_SYNTAX);
+	}
+	if (quote)
+		appendStringInfoChar(buf, '\'');
+	for (valptr = val; *valptr; valptr++)
+	{
+		char		ch = *valptr;
+
+		if (SQL_STR_DOUBLE(ch, true))
+		{
+			appendStringInfoChar(buf, ch);
+		}
+		appendStringInfoChar(buf, ch);
+	}
+	if (quote)
+		appendStringInfoChar(buf, '\'');
+}
+
+/*
+ * Deparse given expression into context->buf.
+ *
+ * This function must support all the same node types that foreign_expr_walker
+ * accepts.
+ *
+ * Note: unlike ruleutils.c, we just use a simple hard-wired parenthesization
+ * scheme: anything more complex than a Var, Const, function call or cast
+ * should be self-parenthesized.
+ */
+static void
+deparseExpr(Expr *node, deparse_expr_cxt *context)
+{
+	if (node == NULL)
+	{
+		return;
+	}
+
+	switch (nodeTag(node))
+	{
+	case T_Var:
+		deparseVar((Var *) node, context);
+		break;
+	case T_Const:
+		deparseConst((Const *) node, context, 0);
+		break;
+	case T_SubscriptingRef:
+		deparseSubscriptingRef((SubscriptingRef *) node, context);
+		break;
+	case T_FuncExpr:
+		deparseFuncExpr((FuncExpr *) node, context);
+		break;
+	case T_OpExpr:
+		deparseOpExpr((OpExpr *) node, context);
+		break;
+	case T_DistinctExpr:
+		deparseDistinctExpr((DistinctExpr *) node, context);
+		break;
+	case T_NullIfExpr:
+		deparseNullIfExpr((NullIfExpr *) node, context);
+		break;
+	case T_ScalarArrayOpExpr:
+		deparseScalarArrayOpExpr((ScalarArrayOpExpr *) node, context);
+		break;
+	case T_RelabelType:
+		deparseRelabelType((RelabelType *) node, context);
+		break;
+	case T_BoolExpr:
+		deparseBoolExpr((BoolExpr *) node, context);
+		break;
+	case T_NullTest:
+		deparseNullTest((NullTest *) node, context);
+		break;
+	case T_ArrayExpr:
+		deparseArrayExpr((ArrayExpr *) node, context);
+		break;
+	case T_Aggref:
+		deparseAggref((Aggref *) node, context);
+		break;
+	case T_CaseExpr:
+		deparseCaseExpr((CaseExpr *) node, context);
+		break;
+	case T_CaseWhen:
+		deparseCaseWhen((CaseWhen *) node, context);
+		break;
+	case T_CoalesceExpr:
+		deparseCoalesceExpr((CoalesceExpr *) node, context);
+		break;
+	case T_MinMaxExpr:
+		deparseMinMaxExpr((MinMaxExpr *) node, context);
+		break;
+	case T_CoerceViaIO:
+		deparseCoerceViaIO((CoerceViaIO *) node, context);
+		break;
+	case T_RowExpr:
+		deparseRowExpr((RowExpr *) node, context);
+		break;
+	default:
+		elog(ERROR, "unsupported expression type for deparse: %d",
+			 (int) nodeTag(node));
+		break;
+	}
+}
+
+/*
+ * Deparse given Var node into context->buf.
+ *
+ * If the Var belongs to the foreign relation, just print its remote name.
+ * Otherwise, it's effectively a Param (and will in fact be a Param at
+ * run time).  Handle it the same way we handle plain Params.
+ */
+static void
+deparseVar(Var *node, deparse_expr_cxt *context)
+{
+	CustomObjectDef	*cdef;
+	Relids		relids = context->scanrel->relids;
+	int			relno;
+	int			colno;
+
+	/* Qualify columns when multiple relations are involved. */
+	bool		qualify_col = (bms_num_members(relids) > 1);
+
+	/*
+	 * If the Var belongs to the foreign relation that is deparsed as a
+	 * subquery, use the relation and column alias to the Var provided by the
+	 * subquery, instead of the remote name.
+	 */
+	if (is_subquery_var(node, context->scanrel, &relno, &colno))
+	{
+		appendStringInfo(context->buf, "%s%d.%s%d",
+						 SUBQUERY_REL_ALIAS_PREFIX, relno,
+						 SUBQUERY_COL_ALIAS_PREFIX, colno);
+		return;
+	}
+
+	cdef = context->func;
+	if (!cdef)
+		cdef = chfdw_check_for_custom_type(node->vartype);
+
+	if (bms_is_member(node->varno, relids) && node->varlevelsup == 0)
+		deparseColumnRef(context->buf, cdef,
+						 node->varno, node->varattno,
+						 planner_rt_fetch(node->varno, context->root),
+						 qualify_col);
+	else
+		elog(ERROR, "clickhouse_fdw does not support params");
+}
+
+#define USE_ISO_DATES			1
+
+Datum
+ch_time_out(PG_FUNCTION_ARGS)
+{
+	TimeADT		time = PG_GETARG_TIMEADT(0);
+	char	   *result;
+	struct pg_tm tt,
+			   *tm = &tt;
+	fsec_t		fsec;
+	char		buf[MAXDATELEN + 1];
+
+	time2tm(time, tm, &fsec);
+	EncodeTimeOnly(tm, fsec, false, 0, USE_ISO_DATES, buf);
+
+	result = pstrdup(buf);
+	PG_RETURN_CSTRING(result);
+}
+
+/* date_out()
+ * Given internal format date, convert to text string.
+ */
+Datum
+ch_date_out(PG_FUNCTION_ARGS)
+{
+	DateADT		date = PG_GETARG_DATEADT(0);
+	char	   *result;
+	struct pg_tm tt,
+			   *tm = &tt;
+	char		buf[MAXDATELEN + 1];
+
+	if (DATE_NOT_FINITE(date))
+		EncodeSpecialDate(date, buf);
+	else
+	{
+		j2date(date + POSTGRES_EPOCH_JDATE,
+			   &(tm->tm_year), &(tm->tm_mon), &(tm->tm_mday));
+		EncodeDateOnly(tm, USE_ISO_DATES, buf);
+	}
+
+	result = pstrdup(buf);
+	PG_RETURN_CSTRING(result);
+}
+
+Datum
+ch_timestamp_out(PG_FUNCTION_ARGS)
+{
+	Timestamp	timestamp = PG_GETARG_TIMESTAMP(0);
+	char	   *result;
+	struct pg_tm tt,
+			   *tm = &tt;
+	fsec_t		fsec;
+	char		buf[MAXDATELEN + 1];
+
+	if (TIMESTAMP_NOT_FINITE(timestamp))
+		EncodeSpecialTimestamp(timestamp, buf);
+	else if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) == 0)
+		/* we ignore ftractional seconds */
+		EncodeDateTime(tm, 0, false, 0, NULL, USE_ISO_DATES, buf);
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
+
+	result = pstrdup(buf);
+	PG_RETURN_CSTRING(result);
+}
+
+static void
+deparseArray(Datum arr, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	AnyArrayType *array = DatumGetAnyArrayP(arr);
+	int			ndims = AARR_NDIM(array);
+	int		   *dims = AARR_DIMS(array);
+	Oid			element_type = AARR_ELEMTYPE(array);
+
+	int16		typlen;
+	bool		typbyval;
+	char		typalign;
+	char		typdelim;
+	Oid			typioparam;
+	Oid			typiofunc;
+	int			nitems;
+	array_iter	iter;
+	int			i;
+	bool		first;
+
+	if (ndims > 1)
+		elog(ERROR, "only one dimension of arrays supported by clickhouse_fdw");
+
+	get_type_io_data(element_type, IOFunc_output,
+					 &typlen, &typbyval,
+					 &typalign, &typdelim,
+					 &typioparam, &typiofunc);
+
+	/* Loop over source data */
+	nitems = ArrayGetNItems(ndims, dims);
+	array_iter_setup(&iter, array);
+	first = true;
+
+	if (context->array_as_tuple)
+		appendStringInfoChar(buf, '(');
+	else
+		appendStringInfoChar(buf, '[');
+
+	for (i = 0; i < nitems; i++)
+	{
+		Datum		elt;
+		bool		isnull;
+
+		if (!first)
+			appendStringInfoChar(buf, ',');
+		first = false;
+
+		/* Get element, checking for NULL */
+		elt = array_iter_next(&iter, &isnull, i, typlen, typbyval, typalign);
+
+		if (isnull)
+		{
+			appendStringInfoString(buf, "NULL");
+		}
+		else
+		{
+			char *extval = OidOutputFunctionCall(typiofunc, elt);
+			switch (element_type)
+			{
+			case INT2OID:
+			case INT4OID:
+			case INT8OID:
+			case OIDOID:
+			case FLOAT4OID:
+			case FLOAT8OID:
+			case NUMERICOID:
+			{
+				/*
+				 * No need to quote unless it's a special value such as 'NaN'.
+				 * See comments in get_const_expr().
+				 */
+				if (strspn(extval, "0123456789+-eE.") == strlen(extval))
+				{
+					if (extval[0] == '+' || extval[0] == '-')
+						appendStringInfo(buf, "(%s)", extval);
+					else
+						appendStringInfoString(buf, extval);
+				}
+				else
+					appendStringInfo(buf, "'%s'", extval);
+			}
+			break;
+			case BOOLOID:
+				if (strcmp(extval, "t") == 0)
+					appendStringInfoString(buf, "true");
+				else
+					appendStringInfoString(buf, "false");
+				break;
+			default:
+				deparseStringLiteral(buf, extval, true);
+				break;
+			}
+			pfree(extval);
+		}
+	}
+	if (context->array_as_tuple)
+		appendStringInfoChar(buf, ')');
+	else
+		appendStringInfoChar(buf, ']');
+}
+
+/*
+ * Deparse given constant value into context->buf.
+ *
+ * This function has to be kept in sync with ruleutils.c's get_const_expr.
+ * As for that function, showtype can be -1 to never show "::typename" decoration,
+ * or +1 to always show it, or 0 to show it only if the constant wouldn't be assumed
+ * to be the right type by default.
+ */
+static void
+deparseConst(Const *node, deparse_expr_cxt *context, int showtype)
+{
+	StringInfo	buf = context->buf;
+	Oid			typoutput;
+	bool		typIsVarlena;
+	char	   *extval = NULL;
+	bool		closebr = false;
+
+	if (node->constisnull)
+	{
+		appendStringInfoString(buf, "NULL");
+		return;
+	}
+
+	if (showtype > 0)
+		appendStringInfoString(buf, "cast(");
+
+	getTypeOutputInfo(node->consttype,
+					  &typoutput, &typIsVarlena);
+
+	if (typoutput == F_TIMESTAMPTZ_OUT || typoutput == F_TIMESTAMP_OUT)
+	{
+		/*
+		 * We use our own function here, that removes fractional seconds since
+		 * there are not supported in clickhouse
+		 * */
+		extval = DatumGetCString(DirectFunctionCall1(ch_timestamp_out, node->constvalue));
+	}
+	else if (typoutput == F_INTERVAL_OUT)
+	{
+		/* basicly we can't convert month part since we should know about
+		 * related timestamp first.
+		 *
+		 * for other types we just convert to seconds.
+		 * */
+		uint64		sec;
+		Interval   *ival = DatumGetIntervalP(node->constvalue);
+		char		bufint8[MAXINT8LEN + 1];
+
+		if (ival->month != 0)
+			elog(ERROR, "we can't convert interval with months into clickhouse");
+
+		sec = 86400 /* sec in day */ * ival->day + (int64) (ival->time / 1000000);
+		pg_lltoa(sec, bufint8);
+		appendStringInfoString(buf, bufint8);
+		goto cleanup;
+	}
+	else if (typoutput == F_ARRAY_OUT)
+	{
+		deparseArray(node->constvalue, context);
+		goto cleanup;
+	}
+	else
+	{
+		CustomObjectDef *cdef = chfdw_check_for_custom_function(typoutput);
+
+		extval = OidOutputFunctionCall(typoutput, node->constvalue);
+		if (cdef && cdef->cf_type == CF_AJBOOL_OUT)
+		{
+			/* ajbool:
+				'f' => 0
+				't' => 1
+				'u' => -1
+			*/
+			if (extval[0] == 'f')
+				appendStringInfoChar(buf, '0');
+			else if (extval[0] == 't')
+				appendStringInfoChar(buf, '1');
+			else if (extval[0] == 'u')
+				appendStringInfoString(buf, "-1");
+			else
+				elog(ERROR, "unexpected output of ajbool");
+
+			goto cleanup;
+		}
+		else if (cdef && cdef->cf_type == CF_AJTIME_OUT)
+		{
+			closebr = true;
+			appendStringInfoString(buf, "toDateTime(");
+		}
+	}
+
+	switch (node->consttype)
+	{
+	case INT2OID:
+	case INT4OID:
+	case INT8OID:
+	case OIDOID:
+	case FLOAT4OID:
+	case FLOAT8OID:
+	case NUMERICOID:
+	{
+		/*
+		 * No need to quote unless it's a special value such as 'NaN'.
+		 * See comments in get_const_expr().
+		 */
+		if (strspn(extval, "0123456789+-eE.") == strlen(extval))
+		{
+			if (extval[0] == '+' || extval[0] == '-')
+				appendStringInfo(buf, "(%s)", extval);
+			else
+				appendStringInfoString(buf, extval);
+		}
+		else
+			appendStringInfo(buf, "'%s'", extval);
+	}
+	break;
+	case BITOID:
+	case VARBITOID:
+		appendStringInfo(buf, "B'%s'", extval);
+		break;
+	case BOOLOID:
+		if (strcmp(extval, "t") == 0)
+			appendStringInfoString(buf, "1");
+		else
+			appendStringInfoString(buf, "0");
+		break;
+	default:
+		deparseStringLiteral(buf, extval, true);
+		break;
+	}
+
+	if (closebr)
+		appendStringInfoChar(buf, ')');
+
+cleanup:
+	if (showtype > 0)
+		appendStringInfo(buf, " as %s)",
+						 deparse_type_name(node->consttype,
+										   node->consttypmod));
+	if (extval)
+		pfree(extval);
+
+}
+
+/*
+ * Deparse an array subscript expression.
+ */
+static void
+deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	ListCell   *lowlist_item;
+	ListCell   *uplist_item;
+
+	/* Always parenthesize the expression. */
+	appendStringInfoChar(buf, '(');
+
+	/*
+	 * Deparse referenced array expression first.  If that expression includes
+	 * a cast, we have to parenthesize to prevent the array subscript from
+	 * being taken as typename decoration.  We can avoid that in the typical
+	 * case of subscripting a Var, but otherwise do it.
+	 */
+	if (IsA(node->refexpr, Var))
+	{
+		deparseExpr(node->refexpr, context);
+	}
+	else
+	{
+		appendStringInfoChar(buf, '(');
+		deparseExpr(node->refexpr, context);
+		appendStringInfoChar(buf, ')');
+	}
+
+	/* Deparse subscript expressions. */
+	lowlist_item = list_head(node->reflowerindexpr);	/* could be NULL */
+	foreach (uplist_item, node->refupperindexpr)
+	{
+		appendStringInfoChar(buf, '[');
+		if (lowlist_item)
+		{
+			deparseExpr(lfirst(lowlist_item), context);
+			appendStringInfoChar(buf, ':');
+			lowlist_item = lnext_compat(node->reflowerindexpr, lowlist_item);
+		}
+		deparseExpr(lfirst(uplist_item), context);
+		appendStringInfoChar(buf, ']');
+	}
+
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * Deparse a function call.
+ */
+static void
+deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	bool		first;
+	ListCell   *arg;
+	CustomObjectDef	*cdef,
+					*old_cdef;
+	CustomObjectDef	 funcdef;
+	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
+
+	/*
+	 * If the function call came from an implicit coercion, then just show the
+	 * first argument.
+	 */
+	if (node->funcformat == COERCE_IMPLICIT_CAST)
+	{
+		deparseExpr((Expr *) linitial(node->args), context);
+		return;
+	}
+
+	/*
+	 * If the function call came from a cast, then show the first argument
+	 * plus an explicit cast operation.
+	 */
+	if (node->funcformat == COERCE_EXPLICIT_CAST)
+	{
+		Oid			rettype = node->funcresulttype;
+		int32		coercedTypmod;
+
+		/* Get the typmod if this is a length-coercion function */
+		(void) exprIsLengthCoercion((Node *) node, &coercedTypmod);
+
+		appendStringInfoString(buf, "cast(");
+		deparseExpr((Expr *) linitial(node->args), context);
+		appendStringInfo(buf, ", 'Nullable(%s)')",
+						 deparse_type_name(rettype, coercedTypmod));
+		return;
+	}
+
+	/*
+	 * Normal function: display as proname(args).
+	 */
+	cdef = appendFunctionName(node->funcid, context);
+	if (cdef && cdef->cf_type == CF_DATE_TRUNC)
+	{
+		Const *arg = (Const *) linitial(node->args);
+		char *trunctype = TextDatumGetCString(arg->constvalue);
+		CSTRING_TOLOWER(trunctype);
+		int cast_to_datetime64 = 0;
+
+		if (strcmp(trunctype, "week") == 0)
+		{
+			appendStringInfoString(buf, "toMonday");
+		}
+		else if (strcmp(trunctype, "second") == 0)
+		{
+			cast_to_datetime64 = 1;
+			appendStringInfoString(buf, "toStartOfSecond");
+		}
+		else if (strcmp(trunctype, "minute") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfMinute");
+		}
+		else if (strcmp(trunctype, "hour") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfHour");
+		}
+		else if (strcmp(trunctype, "day") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfDay");
+		}
+		else if (strcmp(trunctype, "month") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfMonth");
+		}
+		else if (strcmp(trunctype, "quarter") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfQuarter");
+		}
+		else if (strcmp(trunctype, "year") == 0)
+		{
+			appendStringInfoString(buf, "toStartOfYear");
+		}
+		else
+		{
+			elog(ERROR, "date_trunc cannot be exported for: %s", trunctype);
+		}
+
+		pfree(trunctype);
+		if (cast_to_datetime64)
+		{
+			appendStringInfoString(buf, "(toDateTime64(");
+			deparseExpr(list_nth(node->args, 1), context);
+			appendStringInfoString(buf, ", 1))");
+		}
+		else
+		{
+			appendStringInfoChar(buf, '(');
+			deparseExpr(list_nth(node->args, 1), context);
+			appendStringInfoChar(buf, ')');
+		}
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_DATE_PART)
+	{
+		Const *arg = (Const *) linitial(node->args);
+		char *parttype = TextDatumGetCString(arg->constvalue);
+		CSTRING_TOLOWER(parttype);
+
+		if (strcmp(parttype, "day") == 0)
+			appendStringInfoString(buf, "toDayOfMonth");
+		else if (strcmp(parttype, "doy") == 0)
+			appendStringInfoString(buf, "toDayOfYear");
+		else if (strcmp(parttype, "dow") == 0)
+			appendStringInfoString(buf, "toDayOfWeek");
+		else if (strcmp(parttype, "year") == 0)
+			appendStringInfoString(buf, "toYear");
+		else if (strcmp(parttype, "month") == 0)
+			appendStringInfoString(buf, "toMonth");
+		else if (strcmp(parttype, "hour") == 0)
+			appendStringInfoString(buf, "toHour");
+		else if (strcmp(parttype, "minute") == 0)
+			appendStringInfoString(buf, "toMinute");
+		else if (strcmp(parttype, "second") == 0)
+			appendStringInfoString(buf, "toSecond");
+		else if (strcmp(parttype, "quarter") == 0)
+			appendStringInfoString(buf, "toQuarter");
+		else if (strcmp(parttype, "isoyear") == 0)
+			appendStringInfoString(buf, "toISOYear");
+		else if (strcmp(parttype, "week") == 0)
+			appendStringInfoString(buf, "toISOWeek");
+		else if (strcmp(parttype, "epoch") == 0)
+			appendStringInfoString(buf, "toUnixTimestamp");
+		else
+			elog(ERROR, "date_part cannot be exported for: %s", parttype);
+
+		pfree(parttype);
+		appendStringInfoChar(buf, '(');
+		deparseExpr(list_nth(node->args, 1), context);
+		appendStringInfoChar(buf, ')');
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_ISTORE_SEED)
+	{
+		if (!context->func)
+		{
+			/* not aggregation */
+			appendStringInfoChar(buf, '(');
+		}
+
+		appendStringInfoString(buf, "range(toUInt16(");
+		deparseExpr(list_nth(node->args, 1), context);
+		appendStringInfoString(buf, ") + 1), arrayResize(emptyArrayInt64(),toUInt16(");
+		deparseExpr(list_nth(node->args, 1), context);
+		appendStringInfoString(buf, ") + 1, coalesce(");
+		deparseExpr(list_nth(node->args, 2), context);
+		appendStringInfoString(buf, ", 0)");
+
+		if (context->func && context->func->cf_type == CF_ISTORE_SUM
+			&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
+			appendStringInfo(buf, " * %s", fpinfo->ch_table_sign_field);
+
+		appendStringInfoChar(buf, ')');
+
+		if (!context->func)
+			appendStringInfoChar(buf, ')');
+
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE)
+	{
+		Relids		relids = context->scanrel->relids;
+		Var		   *var = linitial(node->args);
+		bool		qualify_col = (bms_num_members(relids) > 1);
+		char	   *colname = NULL;
+		RangeTblEntry *rte;
+		CustomColumnInfo *cinfo;
+
+		if (!IsA(linitial(node->args), Var))
+			elog(ERROR, "clickhouse_fdw supports simple accumulate with column as first parameter");
+
+		if (bms_is_member(var->varno, relids) && var->varlevelsup == 0)
+			rte = planner_rt_fetch(var->varno, context->root);
+		else
+			elog(ERROR, "unidentified first parameter in accumulate");
+
+		/* Get FDW specific options for this column */
+		cinfo = chfdw_get_custom_column_info(rte->relid, var->varattno);
+		if (!cinfo)
+			elog(ERROR, "unidentified first parameter in accumulate");
+
+		if (!context->func)
+		{
+			/* not aggregation */
+			appendStringInfoChar(buf, '(');
+		}
+
+		colname = cinfo->colname;
+		if (cinfo->coltype == CF_ISTORE_ARR)
+		{
+			char *max_key_alias = get_alias_name();
+			char *colkey = psprintf("%s_keys", colname);
+			char *colval = psprintf("%s_values", colname);
+
+			if (list_length(node->args) == 1)
+				elog(ERROR, "clickhouse_fdw supports accumulate only with max_key parameter");
+
+			/* first block
+			 *	if(a_keys[1] <= max_key, arrayMap(x -> a_keys[1] + x - 1,
+			 *		arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key) - a_keys[1] + 1))), []),
+			 */
+			appendStringInfoString(buf, "if(");
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+
+			appendStringInfoString(buf, colkey);
+			appendStringInfoString(buf, "[1] <= (coalesce(");
+			deparseExpr((Expr *) list_nth(node->args, 1), context);
+			appendStringInfo(buf, ", 0) as %s), arrayMap(x -> ", max_key_alias);
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colkey);
+			appendStringInfoString(buf, "[1] + x - 1, arrayEnumerate(arrayResize(emptyArrayInt32(), (");
+			appendStringInfo(buf, "%s) - ", max_key_alias);
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colkey);
+			appendStringInfoString(buf, "[1] + 1))), []),");
+
+			/* second block:
+			 *	if(a_keys[1] <= max_key, arrayCumSum(arrayMap(x -> sign * (a_values[indexOf(a_keys, a_keys[1] + x - 1)]),
+			 *		arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key) -a_keys[1] + 1)))), [])
+			 */
+			appendStringInfoString(buf, "if(");
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colkey);
+			appendStringInfo(buf, "[1] <= (%s", max_key_alias);
+			appendStringInfoString(buf, "), arrayCumSum(arrayMap(x ->");
+
+			if (context->func && context->func->cf_type == CF_ISTORE_SUM
+				&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
+				appendStringInfo(buf, "%s * ", fpinfo->ch_table_sign_field);
+
+			appendStringInfoChar(buf, '(');
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colval);
+			appendStringInfoString(buf, "[indexOf(");
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colkey);
+			appendStringInfoChar(buf, ',');
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, colkey);
+			appendStringInfoString(buf, "[1] + x - 1)]), arrayEnumerate(arrayResize(emptyArrayInt32(), (");
+			appendStringInfo(buf, "%s) - ", max_key_alias);
+			appendStringInfoString(buf, colkey);
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+			appendStringInfoString(buf, "[1] + 1)))), [])");
+
+			pfree(colkey);
+			pfree(colval);
+
+			return;
+		}
+		else if (cinfo->coltype == CF_ISTORE_COL)
+		{
+			/* (mapFill((finalizeAggregation(col) as t1).1, t1.2, <max_key>) as t2).1,
+			 * arrayCumSum(t2.2)
+			 *
+			 * simple:
+			 * (mapFill((col as t1).1, t1.2, <max_key>) as t2).1,
+			 * arrayCumSum(t2.2) */
+
+			char *alias1 = get_alias_name();
+			char *alias2 = get_alias_name();
+
+			appendStringInfoString(buf, "(mapFill((");
+			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
+				appendStringInfoString(buf, "finalizeAggregation(");
+			else
+				appendStringInfoChar(buf, '(');
+
+			if (qualify_col)
+				ADD_REL_QUALIFIER(buf, var->varno);
+
+			appendStringInfoString(buf, colname);
+			appendStringInfo(buf, ") as %s).1, %s.2", alias1, alias1);
+
+			if (list_length(node->args) > 1)
+			{
+				/* max key, for now just assume it keys are always int32 */
+				appendStringInfoString(buf, ", toInt32(assumeNotNull(");
+				deparseExpr((Expr *) list_nth(node->args, 1), context);
+				appendStringInfoString(buf, "))");
+			}
+			appendStringInfo(buf, ") as %s).1, arrayCumSum(%s.2)", alias2, alias2);
+
+			return;
+		}
+		else
+			elog(ERROR, "accumulate for this kind of istore not implemented");
+
+		if (!context->func)
+			appendStringInfoChar(buf, ')');
+	}
+	appendStringInfoChar(buf, '(');
+	if (cdef && cdef->cf_type == CF_AJTIME_DAY_DIFF)
+	{
+		appendStringInfoString(buf, "(cast(");
+		deparseExpr((Expr *) list_nth(node->args, 1), context);
+		appendStringInfoString(buf, ", 'DateTime') - ");
+		deparseExpr((Expr *) linitial(node->args), context);
+		appendStringInfoString(buf, ") / 86400)");
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_TIMEZONE)
+	{
+		deparseExpr((Expr *) list_nth(node->args, 1), context);
+		appendStringInfoString(buf, ", ");
+		deparseExpr((Expr *) linitial(node->args), context);
+		appendStringInfoChar(buf, ')');
+		return;
+	}
+
+	old_cdef = context->func;
+
+	/* sup_up requires only values part of array */
+	if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
+	{
+		/* sum_up(daily_time_spent_cohort, 12)
+			=>
+			arraySum(arrayFilter((v, k) -> k <= 12,
+			daily_time_spent_cohort_values,
+			daily_time_spent_cohort_keys))
+
+			sum_up(daily_time_spent_cohort)
+			=>
+			arraySum(daily_time_spent_cohort_values)
+
+			!!!! or in case of AggregateFunction:
+			sum_up(daily_time_spent_cohort, 12)
+			=>
+			arraySum(arrayFilter((v, k) -> k <= 12,
+			(finalizeAggregation(daily_time_spent_cohort) as _tmp).2,
+			_tmp.1))
+
+			sum_up(daily_time_spent_cohort)
+			=>
+			arraySum(finalizeAggregation(daily_time_spent_cohort).2)
+		*/
+		funcdef = *cdef;
+		funcdef.cf_context = node->args;
+		context->func = &funcdef;
+
+		if (list_length(node->args) == 2)
+		{
+			appendStringInfoString(buf, "arrayFilter((v, k) -> k <= ");
+			appendStringInfoChar(buf, '(');
+			deparseExpr((Expr *) list_nth(node->args, 1), context);
+			appendStringInfoChar(buf, ')');
+			appendStringInfoChar(buf, ',');
+			deparseExpr((Expr *) linitial(node->args), context);
+			appendStringInfoChar(buf, ')');
+		}
+		else
+			deparseExpr((Expr *) linitial(node->args), context);
+
+		goto end;
+	}
+
+	/* ... and all the arguments */
+	first = true;
+	foreach (arg, node->args)
+	{
+		if (!first)
+			appendStringInfoString(buf, ", ");
+
+		deparseExpr((Expr *) lfirst(arg), context);
+		first = false;
+	}
+
+end:
+	context->func = old_cdef;
+	appendStringInfoChar(buf, ')');
+}
+
+static void
+deparseIntervalOp(Node *first, Node *second, deparse_expr_cxt *context, bool plus)
+{
+	StringInfo	buf = context->buf;
+	Const	   *constval;
+	Interval   *span;
+	char		ibuf[MAXINT8LEN + 1];
+
+	if (!IsA(second, Const))
+	{
+		bool old_op = context->interval_op;
+		/* first argument */
+		deparseExpr((Expr *) first, context);
+
+		if (plus)
+			appendStringInfoString(buf, " + ");
+		else
+			appendStringInfoString(buf, " - ");
+
+		appendStringInfoString(buf, "INTERVAL ");
+
+		/* second */
+		context->interval_op = true;
+		deparseExpr((Expr *) second, context);
+		context->interval_op = old_op;
+		return;
+	}
+
+	constval = (Const *) second;
+	span = DatumGetIntervalP(constval->constvalue);
+
+	/* top function is always addSeconds */
+	appendStringInfoString(buf, "addSeconds(");
+
+	if (span->day)
+		appendStringInfoString(buf, "addDays(");
+
+	if (span->month)
+		appendStringInfoString(buf, "addMonths(");
+
+	/* first argument here */
+	deparseExpr((Expr *) first, context);
+
+	if (span->month)
+	{
+		/* addMonths arg */
+		appendStringInfoChar(buf, ',');
+		snprintf(ibuf, sizeof(ibuf), "%d", span->month);
+		if (!plus)
+		{
+			appendStringInfoString(buf, "-(");
+			appendStringInfoString(buf, ibuf);
+			appendStringInfoChar(buf, ')');
+		}
+		else
+			appendStringInfoString(buf, ibuf);
+		appendStringInfoChar(buf, ')');
+	}
+
+	if (span->day)
+	{
+		/* addDays arg */
+		appendStringInfoChar(buf, ',');
+		snprintf(ibuf, sizeof(ibuf), "%d", span->day);
+		if (!plus)
+		{
+			appendStringInfoString(buf, "-(");
+			appendStringInfoString(buf, ibuf);
+			appendStringInfoChar(buf, ')');
+		}
+		else
+			appendStringInfoString(buf, ibuf);
+		appendStringInfoChar(buf, ')');
+	}
+
+	/* addSeconds arg */
+	appendStringInfoChar(buf, ',');
+	pg_lltoa((int64)(span->time / 1000000), ibuf);
+	if (!plus)
+	{
+		appendStringInfoString(buf, "-(");
+		appendStringInfoString(buf, ibuf);
+		appendStringInfoChar(buf, ')');
+	}
+	else
+		appendStringInfoString(buf, ibuf);
+	appendStringInfoChar(buf, ')');
+}
+
+static Oid
+findFunction(Oid typoid, char *name)
+{
+	int			i;
+	Oid			result = InvalidOid;
+	HeapTuple	proctup;
+	Form_pg_proc procform;
+	CatCList   *catlist;
+	catlist = SearchSysCacheList1(PROCNAMEARGSNSP,
+			CStringGetDatum(name));
+
+	if (catlist->n_members == 0)
+		elog(ERROR, "clickhouse_fdw requires istore extension to parse istore values");
+
+	for (i = 0; i < catlist->n_members; i++)
+	{
+		proctup = &catlist->members[i]->tuple;
+		procform = (Form_pg_proc) GETSTRUCT(proctup);
+		if (procform->proargtypes.values[0] == typoid)
+#if PG_VERSION_NUM < 120000
+			result = HeapTupleGetOid(proctup);
+#else
+			result = procform->oid;
+#endif
+	}
+
+	ReleaseSysCacheList(catlist);
+
+	return result;
+}
+
+/*
+ * Deparse given operator expression.   To avoid problems around
+ * priority of operations, we always parenthesize the arguments.
+ */
+static void
+deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	HeapTuple	tuple;
+	Form_pg_operator form;
+	char		oprkind;
+	ListCell   *arg;
+	CustomObjectDef	*cdef;
+
+	/* Retrieve information about the operator from system catalog. */
+	tuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(node->opno));
+	if (!HeapTupleIsValid(tuple))
+		elog(ERROR, "cache lookup failed for operator %u", node->opno);
+
+	form = (Form_pg_operator) GETSTRUCT(tuple);
+	oprkind = form->oprkind;
+
+	/* Sanity check. */
+	Assert((oprkind == 'r' && list_length(node->args) == 1) ||
+		   (oprkind == 'l' && list_length(node->args) == 1) ||
+		   (oprkind == 'b' && list_length(node->args) == 2));
+
+	cdef = chfdw_check_for_custom_operator(node->opno, form);
+	if (cdef)
+	{
+		switch (cdef->cf_type)
+		{
+			case CF_AJTIME_OPERATOR:
+			{
+				/* intervals with ajtime */
+				CustomObjectDef	*fdef = chfdw_check_for_custom_function(form->oprcode);
+				if (fdef && fdef->cf_type == CF_AJTIME_PL_INTERVAL)
+				{
+					deparseIntervalOp(linitial(node->args),
+						list_nth(node->args, 1), context, true);
+					goto cleanup;
+				}
+				else if (fdef && fdef->cf_type == CF_AJTIME_MI_INTERVAL)
+				{
+					deparseIntervalOp(linitial(node->args),
+						list_nth(node->args, 1), context, false);
+					goto cleanup;
+				}
+			}
+			break;
+			case CF_TIMESTAMPTZ_PL_INTERVAL:
+			{
+				deparseIntervalOp(linitial(node->args),
+					list_nth(node->args, 1), context, true);
+				goto cleanup;
+			}
+			break;
+			case CF_HSTORE_FETCHVAL:
+			{
+				Expr *arg1 = linitial(node->args);
+				Expr *arg2 = list_nth(node->args, 1);
+
+				if (IsA(arg1, Const))
+				{
+					Const	   *constval = (Const *) arg1;
+					Oid			akeys = findFunction(constval->consttype, "akeys");
+					Oid			avalues = findFunction(constval->consttype, "avals");
+
+					/* vals[nullif(indexOf(keys,toString(arg1)), 0)] */
+					appendStringInfoChar(buf, '(');
+					deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
+					appendStringInfoString(buf, "[nullif(indexOf(");
+					deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
+					appendStringInfoChar(buf, ',');
+					deparseExpr(arg2, context);
+					appendStringInfoString(buf, "), 0)])");
+				}
+				else
+					elog(ERROR, "clickhouse_fdw supports hstore fetchval "
+							"only for scalars");
+
+				goto cleanup;
+			}
+			break;
+			case CF_ISTORE_FETCHVAL:
+			{
+				Node *arg = linitial(node->args);
+
+				if (IsA(arg, Var))
+				{
+					CustomObjectDef	*temp;
+
+					temp = context->func;
+					context->func = cdef;
+
+					/* values[nullif(indexOf(ids, ...  in deparseColumnRef */
+					deparseExpr((Expr *) arg, context);
+					deparseExpr((Expr *) list_nth(node->args, 1), context);
+					/* ... 0)] */
+					appendStringInfoString(buf, "), 0)]");
+
+					context->func = temp;
+				}
+				else if (IsA(arg, Const))
+				{
+					Const	   *constval = (Const *) arg;
+					Oid			akeys = findFunction(constval->consttype, "akeys");
+					Oid			avalues = findFunction(constval->consttype, "avals");
+
+					/* ([val1, val2][nullif(indexOf([key1, key2], arg), 0]) */
+					appendStringInfoChar(buf, '(');
+					deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
+					appendStringInfoString(buf, "[nullif(indexOf(");
+					deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr((Expr *) list_nth(node->args, 1), context);
+					appendStringInfoString(buf, "), 0)])");
+				}
+				else
+					elog(ERROR, "clickhouse_fdw supports fetchval only for columns and consts");
+
+				goto cleanup;
+			}
+			break;
+			default: /* keep compiler quiet */ ;
+		}
+	}
+
+	if ((node->opresulttype == INT2OID ||
+		 node->opresulttype == INT4OID ||
+		 node->opresulttype == INT8OID) &&
+			strcmp(NameStr(form->oprname), "/") == 0)
+	{
+		char *s = ch_format_type_extended(node->opresulttype, 0, 0);
+		appendStringInfo(buf, "to%s", s);
+	}
+
+	/* Always parenthesize the expression. */
+	appendStringInfoChar(buf, '(');
+
+	/* Deparse left operand. */
+	if (oprkind == 'r' || oprkind == 'b')
+	{
+		arg = list_head(node->args);
+
+		/*
+		 * Check for TestCaseExpr, in statements like CASE expr WHEN <val>.
+		 * Basically they would look like, OpExpr->(TestCaseExpr, Const).
+		 * We should just skip first arg and deparse second.
+		 */
+		if (IsA(lfirst(arg), CaseTestExpr))
+		{
+			arg = list_tail(node->args);
+			deparseExpr(lfirst(arg), context);
+			appendStringInfoChar(buf, ')');
+			goto cleanup;
+		}
+
+		deparseExpr(lfirst(arg), context);
+		appendStringInfoChar(buf, ' ');
+	}
+
+	/*
+	 * Here we add support of special case like (<expr> || ' days')::interval.
+	 * We convert it to (<expr>) day. INTERVAL keyword added earlier
+	 */
+	if (context->interval_op && strcmp(NameStr(form->oprname), "||") == 0)
+	{
+		Const *right = lfirst(list_tail(node->args));
+		if (IsA(right, Const) && right->consttype == TEXTOID)
+		{
+			char *s = TextDatumGetCString(right->constvalue);
+			if (strstr(s, "day") != NULL)
+				appendStringInfoString(buf, ") day");
+			else if (strstr(s, "year") != NULL)
+				appendStringInfoString(buf, ") year");
+			else if (strstr(s, "month") != NULL)
+				appendStringInfoString(buf, ") month");
+			else
+				elog(ERROR, "unsupported type of interval");
+			pfree(s);
+
+			goto cleanup;
+		}
+	}
+
+	/* Deparse operator name. */
+	deparseOperatorName(buf, form);
+
+	/* Deparse right operand. */
+	if (oprkind == 'l' || oprkind == 'b')
+	{
+		arg = list_tail(node->args);
+		appendStringInfoChar(buf, ' ');
+		deparseExpr(lfirst(arg), context);
+	}
+
+	appendStringInfoChar(buf, ')');
+
+cleanup:
+	ReleaseSysCache(tuple);
+}
+
+/*
+ * Print the name of an operator.
+ */
+static void
+deparseOperatorName(StringInfo buf, Form_pg_operator opform)
+{
+	char	   *opname;
+
+	opname = NameStr(opform->oprname);
+
+	if (strcmp(opname, "~~") == 0)
+		appendStringInfoString(buf, "LIKE");
+	else if (strcmp(opname, "~~*") == 0)
+		appendStringInfoString(buf, "LIKE");
+	else if (strcmp(opname, "!~~") == 0)
+		appendStringInfoString(buf, "NOT LIKE");
+	else if (strcmp(opname, "!~~*") == 0)
+		appendStringInfoString(buf, "NOT LIKE");
+	else
+		appendStringInfoString(buf, opname);
+}
+
+/*
+ * Deparse IS DISTINCT FROM.
+ */
+static void
+deparseDistinctExpr(DistinctExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+
+	Assert(list_length(node->args) == 2);
+
+	appendStringInfoChar(buf, '(');
+	deparseExpr(linitial(node->args), context);
+	appendStringInfoString(buf, " IS DISTINCT FROM ");
+	deparseExpr(lsecond(node->args), context);
+	appendStringInfoChar(buf, ')');
+}
+
+static void
+deparseNullIfExpr(NullIfExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+
+	Assert(list_length(node->args) == 2);
+
+	appendStringInfoString(buf, "NULLIF(");
+	deparseExpr(linitial(node->args), context);
+	appendStringInfoChar(buf, ',');
+	deparseExpr(lsecond(node->args), context);
+	appendStringInfoChar(buf, ')');
+}
+
+static void deparseAsIn(ScalarArrayOpExpr *node, deparse_expr_cxt *context, int optype)
+{
+	StringInfo	buf = context->buf;
+	Expr *arg1 = linitial(node->args);
+	Expr *arg2 = lsecond(node->args);
+
+	deparseExpr(arg1, context);
+	if (optype == 1)
+		appendStringInfoString(buf, " IN ");
+	else
+		appendStringInfoString(buf, " NOT IN ");
+
+	Assert(IsA(arg2, Const));
+	context->array_as_tuple = true;
+	deparseExpr(arg2, context);
+	context->array_as_tuple = false;
+}
+
+/*
+ * Deparse given ScalarArrayOpExpr expression.  To avoid problems
+ * around priority of operations, we always parenthesize the arguments.
+ */
+static void
+deparseScalarArrayOpExpr(ScalarArrayOpExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	Expr	   *arg1;
+	Expr	   *arg2;
+
+	/* Retrieve information about the operator from system catalog. */
+	int			optype = chfdw_is_equal_op(node->opno);
+
+	if (optype == 0)
+		elog(ERROR, "clickhouse_fdw supports only equal (not equal) operations on ANY/ALL functions");
+
+	/* Sanity check. */
+	Assert(list_length(node->args) == 2);
+
+	appendStringInfoChar(buf, '(');
+	if (node->useOr)
+	{
+		arg2 = lsecond(node->args);
+
+		/* very narrow case for = ANY(ARRAY) */
+		if (optype == 1 && IsA(arg2, Const))
+			deparseAsIn(node, context, optype);
+		else
+		{
+			if (optype == 1)
+				appendStringInfoString(buf, "has(");
+			else
+				appendStringInfoString(buf, "not has(");
+
+			/* Deparse right operand. */
+			deparseExpr(arg2, context);
+			appendStringInfoChar(buf, ',');
+
+			/* Deparse left operand. */
+			arg1 = linitial(node->args);
+			deparseExpr(arg1, context);
+
+			/* Close function call */
+			appendStringInfoChar(buf, ')');
+		}
+	}
+	else
+	{
+		arg2 = lsecond(node->args);
+
+		/* very narrow case for <> ALL(ARRAY) */
+		if (optype == 2 && IsA(arg2, Const))
+			deparseAsIn(node, context, optype);
+		else
+		{
+			appendStringInfoString(buf, "countEqual(");
+
+			/* Deparse right operand. */
+			arg2 = lsecond(node->args);
+			deparseExpr(arg2, context);
+			appendStringInfoChar(buf, ',');
+
+			/* Deparse left operand. */
+			arg1 = linitial(node->args);
+			deparseExpr(arg1, context);
+
+			/* Close function call */
+			if (optype == 1)
+			{
+				appendStringInfoString(buf, ") = length(");
+
+				/* Deparse right operand again */
+				deparseExpr(arg2, context);
+				appendStringInfoChar(buf, ')');
+			} else {
+				appendStringInfoString(buf, ") = 0");
+			}
+		}
+	}
+
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * Deparse a RelabelType (binary-compatible cast) node.
+ */
+static void
+deparseRelabelType(RelabelType *node, deparse_expr_cxt *context)
+{
+	deparseExpr(node->arg, context);
+}
+
+/*
+ * Deparse a BoolExpr node.
+ */
+static void
+deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	const char *op = NULL;		/* keep compiler quiet */
+	bool		first;
+	ListCell   *lc;
+
+	switch (node->boolop)
+	{
+	case AND_EXPR:
+		op = "AND";
+		break;
+	case OR_EXPR:
+		op = "OR";
+		break;
+	case NOT_EXPR:
+		appendStringInfoString(buf, "(NOT ");
+		deparseExpr(linitial(node->args), context);
+		appendStringInfoChar(buf, ')');
+		return;
+	}
+
+	appendStringInfoChar(buf, '(');
+	first = true;
+	foreach (lc, node->args)
+	{
+		if (!first)
+		{
+			appendStringInfo(buf, " %s ", op);
+		}
+		deparseExpr((Expr *) lfirst(lc), context);
+		first = false;
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * Deparse IS [NOT] NULL expression.
+ */
+static void
+deparseNullTest(NullTest *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+
+	appendStringInfoChar(buf, '(');
+	deparseExpr(node->arg, context);
+
+	/*
+	 * For scalar inputs, we prefer to print as IS [NOT] NULL, which is
+	 * shorter and traditional.  If it's a rowtype input but we're applying a
+	 * scalar test, must print IS [NOT] DISTINCT FROM NULL to be semantically
+	 * correct.
+	 */
+	if (node->argisrow || !type_is_rowtype(exprType((Node *) node->arg)))
+	{
+		if (node->nulltesttype == IS_NULL)
+			appendStringInfoString(buf, " IS NULL)");
+		else
+			appendStringInfoString(buf, " IS NOT NULL)");
+	}
+	else
+	{
+		if (node->nulltesttype == IS_NULL)
+			appendStringInfoString(buf, " IS NOT DISTINCT FROM NULL)");
+		else
+			appendStringInfoString(buf, " IS DISTINCT FROM NULL)");
+	}
+}
+
+/*
+ * Deparse ARRAY[...] construct.
+ */
+static void
+deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	bool		first = true;
+	ListCell   *lc;
+
+	if (node->elements == NIL)
+		appendStringInfoString(buf, "CAST(");
+
+	appendStringInfoString(buf, "[");
+	foreach(lc, node->elements)
+	{
+		if (!first)
+			appendStringInfoString(buf, ", ");
+		deparseExpr(lfirst(lc), context);
+		first = false;
+	}
+	appendStringInfoChar(buf, ']');
+
+	/* If the array is empty, we need an explicit cast to the array type. */
+	if (node->elements == NIL)
+		appendStringInfo(buf, ", '%s')",
+			deparse_type_name(node->array_typeid, -1));
+}
+
+/*
+ * Deparse an Aggref node.
+ */
+static void
+deparseAggref(Aggref *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	CustomObjectDef	*cdef;
+	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
+	bool	aggfilter = false;
+	bool	sign_count_filter = false;
+	uint8	brcount = 1;
+
+	/* Only basic, non-split aggregation accepted. */
+	Assert(node->aggsplit == AGGSPLIT_SIMPLE);
+
+	/* Find aggregate name from aggfnoid which is a pg_proc entry */
+	cdef = context->func;
+	context->func = appendFunctionName(node->aggfnoid, context);
+
+	/* 'If' part */
+	if (context->func && context->func->cf_type == CF_SIGN_COUNT && !node->aggstar)
+		sign_count_filter = true;
+
+	/* We use this field as indicator of aggregate functions */
+	if (node->location == -2)
+		appendStringInfoString(buf, "Merge");
+
+	if (node->aggfilter || sign_count_filter)
+	{
+		aggfilter = true;
+		appendStringInfoString(buf, "If");
+	}
+
+	appendStringInfoChar(buf, '(');
+
+	/* Add DISTINCT */
+	appendStringInfoString(buf, (node->aggdistinct != NIL) ? "DISTINCT " : "");
+
+	/* aggstar can be set only in zero-argument aggregates */
+	if (node->aggstar)
+	{
+		if (context->func && context->func->cf_type == CF_SIGN_COUNT)
+		{
+			Assert(fpinfo && fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE);
+			appendStringInfoString(buf, fpinfo->ch_table_sign_field);
+		}
+		else
+			appendStringInfoChar(buf, '*');
+	}
+	else
+	{
+		ListCell   *arg;
+		bool		first = true;
+		bool		signMultiply = (context->func &&
+						(context->func->cf_type == CF_SIGN_AVG ||
+						 context->func->cf_type == CF_SIGN_SUM));
+
+		/* Add all the arguments */
+		if (sign_count_filter)
+			/* in case if COUNT(col) we should get countIf(sign, col is not null) */
+			appendStringInfoString(buf, fpinfo->ch_table_sign_field);
+		else
+		{
+			/* default columns output */
+			foreach (arg, node->args)
+			{
+				TargetEntry *tle = (TargetEntry *) lfirst(arg);
+				Node	   *n = (Node *) tle->expr;
+
+				if (tle->resjunk)
+					continue;
+
+				if (!first)
+					appendStringInfoString(buf, ", ");
+
+				first = false;
+
+				deparseExpr((Expr *) n, context);
+			}
+
+			if (signMultiply)
+			{
+				Assert(fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE);
+				appendStringInfoString(buf, " * ");
+				appendStringInfoString(buf, fpinfo->ch_table_sign_field);
+			}
+		}
+	}
+
+	/* Add 'If' part condition */
+	if (aggfilter)
+	{
+		appendStringInfoChar(buf, ',');
+
+		if (node->aggfilter)
+		{
+			appendStringInfoString(buf, "((");
+			deparseExpr((Expr *) node->aggfilter, context);
+			appendStringInfoString(buf, ") > 0)");
+		}
+
+		if (sign_count_filter)
+		{
+			if (node->aggfilter)
+				appendStringInfoString(buf, " AND ");
+
+			appendStringInfoChar(buf, '(');
+			deparseExpr((Expr *) ((TargetEntry *) linitial(node->args))->expr, context);
+			appendStringInfoString(buf, ") IS NOT NULL");
+		}
+	}
+
+	while (brcount--)
+		appendStringInfoChar(buf, ')');
+
+	/* AVG stuff */
+	if (context->func && context->func->cf_type == CF_SIGN_AVG)
+	{
+		appendStringInfoString(buf, " / sumIf(");
+		appendStringInfoString(buf, fpinfo->ch_table_sign_field);
+		appendStringInfoChar(buf, ',');
+		if (node->aggfilter)
+		{
+			deparseExpr((Expr *) node->aggfilter, context);
+			appendStringInfoString(buf, " AND ");
+		}
+		deparseExpr((Expr *) ((TargetEntry *) linitial(node->args))->expr, context);
+		appendStringInfoString(buf, " IS NOT NULL");
+		appendStringInfoChar(buf, ')');
+	}
+
+	/* original */
+	context->func = cdef;
+}
+
+static void
+deparseCaseExpr(CaseExpr *node, deparse_expr_cxt *context)
+{
+#define DEPARSE_WRAPPED(node) \
+do { \
+	bool isnull = (IsA(node, Const) && ((Const *) (node))->constisnull); \
+	if (conv && !isnull) \
+		appendStringInfoString(buf, conv); \
+	deparseExpr(node, context); \
+	if (conv && !isnull) \
+		appendStringInfoChar(buf, ')'); \
+} while (0)
+
+	StringInfo	buf = context->buf;
+	ListCell   *lc;
+	char	   *conv = NULL;
+
+	if (node->casetype == INT2OID ||
+		node->casetype == INT4OID ||
+		node->casetype == INT8OID)
+	{
+		conv = ch_format_type_extended(node->casetype, 0, 0);
+		conv = psprintf("to%s(", conv);
+	}
+
+	appendStringInfoString(buf, "CASE");
+	if (node->arg)
+	{
+		appendStringInfoChar(buf, ' ');
+		deparseExpr(node->arg, context);
+	}
+
+	foreach(lc, node->args)
+	{
+		CaseWhen	*arg = lfirst(lc);
+
+		Assert(IsA(arg, CaseWhen));
+		appendStringInfoString(buf, " WHEN ");
+		deparseExpr(arg->expr, context);
+
+		/* in simple cases like WHEN val THEN we should extend the condition
+		 * for WHEN val = 1 since there is no bool type in ClickHouse */
+		if (IsA(arg->expr, Var))
+			appendStringInfoString(buf, " = 1");
+
+		appendStringInfoString(buf, " THEN ");
+		DEPARSE_WRAPPED(arg->result);
+	}
+
+	if (node->defresult)
+	{
+		appendStringInfoString(buf, " ELSE ");
+		DEPARSE_WRAPPED(node->defresult);
+	}
+
+	if (conv)
+		pfree(conv);
+	appendStringInfoString(buf, " END");
+}
+
+static void
+deparseCaseWhen(CaseWhen *node, deparse_expr_cxt *context)
+{
+	// XXX Needs implementation.
+	// StringInfo	buf = context->buf;
+	// ListCell   *lc;
+}
+
+static void
+deparseRowExpr(RowExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	ListCell   *lc;
+
+	bool		first = true;
+
+	appendStringInfoChar(buf, '(');
+	foreach(lc, node->args)
+	{
+		if (!first)
+			appendStringInfoChar(buf, ',');
+
+		first = false;
+		if (IsA(lfirst(lc), Const))
+			deparseConst((Const *) lfirst(lc), context, 1);
+		else
+			deparseExpr(lfirst(lc), context);
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+static void
+deparseCoerceViaIO(CoerceViaIO *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+
+	if (node->resulttype == INTERVALOID)
+		deparseExpr(node->arg, context);
+	else
+	{
+		appendStringInfoString(buf, "CAST(");
+		deparseExpr(node->arg, context);
+		appendStringInfoString(buf, " AS ");
+
+		if (node->resultcollid == 1)
+			appendStringInfoString(buf, "Nullable(");
+
+		appendStringInfoString(buf, deparse_type_name(node->resulttype, 0));
+
+		if (node->resultcollid == 1)
+			appendStringInfoChar(buf, ')');
+
+		appendStringInfoChar(buf, ')');
+	}
+}
+
+static void
+deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	ListCell   *lc;
+	bool		first;
+
+	appendStringInfoString(buf, "COALESCE(");
+
+	first = true;
+	foreach (lc, node->args)
+	{
+		Expr *arg = lfirst(lc);
+
+		if (!first)
+			appendStringInfoString(buf, ", ");
+
+		/* first arg should be nullable */
+		if (IsA(arg, CoerceViaIO))
+		{
+			CoerceViaIO *vio = (CoerceViaIO *) arg;
+
+			if (arg != llast(node->args))
+				vio->resultcollid = 1;
+			else
+				vio->resultcollid = InvalidOid;
+		}
+
+		first = false;
+		deparseExpr(arg, context);
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+static void
+deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	ListCell   *lc;
+	bool		first;
+
+	if (node->op == IS_GREATEST)
+		appendStringInfoString(buf, "greatest");
+	else
+		appendStringInfoString(buf, "least");
+
+	appendStringInfoChar(buf, '(');
+	first = true;
+	foreach (lc, node->args)
+	{
+		if (!first)
+			appendStringInfoString(buf, ", ");
+
+		first = false;
+
+		deparseExpr(lfirst(lc), context);
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * Deparse GROUP BY clause.
+ */
+static void
+appendGroupByClause(List *tlist, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	Query	   *query = context->root->parse;
+	ListCell   *lc;
+	bool		first = true;
+
+	/* Nothing to be done, if there's no GROUP BY clause in the query. */
+	if (!query->groupClause)
+		return;
+
+	appendStringInfoString(buf, " GROUP BY ");
+
+	/*
+	 * Queries with grouping sets are not pushed down, so we don't expect
+	 * grouping sets here.
+	 */
+	Assert(!query->groupingSets);
+
+	foreach (lc, query->groupClause)
+	{
+		SortGroupClause *grp = (SortGroupClause *) lfirst(lc);
+
+		if (!first)
+			appendStringInfoString(buf, ", ");
+
+		first = false;
+
+		deparseSortGroupClause(grp->tleSortGroupRef, tlist, true, context);
+	}
+}
+
+/*
+ * Deparse ORDER BY clause according to the given pathkeys for given base
+ * relation. From given pathkeys expressions belonging entirely to the given
+ * base relation are obtained and deparsed.
+ */
+static void
+appendOrderByClause(List *pathkeys, bool has_final_sort,
+					deparse_expr_cxt *context)
+{
+	ListCell   *lcell;
+	char	   *delim = " ";
+	RelOptInfo *baserel = context->scanrel;
+	StringInfo	buf = context->buf;
+
+	appendStringInfoString(buf, " ORDER BY");
+	foreach(lcell, pathkeys)
+	{
+		PathKey    *pathkey = lfirst(lcell);
+		Expr	   *em_expr;
+
+		if (has_final_sort)
+		{
+			/*
+			 * By construction, context->foreignrel is the input relation to
+			 * the final sort.
+			 */
+			em_expr = chfdw_find_em_expr_for_input_target(context->root,
+													pathkey->pk_eclass,
+													context->foreignrel->reltarget);
+		}
+		else
+			em_expr = chfdw_find_em_expr_for_rel(pathkey->pk_eclass, baserel);
+
+		Assert(em_expr != NULL);
+
+		appendStringInfoString(buf, delim);
+		deparseExpr(em_expr, context);
+		if (pathkey->pk_strategy == BTLessStrategyNumber)
+			appendStringInfoString(buf, " ASC");
+		else
+			appendStringInfoString(buf, " DESC");
+
+		if (pathkey->pk_nulls_first)
+			appendStringInfoString(buf, " NULLS FIRST");
+		//else
+		//	appendStringInfoString(buf, " NULLS LAST");
+
+		delim = ", ";
+	}
+}
+
+/*
+ * Deparse LIMIT/OFFSET clause.
+ */
+static void
+appendLimitClause(deparse_expr_cxt *context)
+{
+	PlannerInfo *root = context->root;
+	StringInfo	buf = context->buf;
+
+	if (root->parse->limitCount)
+	{
+		appendStringInfoString(buf, " LIMIT ");
+		deparseExpr((Expr *) root->parse->limitCount, context);
+	}
+	if (root->parse->limitOffset)
+	{
+		appendStringInfoString(buf, " OFFSET ");
+		deparseExpr((Expr *) root->parse->limitOffset, context);
+	}
+}
+
+/*
+ * appendFunctionName
+ *		Deparses function name from given function oid.
+ *		Returns was custom or not.
+ */
+static CustomObjectDef *
+appendFunctionName(Oid funcid, deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	HeapTuple	proctup;
+	Form_pg_proc procform;
+	const char *proname;
+	CustomObjectDef	*cdef;
+	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
+
+	cdef = chfdw_check_for_custom_function(funcid);
+	if (cdef && cdef->custom_name[0] != '\0')
+	{
+		if (cdef->custom_name[0] != '\1')
+			appendStringInfoString(buf, cdef->custom_name);
+		return cdef;
+	}
+
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcid));
+	if (!HeapTupleIsValid(proctup))
+		elog(ERROR, "cache lookup failed for function %u", funcid);
+
+	procform = (Form_pg_proc) GETSTRUCT(proctup);
+	proname = NameStr(procform->proname);
+
+	/* we have some additional conditions on aggregation functions */
+	if (chfdw_is_builtin(funcid) && procform->prokind == PROKIND_AGGREGATE
+			&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
+	{
+		cdef = palloc(sizeof(CustomObjectDef));
+		cdef->cf_oid = funcid;
+
+		if (strcmp(proname, "sum") == 0)
+			cdef->cf_type = CF_SIGN_SUM;
+		else if (strcmp(proname, "avg") == 0)
+		{
+			cdef->cf_type = CF_SIGN_AVG;;
+			proname = "sum";
+		}
+		else if (strcmp(proname, "count") == 0)
+		{
+			cdef->cf_type = CF_SIGN_COUNT;
+			proname = "sum";
+		}
+		else
+		{
+			pfree(cdef);
+			cdef = NULL;
+		}
+	}
+
+	/* Always print the function name */
+	appendStringInfoString(buf, proname);
+
+	ReleaseSysCache(proctup);
+
+	return cdef;
+}
+
+/*
+ * Appends a sort or group clause.
+ *
+ * Like get_rule_sortgroupclause(), returns the expression tree, so caller
+ * need not find it again.
+ */
+static Node *
+deparseSortGroupClause(Index ref, List *tlist, bool force_colno,
+                       deparse_expr_cxt *context)
+{
+	StringInfo	buf = context->buf;
+	TargetEntry *tle;
+	Expr	   *expr;
+
+	tle = get_sortgroupref_tle(ref, tlist);
+	expr = tle->expr;
+
+	if (expr && IsA(expr, Const))
+	{
+		/*
+		 * Force a typecast here so that we don't emit something like "GROUP
+		 * BY 2", which will be misconstrued as a column position rather than
+		 * a constant.
+		 */
+		deparseConst((Const *) expr, context, 1);
+	}
+	else if (!expr || IsA(expr, Var))
+	{
+		deparseExpr(expr, context);
+	}
+	else
+	{
+		/* Always parenthesize the expression. */
+		appendStringInfoChar(buf, '(');
+		deparseExpr(expr, context);
+		appendStringInfoChar(buf, ')');
+	}
+
+	return (Node *) expr;
+}
+
+
+/*
+ * Returns true if given Var is deparsed as a subquery output column, in
+ * which case, *relno and *colno are set to the IDs for the relation and
+ * column alias to the Var provided by the subquery.
+ */
+static bool
+is_subquery_var(Var *node, RelOptInfo *foreignrel, int *relno, int *colno)
+{
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+	RelOptInfo *outerrel = fpinfo->outerrel;
+	RelOptInfo *innerrel = fpinfo->innerrel;
+
+	/* Should only be called in these cases. */
+	Assert(IS_SIMPLE_REL(foreignrel) || IS_JOIN_REL(foreignrel));
+
+	/*
+	 * If the given relation isn't a join relation, it doesn't have any lower
+	 * subqueries, so the Var isn't a subquery output column.
+	 */
+	if (!IS_JOIN_REL(foreignrel))
+		return false;
+
+	/*
+	 * If the Var doesn't belong to any lower subqueries, it isn't a subquery
+	 * output column.
+	 */
+	if (!bms_is_member(node->varno, fpinfo->lower_subquery_rels))
+		return false;
+
+	if (bms_is_member(node->varno, outerrel->relids))
+	{
+		/*
+		 * If outer relation is deparsed as a subquery, the Var is an output
+		 * column of the subquery; get the IDs for the relation/column alias.
+		 */
+		if (fpinfo->make_outerrel_subquery)
+		{
+			get_relation_column_alias_ids(node, outerrel, relno, colno);
+			return true;
+		}
+
+		/* Otherwise, recurse into the outer relation. */
+		return is_subquery_var(node, outerrel, relno, colno);
+	}
+	else
+	{
+		Assert(bms_is_member(node->varno, innerrel->relids));
+
+		/*
+		 * If inner relation is deparsed as a subquery, the Var is an output
+		 * column of the subquery; get the IDs for the relation/column alias.
+		 */
+		if (fpinfo->make_innerrel_subquery)
+		{
+			get_relation_column_alias_ids(node, innerrel, relno, colno);
+			return true;
+		}
+
+		/* Otherwise, recurse into the inner relation. */
+		return is_subquery_var(node, innerrel, relno, colno);
+	}
+}
+
+/*
+ * Get the IDs for the relation and column alias to given Var belonging to
+ * given relation, which are returned into *relno and *colno.
+ */
+static void
+get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel,
+                              int *relno, int *colno)
+{
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+	int			i;
+	ListCell   *lc;
+
+	/* Get the relation alias ID */
+	*relno = fpinfo->relation_index;
+
+	/* Get the column alias ID */
+	i = 1;
+	foreach (lc, foreignrel->reltarget->exprs)
+	{
+		if (equal(lfirst(lc), (Node *) node))
+		{
+			*colno = i;
+			return;
+		}
+		i++;
+	}
+
+	/* Shouldn't get here */
+	elog(ERROR, "unexpected expression in subquery output");
+}

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -1,44 +1,2837 @@
 /*
-	A PostgreSQL function for getting the an environment variable value.
+	A PostgreSQL extension for connecting to ClickHouse servers.
 */
 
+// PostgreSQL includes.
 #include "postgres.h"
-#include <stdlib.h>
+#include "catalog/pg_class_d.h"
+#include "commands/explain.h"
+#include "foreign/fdwapi.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "optimizer/cost.h"
+#include "optimizer/pathnode.h"
+#include "optimizer/paths.h"
+#include "optimizer/planmain.h"
+#include "optimizer/restrictinfo.h"
+#include "optimizer/tlist.h"
+#include "parser/parsetree.h"
 #include "utils/builtins.h"
-#include "include/binary.hh"
-#include "include/internal.h"
-#include "include/fdw.h"
+#include "utils/lsyscache.h"
+#include "utils/palloc.h"
+#include "utils/rel.h"
 #if PG_VERSION_NUM >= 160000
 #include "varatt.h"
 #endif
+#if PG_VERSION_NUM >= 140000
+#include "optimizer/appendinfo.h"
+#endif
 
+// extension includes.
+#include "utils/builtins.h"
+#include "binary.hh"
+#include "internal.h"
+#include "fdw.h"
+
+// Extension metadata for the server.
 #ifdef PG_MODULE_MAGIC_EXT
 PG_MODULE_MAGIC_EXT(.name = "clickhouse_fdw", .version = "__VERSION__");
 #else
 PG_MODULE_MAGIC;
 #endif
 
-ch_connection
-chfdw_binary_connect(ch_connection_details *details)
+/* Default CPU cost to start up a foreign query. */
+#define DEFAULT_FDW_STARTUP_COST	100.0
+
+/* Default CPU cost to process 1 row (above and beyond cpu_tuple_cost). */
+#define DEFAULT_FDW_TUPLE_COST		0.01
+
+/* If no remote estimates, assume a sort costs 20% extra */
+#define DEFAULT_FDW_SORT_MULTIPLIER 1.2
+
+/*
+ * Indexes of FDW-private information stored in fdw_private lists.
+ *
+ * These items are indexed with the enum FdwScanPrivateIndex, so an item
+ * can be fetched with list_nth().  For example, to get the SELECT statement:
+ *		sql = strVal(list_nth(fdw_private, FdwScanPrivateSelectSql));
+ */
+enum FdwScanPrivateIndex
 {
-	char *ch_error = NULL;
-	ch_connection res;
-	ch_binary_connection_t *conn = ch_binary_connect(details->host, details->port,
-			details->dbname, details->username, details->password, &ch_error);
+	/* SQL statement to execute remotely (as a String node) */
+	FdwScanPrivateSelectSql,
+	/* Integer list of attribute numbers retrieved by the SELECT */
+	FdwScanPrivateRetrievedAttrs,
+	/* Integer representing the desired fetch_size */
+	FdwScanPrivateFetchSize,
 
-	if (conn == NULL)
+	/*
+	 * String describing join i.e. names of relations being joined and types
+	 * of join, added when the scan is join
+	 */
+	FdwScanPrivateRelations
+};
+
+/*
+ * Similarly, this enum describes what's kept in the fdw_private list for
+ * a ModifyTable node referencing a postgres_fdw foreign table.  We store:
+ *
+ * 1) INSERT statement text to be sent to the remote server
+ * 2) Integer list of target attribute numbers for INSERT
+ */
+enum FdwModifyPrivateIndex
+{
+	/* SQL statement to execute remotely (as a String node) */
+	FdwModifyPrivateInsertSQL,
+	/* Integer list of target attribute numbers for INSERT/UPDATE */
+	FdwModifyPrivateTargetAttnums,
+	/* Deparsed name of the result table */
+	FdwModifyPrivateTableName
+};
+
+
+/*
+ * Execution state of a foreign scan using postgres_fdw.
+ */
+typedef struct ChFdwScanState
+{
+	Relation	rel;			/* relcache entry for the foreign table. NULL
+						 * for a foreign join scan. */
+	TupleDesc	tupdesc;		/* tuple descriptor of scan */
+	AttInMetadata *attinmeta;	/* attribute datatype conversion metadata */
+
+	/* extracted fdw_private data */
+	char	   *query;			/* text of SELECT command */
+	List	   *retrieved_attrs;	/* list of retrieved attribute numbers */
+
+	/* for remote query execution */
+	ch_connection	conn;			/* connection for the scan */
+	int			numParams;		/* number of parameters passed to query */
+	FmgrInfo   *param_flinfo;	/* output conversion functions for them */
+	List	   *param_exprs;	/* executable expressions for param values */
+	const char **param_values;	/* textual values of query parameters */
+	ch_cursor  *ch_cursor;		/* result of query from clickhouse */
+
+	/* for storing result tuple */
+	HeapTuple  tuple;			/* array of currently-retrieved tuples */
+
+	/* working memory contexts */
+	MemoryContext batch_cxt;	/* context holding current batch of tuples */
+	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
+
+	int			fetch_size;		/* number of tuples per fetch */
+} ChFdwScanState;
+
+/*
+ * Execution state of a foreign insert.
+ */
+typedef struct CHFdwModifyState
+{
+	Relation	rel;			/* relcache entry for the foreign table */
+	AttInMetadata *attinmeta;	/* attribute datatype conversion metadata */
+
+	/* for remote query execution */
+	ch_connection	conn;		/* connection for the scan */
+
+	/* extracted fdw_private data */
+	char	   *query;			/* text of INSERT/UPDATE/DELETE command */
+	void	   *state;			/* internal state for a connection */
+
+	/* working memory context */
+	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
+} CHFdwModifyState;
+
+/*
+ * This enum describes what's kept in the fdw_private list for a ForeignPath.
+ * We store:
+ *
+ * 1) Boolean flag showing if the remote query has the final sort
+ * 2) Boolean flag showing if the remote query has the LIMIT clause
+ */
+enum FdwPathPrivateIndex
+{
+	/* has-final-sort flag (as an integer Value node) */
+	FdwPathPrivateHasFinalSort,
+	/* has-limit flag (as an integer Value node) */
+	FdwPathPrivateHasLimit
+};
+
+/* Struct for extra information passed to estimate_path_cost_size() */
+typedef struct
+{
+	PathTarget *target;
+	bool		has_final_sort;
+	bool		has_limit;
+	double		limit_tuples;
+	int64		count_est;
+	int64		offset_est;
+} ChFdwPathExtraData;
+
+
+/*
+ * SQL functions
+ */
+PG_FUNCTION_INFO_V1(clickhouse_fdw_handler);
+PG_FUNCTION_INFO_V1(clickhouse_raw_query);
+PG_FUNCTION_INFO_V1(clickhouse_mock);
+extern PGDLLEXPORT void _PG_init(void);
+static double time_used = 0;
+
+/*
+ * FDW callback routines
+ */
+static void clickhouseGetForeignRelSize(PlannerInfo *root,
+                                        RelOptInfo *baserel,
+                                        Oid foreigntableid);
+static ForeignScan *clickhouseGetForeignPlan(PlannerInfo *root,
+        RelOptInfo *foreignrel,
+        Oid foreigntableid,
+        ForeignPath *best_path,
+        List *tlist,
+        List *scan_clauses,
+        Plan *outer_plan);
+static int
+clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
+                                HeapTuple *rows, int targrows,
+                                double *totalrows,
+                                double *totaldeadrows);
+static void clickhouseBeginForeignScan(ForeignScanState *node, int eflags);
+static TupleTableSlot *clickhouseIterateForeignScan(ForeignScanState *node);
+static void clickhouseEndForeignScan(ForeignScanState *node);
+static List *clickhousePlanForeignModify(PlannerInfo *root,
+        ModifyTable *plan,
+        Index resultRelation,
+        int subplan_index);
+static void clickhouseBeginForeignModify(ModifyTableState *mtstate,
+        ResultRelInfo *resultRelInfo,
+        List *fdw_private,
+        int subplan_index,
+        int eflags);
+static TupleTableSlot *clickhouseExecForeignInsert(EState *estate,
+        ResultRelInfo *resultRelInfo,
+        TupleTableSlot *slot,
+        TupleTableSlot *planSlot);
+static void clickhouseBeginForeignInsert(ModifyTableState *mtstate,
+        ResultRelInfo *resultRelInfo);
+static void clickhouseEndForeignInsert(EState *estate,
+                                       ResultRelInfo *resultRelInfo);
+static void clickhouseExplainForeignScan(ForeignScanState *node,
+        ExplainState *es);
+static void clickhouseGetForeignUpperPaths(PlannerInfo *root,
+        UpperRelationKind stage,
+        RelOptInfo *input_rel, RelOptInfo *output_rel,
+        void *extra);
+static bool clickhouseAnalyzeForeignTable(Relation relation,
+        AcquireSampleRowsFunc *func,
+        BlockNumber *totalpages);
+static bool clickhouseRecheckForeignScan(ForeignScanState *node,
+        TupleTableSlot *slot);
+
+/*
+ * Helper functions
+ */
+static void estimate_path_cost_size(double *p_rows, int *p_width,
+                                    Cost *p_startup_cost, Cost *p_total_cost,
+									double coef);
+static CHFdwModifyState *create_foreign_modify(EState *estate,
+        RangeTblEntry *rte,
+        ResultRelInfo *resultRelInfo,
+        CmdType operation,
+        Plan *subplan,
+        char *query,
+        List *target_attrs,
+		char *table_name);
+static void finish_foreign_modify(CHFdwModifyState *fmstate);
+static void prepare_query_params(PlanState *node,
+                                 List *fdw_exprs,
+                                 int numParams,
+                                 FmgrInfo **param_flinfo,
+                                 List **param_exprs,
+                                 const char ***param_values);
+static bool foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel,
+                            JoinType jointype, RelOptInfo *outerrel, RelOptInfo *innerrel,
+                            JoinPathExtraData *extra);
+static bool foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
+                                Node *havingQual);
+static List *get_useful_pathkeys_for_relation(PlannerInfo *root,
+        RelOptInfo *rel);
+static void add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
+        Path *epq_path);
+static void add_foreign_grouping_paths(PlannerInfo *root,
+                                       RelOptInfo *input_rel,
+                                       RelOptInfo *grouped_rel,
+                                       GroupPathExtraData *extra);
+static void add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
+						  RelOptInfo *ordered_rel);
+static void add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
+						RelOptInfo *final_rel,
+						void *fextra);
+static void merge_fdw_options(CHFdwRelationInfo *fpinfo,
+                              const CHFdwRelationInfo *fpinfo_o,
+                              const CHFdwRelationInfo *fpinfo_i);
+
+/* empty _PG_init_ function */
+void _PG_init(void){}
+
+
+/* Make one query and close the connection */
+Datum
+clickhouse_raw_query(PG_FUNCTION_ARGS)
+{
+	char *connstring = text_to_cstring(PG_GETARG_TEXT_P(1)),
+		 *query = text_to_cstring(PG_GETARG_TEXT_P(0));
+
+	ch_connection_details *details = connstring_parse(connstring);
+	ch_connection	conn = chfdw_http_connect(details);
+	ch_cursor	   *cursor = conn.methods->simple_query(conn.conn, query);
+	text		   *res = chfdw_http_fetch_raw_data(cursor);
+
+	MemoryContextDelete(cursor->memcxt);
+	conn.methods->disconnect(conn.conn);
+
+	if (res)
+		PG_RETURN_TEXT_P(res);
+
+	PG_RETURN_NULL();
+}
+
+//calculate difference
+double
+time_diff(struct timeval * prior, struct timeval * latter)
+{
+	double x =
+		(double)(latter->tv_usec - prior->tv_usec) / 1000.0L +
+		(double)(latter->tv_sec - prior->tv_sec) * 1000.0L;
+
+	return x;
+}
+
+/*
+ * clickhouseGetForeignRelSize
+ *		Estimate # of rows and width of the result of the scan
+ *
+ * We should consider the effect of all baserestrictinfo clauses here, but
+ * not any join clauses.
+ */
+static void
+clickhouseGetForeignRelSize(PlannerInfo *root,
+                            RelOptInfo *baserel,
+                            Oid foreigntableid)
+{
+	CHFdwRelationInfo *fpinfo;
+	ListCell   *lc;
+	RangeTblEntry *rte = planner_rt_fetch(baserel->relid, root);
+	char *relname,
+		 *refname;
+
+	/*
+	 * We use CHFdwRelationInfo to pass various information to subsequent
+	 * functions.
+	 */
+	fpinfo = (CHFdwRelationInfo *) palloc0(sizeof(CHFdwRelationInfo));
+	baserel->fdw_private = (void *) fpinfo;
+
+	/* Base foreign tables need to be pushed down always. */
+	fpinfo->pushdown_safe = true;
+
+	/* Look up foreign-table catalog info. */
+	fpinfo->table = GetForeignTable(foreigntableid);
+	fpinfo->server = GetForeignServer(fpinfo->table->serverid);
+
+	/*
+	 * Extract user-settable option values.  Note that per-table setting of
+	 * use_remote_estimate overrides per-server setting.
+	 */
+	fpinfo->fdw_startup_cost = DEFAULT_FDW_STARTUP_COST;
+	fpinfo->fdw_tuple_cost = DEFAULT_FDW_TUPLE_COST;
+	fpinfo->shippable_extensions = NIL;
+
+	chfdw_apply_custom_table_options(fpinfo, foreigntableid);
+
+	fpinfo->user = NULL;
+
+	/*
+	 * Identify which baserestrictinfo clauses can be sent to the remote
+	 * server and which can't.
+	 */
+	chfdw_classify_conditions(root, baserel, baserel->baserestrictinfo,
+	                   &fpinfo->remote_conds, &fpinfo->local_conds);
+
+	/*
+	 * Identify which attributes will need to be retrieved from the remote
+	 * server.  These include all attrs needed for joins or final output, plus
+	 * all attrs used in the local_conds.  (Note: if we end up using a
+	 * parameterized scan, it's possible that some of the join clauses will be
+	 * sent to the remote and thus we wouldn't really need to retrieve the
+	 * columns used in them.  Doesn't seem worth detecting that case though.)
+	 */
+	fpinfo->attrs_used = NULL;
+	pull_varattnos((Node *) baserel->reltarget->exprs, baserel->relid,
+	               &fpinfo->attrs_used);
+	foreach (lc, fpinfo->local_conds)
 	{
-		Assert(ch_error);
-		char *error = pstrdup(ch_error);
-		free(ch_error);
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
 
-		ereport(ERROR,
-				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-				 errmsg("clickhouse_fdw: connection error: %s", error)));
+		pull_varattnos((Node *) rinfo->clause, baserel->relid,
+		               &fpinfo->attrs_used);
 	}
 
-	res.conn = conn;
-	// res.methods = &binary_methods;
-	res.is_binary = true;
+	/*
+	 * Compute the selectivity and cost of the local_conds, so we don't have
+	 * to do it over again for each path.  The best we can do for these
+	 * conditions is to estimate selectivity on the basis of local statistics.
+	 */
+	fpinfo->local_conds_sel = clauselist_selectivity(root,
+	                          fpinfo->local_conds,
+	                          baserel->relid,
+	                          JOIN_INNER,
+	                          NULL);
+
+	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
+
+	/*
+	 * Set cached relation costs to some negative value, so that we can detect
+	 * when they are set to some sensible costs during one (usually the first)
+	 * of the calls to estimate_path_cost_size().
+	 */
+	fpinfo->rel_startup_cost = -1;
+	fpinfo->rel_total_cost = -1;
+
+	/*
+	 * Set the name of relation in fpinfo, while we are constructing it here.
+	 * It will be used to build the string describing the join relation in
+	 * EXPLAIN output. We can't know whether VERBOSE option is specified or
+	 * not, so always schema-qualify the foreign table name.
+	 */
+	fpinfo->relation_name = makeStringInfo();
+	relname = get_rel_name(foreigntableid);
+	refname = rte->eref->aliasname;
+	appendStringInfo(fpinfo->relation_name, "%s", quote_identifier(relname));
+	if (*refname && strcmp(refname, relname) != 0)
+		appendStringInfo(fpinfo->relation_name, " %s",
+		                 quote_identifier(rte->eref->aliasname));
+
+	/* No outer and inner relations. */
+	fpinfo->make_outerrel_subquery = false;
+	fpinfo->make_innerrel_subquery = false;
+	fpinfo->lower_subquery_rels = NULL;
+	/* Set the relation index. */
+	fpinfo->relation_index = baserel->relid;
+}
+
+/*
+ * get_useful_pathkeys_for_relation
+ *		Determine which orderings of a relation might be useful.
+ *
+ * Getting data in sorted order can be useful either because the requested
+ * order matches the final output ordering for the overall query we're
+ * planning, or because it enables an efficient merge join.  Here, we try
+ * to figure out which pathkeys to consider.
+ */
+static List *
+get_useful_pathkeys_for_relation(PlannerInfo *root, RelOptInfo *rel)
+{
+	List	   *useful_pathkeys_list = NIL;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) rel->fdw_private;
+	ListCell   *lc;
+
+	/*
+	 * Pushing the query_pathkeys to the remote server is always worth
+	 * considering, because it might let us avoid a local sort.
+	 */
+	fpinfo->qp_is_pushdown_safe = false;
+	if (root->query_pathkeys)
+	{
+		bool		query_pathkeys_ok = true;
+
+		foreach(lc, root->query_pathkeys)
+		{
+			PathKey    *pathkey = (PathKey *) lfirst(lc);
+			EquivalenceClass *pathkey_ec = pathkey->pk_eclass;
+			Expr	   *em_expr;
+
+			/*
+			 * The planner and executor don't have any clever strategy for
+			 * taking data sorted by a prefix of the query's pathkeys and
+			 * getting it to be sorted by all of those pathkeys. We'll just
+			 * end up resorting the entire data set.  So, unless we can push
+			 * down all of the query pathkeys, forget it.
+			 *
+			 * chfdw_is_foreign_expr would detect volatile expressions as well, but
+			 * checking ec_has_volatile here saves some cycles.
+			 */
+			if (pathkey_ec->ec_has_volatile ||
+				!(em_expr = chfdw_find_em_expr_for_rel(pathkey_ec, rel)) ||
+				!chfdw_is_foreign_expr(root, rel, em_expr))
+			{
+				query_pathkeys_ok = false;
+				break;
+			}
+		}
+
+		if (query_pathkeys_ok)
+		{
+			useful_pathkeys_list = list_make1(list_copy(root->query_pathkeys));
+			fpinfo->qp_is_pushdown_safe = true;
+		}
+	}
+
+	return useful_pathkeys_list;
+}
+
+/*
+ * postgresGetForeignPaths
+ *		Create possible scan paths for a scan on the foreign table
+ */
+static void
+clickhouseGetForeignPaths(PlannerInfo *root,
+                          RelOptInfo *baserel,
+                          Oid foreigntableid)
+{
+	ForeignPath			*path;
+	CHFdwRelationInfo	*fpinfo = (CHFdwRelationInfo *) baserel->fdw_private;
+
+	path = create_foreignscan_path(root, baserel, NULL,
+		fpinfo->rows, fpinfo->startup_cost, fpinfo->total_cost,
+		NULL, NULL, NULL, NIL
+#if PG_VERSION_NUM >= 170000
+		, NIL
+#endif
+		);
+
+	add_path(baserel, (Path *) path);
+	add_paths_with_pathkeys_for_rel(root, baserel, NULL);
+}
+
+/*
+ * clickhouseGetForeignPlan
+ *		Create ForeignScan plan node which implements selected best path
+ */
+static ForeignScan *
+clickhouseGetForeignPlan(PlannerInfo *root,
+                         RelOptInfo *foreignrel,
+                         Oid foreigntableid,
+                         ForeignPath *best_path,
+                         List *tlist,
+                         List *scan_clauses,
+                         Plan *outer_plan)
+{
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
+	Index		scan_relid;
+	List	   *fdw_private;
+	List	   *remote_exprs = NIL;
+	List	   *local_exprs = NIL;
+	List	   *params_list = NIL;
+	List	   *fdw_scan_tlist = NIL;
+	List	   *fdw_recheck_quals = NIL;
+	List	   *retrieved_attrs;
+	StringInfoData sql;
+	bool		has_final_sort = false;
+	bool		has_limit = false;
+	ListCell   *lc;
+	struct timeval time1,time2;
+
+	gettimeofday(&time1, NULL);
+
+	/*
+	 * Get FDW private data created by clickhouseGetForeignUpperPaths(), if any.
+	 */
+	if (best_path->fdw_private)
+	{
+		has_final_sort = intVal(list_nth(best_path->fdw_private,
+										 FdwPathPrivateHasFinalSort));
+		has_limit = intVal(list_nth(best_path->fdw_private,
+									FdwPathPrivateHasLimit));
+	}
+
+	if (IS_SIMPLE_REL(foreignrel))
+	{
+		/*
+		 * For base relations, set scan_relid as the relid of the relation.
+		 */
+		scan_relid = foreignrel->relid;
+
+		/*
+		 * In a base-relation scan, we must apply the given scan_clauses.
+		 *
+		 * Separate the scan_clauses into those that can be executed remotely
+		 * and those that can't.  baserestrictinfo clauses that were
+		 * previously determined to be safe or unsafe by chfdw_classify_conditions
+		 * are found in fpinfo->remote_conds and fpinfo->local_conds. Anything
+		 * else in the scan_clauses list will be a join clause, which we have
+		 * to check for remote-safety.
+		 *
+		 * Note: the join clauses we see here should be the exact same ones
+		 * previously examined by postgresGetForeignPaths.  Possibly it'd be
+		 * worth passing forward the classification work done then, rather
+		 * than repeating it here.
+		 *
+		 * This code must match "extract_actual_clauses(scan_clauses, false)"
+		 * except for the additional decision about remote versus local
+		 * execution.
+		 */
+		foreach(lc, scan_clauses)
+		{
+			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+
+			/* Ignore any pseudoconstants, they're dealt with elsewhere */
+			if (rinfo->pseudoconstant)
+				continue;
+
+			if (list_member_ptr(fpinfo->remote_conds, rinfo))
+				remote_exprs = lappend(remote_exprs, rinfo->clause);
+			else if (list_member_ptr(fpinfo->local_conds, rinfo))
+				local_exprs = lappend(local_exprs, rinfo->clause);
+			else if (chfdw_is_foreign_expr(root, foreignrel, rinfo->clause))
+				remote_exprs = lappend(remote_exprs, rinfo->clause);
+			else
+				local_exprs = lappend(local_exprs, rinfo->clause);
+		}
+
+		/*
+		 * For a base-relation scan, we have to support EPQ recheck, which
+		 * should recheck all the remote quals.
+		 */
+		fdw_recheck_quals = remote_exprs;
+	}
+	else
+	{
+		/*
+		 * Join relation or upper relation - set scan_relid to 0.
+		 */
+		scan_relid = 0;
+
+		/*
+		 * For a join rel, baserestrictinfo is NIL and we are not considering
+		 * parameterization right now, so there should be no scan_clauses for
+		 * a joinrel or an upper rel either.
+		 */
+		Assert(!scan_clauses);
+
+		/*
+		 * Instead we get the conditions to apply from the fdw_private
+		 * structure.
+		 */
+		remote_exprs = extract_actual_clauses(fpinfo->remote_conds, false);
+		local_exprs = extract_actual_clauses(fpinfo->local_conds, false);
+
+		/*
+		 * We leave fdw_recheck_quals empty in this case, since we never need
+		 * to apply EPQ recheck clauses.  In the case of a joinrel, EPQ
+		 * recheck is handled elsewhere --- see postgresGetForeignJoinPaths().
+		 * If we're planning an upperrel (ie, remote grouping or aggregation)
+		 * then there's no EPQ to do because SELECT FOR UPDATE wouldn't be
+		 * allowed, and indeed we *can't* put the remote clauses into
+		 * fdw_recheck_quals because the unaggregated Vars won't be available
+		 * locally.
+		 */
+
+		/* Build the list of columns to be fetched from the foreign server. */
+		fdw_scan_tlist = chfdw_build_tlist_to_deparse(foreignrel);
+
+		/*
+		 * Ensure that the outer plan produces a tuple whose descriptor
+		 * matches our scan tuple slot. This is safe because all scans and
+		 * joins support projection, so we never need to insert a Result node.
+		 * Also, remove the local conditions from outer plan's quals, lest
+		 * they will be evaluated twice, once by the local plan and once by
+		 * the scan.
+		 */
+		if (outer_plan)
+		{
+			ListCell   *outer_lc;
+
+			/*
+			 * Right now, we only consider grouping and aggregation beyond
+			 * joins. Queries involving aggregates or grouping do not require
+			 * EPQ mechanism, hence should not have an outer plan here.
+			 */
+			Assert(!IS_UPPER_REL(foreignrel));
+
+			outer_plan->targetlist = fdw_scan_tlist;
+
+			foreach (outer_lc, local_exprs)
+			{
+				Join	   *join_plan = (Join *) outer_plan;
+				Node	   *qual = lfirst(outer_lc);
+
+				outer_plan->qual = list_delete(outer_plan->qual, qual);
+
+				/*
+				 * For an inner join the local conditions of foreign scan plan
+				 * can be part of the joinquals as well.
+				 */
+				if (join_plan->jointype == JOIN_INNER)
+					join_plan->joinqual = list_delete(join_plan->joinqual,
+					                                  qual);
+			}
+		}
+	}
+
+	/*
+	 * Build the query string to be sent for execution, and identify
+	 * expressions to be sent as parameters.
+	 */
+	initStringInfo(&sql);
+	chfdw_deparse_select_stmt_for_rel(&sql, root, foreignrel, fdw_scan_tlist,
+	                        remote_exprs, best_path->path.pathkeys,
+							has_final_sort, has_limit, false,
+							&retrieved_attrs, &params_list);
+
+	/* Remember remote_exprs for possible use by postgresPlanDirectModify */
+	fpinfo->final_remote_exprs = remote_exprs;
+
+	/*
+	 * Build the fdw_private list that will be available to the executor.
+	 * Items in the list must match order in enum FdwScanPrivateIndex.
+	 */
+	fdw_private = list_make3(makeString(sql.data),
+							 retrieved_attrs,
+							 makeInteger(fpinfo->fetch_size));
+	if (IS_JOIN_REL(foreignrel) || IS_UPPER_REL(foreignrel))
+		fdw_private = lappend(fdw_private,
+							  makeString(fpinfo->relation_name->data));
+
+	gettimeofday(&time2, NULL);
+	time_used += time_diff(&time1, &time2);
+
+	/*
+	 * Create the ForeignScan node for the given relation.
+	 *
+	 * Note that the remote parameter expressions are stored in the fdw_exprs
+	 * field of the finished plan node; we can't keep them in private state
+	 * because then they wouldn't be subject to later planner processing.
+	 */
+	return make_foreignscan(tlist,
+							local_exprs,
+							scan_relid,
+							params_list,
+							fdw_private,
+							fdw_scan_tlist,
+							fdw_recheck_quals,
+							outer_plan);
+}
+
+/*
+ * clickhouseBeginForeignScan
+ *		Initiate an executor scan of a foreign PostgreSQL table.
+ */
+static void
+clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
+{
+	ForeignScan *fsplan = (ForeignScan *) node->ss.ps.plan;
+	EState	   *estate = node->ss.ps.state;
+	ChFdwScanState *fsstate;
+	RangeTblEntry *rte;
+	Oid			userid;
+	ForeignTable *table;
+	UserMapping *user;
+	int			rtindex;
+	int			numParams;
+
+	/*
+	 * Do nothing in EXPLAIN (no ANALYZE) case.  node->fdw_state stays NULL.
+	 */
+	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
+		return;
+
+	/*
+	 * We'll save private state in node->fdw_state.
+	 */
+	fsstate = (ChFdwScanState *) palloc0(sizeof(ChFdwScanState));
+	node->fdw_state = (void *) fsstate;
+
+	/*
+	 * Identify which user to do the remote access as.  This should match what
+	 * ExecCheckRTEPerms() does.  In case of a join or aggregate, use the
+	 * lowest-numbered member RTE as a representative; we would get the same
+	 * result from any.
+	 */
+	if (fsplan->scan.scanrelid > 0)
+		rtindex = fsplan->scan.scanrelid;
+	else
+		rtindex = bms_next_member(fsplan->fs_relids, -1);
+	rte = rt_fetch(rtindex, estate->es_range_table);
+#if PG_VERSION_NUM >= 160000
+	userid = OidIsValid(fsplan->checkAsUser) ? fsplan->checkAsUser : GetUserId();
+#else
+	userid = rte->checkAsUser ? rte->checkAsUser : GetUserId();
+#endif
+
+	/* Get info about foreign table. */
+	table = GetForeignTable(rte->relid);
+	user = GetUserMapping(userid, table->serverid);
+
+	/*
+	 * Get connection to the foreign server.  Connection manager will
+	 * establish new connection if necessary.
+	 */
+	fsstate->conn = chfdw_get_connection(user);
+
+	/* Get private info created by planner functions. */
+	fsstate->query = strVal(list_nth(fsplan->fdw_private,
+									 FdwScanPrivateSelectSql));
+	fsstate->retrieved_attrs = (List *) list_nth(fsplan->fdw_private,
+												 FdwScanPrivateRetrievedAttrs);
+	fsstate->fetch_size = intVal(list_nth(fsplan->fdw_private,
+										  FdwScanPrivateFetchSize));
+
+	/* Create contexts for batches of tuples and per-tuple temp workspace. */
+	fsstate->batch_cxt = AllocSetContextCreate(estate->es_query_cxt,
+	                     "clickhouse_fdw tuple data",
+	                     ALLOCSET_DEFAULT_SIZES);
+	fsstate->temp_cxt = AllocSetContextCreate(estate->es_query_cxt,
+	                    "clickhouse_fdw temporary data",
+	                    ALLOCSET_SMALL_SIZES);
+
+	/*
+	 * Get info we'll need for converting data fetched from the foreign server
+	 * into local representation and error reporting during that process.
+	 */
+	if (fsplan->scan.scanrelid > 0)
+	{
+		fsstate->rel = node->ss.ss_currentRelation;
+		fsstate->tupdesc = RelationGetDescr(fsstate->rel);
+	}
+	else
+	{
+		fsstate->rel = NULL;
+		fsstate->tupdesc = node->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
+	}
+
+	fsstate->attinmeta = TupleDescGetAttInMetadata(fsstate->tupdesc);
+
+	/*
+	 * Prepare for processing of parameters used in remote query, if any.
+	 */
+	numParams = list_length(fsplan->fdw_exprs);
+	fsstate->numParams = numParams;
+	if (numParams > 0)
+		prepare_query_params((PlanState *) node,
+							 fsplan->fdw_exprs,
+							 numParams,
+							 &fsstate->param_flinfo,
+							 &fsstate->param_exprs,
+							 &fsstate->param_values);
+}
+
+/*
+ * Create a tuple from the specified row of the PGresult.
+ *
+ * rel is the local representation of the foreign table, attinmeta is
+ * conversion data for the rel's tupdesc, and retrieved_attrs is an
+ * integer list of the table column numbers present in the PGresult.
+ * temp_context is a working context that can be reset after each tuple.
+ */
+static HeapTuple
+fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
+{
+	AttInMetadata *attinmeta = fsstate->attinmeta;
+	Datum	   *values;
+	HeapTuple	tuple = NULL;
+	ItemPointer ctid = NULL;
+	ListCell   *lc;
+	MemoryContext oldcontext;
+	bool	   *nulls;
+	int			j;
+	void      **row_values;
+
+	oldcontext = MemoryContextSwitchTo(fsstate->temp_cxt);
+
+	values = (Datum *) palloc0(tupdesc->natts * sizeof(Datum));
+	nulls = (bool *) palloc(tupdesc->natts * sizeof(bool));
+
+	/* Initialize to nulls for any columns not present in result */
+	memset(nulls, true, tupdesc->natts * sizeof(bool));
+
+	row_values = fsstate->conn.methods->fetch_row(fsstate->ch_cursor,
+		fsstate->retrieved_attrs, tupdesc, values, nulls);
+
+	/* in both cases (binary and non binary), NULL means end of tuples */
+	if (row_values == NULL)
+		goto cleanup;
+
+	/* Parse clickhouse result */
+	if (!fsstate->conn.is_binary)
+	{
+		/*
+		 * for non binary connections we will get strings which we will try
+		 * convert using postgres functions.
+		 */
+		j = 0;
+		foreach(lc, fsstate->retrieved_attrs)
+		{
+			int		i = lfirst_int(lc);
+			char   *valstr = (char *) row_values[j];
+
+			Oid pgtype = TupleDescAttr(tupdesc, i - 1)->atttypid;
+			bool is_array = type_is_array_domain(pgtype);
+
+			/* that's the easy way to check array, otherwise use get_element_type on pgtype */
+			if (valstr && is_array && valstr[0] == '[')
+			{
+				size_t	pos = 0;
+
+				while (valstr[pos] != '\0')
+				{
+					if (valstr[pos] == '[')
+						valstr[pos] = '{';
+					if (valstr[pos] == ']')
+						valstr[pos] = '}';
+					pos++;
+				}
+			}
+			else if (valstr && valstr[0] == '0' && valstr[1] == '0')
+            {
+                /* clickhouse supports such values which are invalid in postgres,
+                 * so we just set set as NULL
+                 */
+                if (strcmp(valstr, "0000-00-00 00:00:00") == 0)
+                    valstr = NULL;
+            }
+			else if (valstr && pgtype == VARCHAROID
+					&& TupleDescAttr(tupdesc, i - 1)->atttypmod != 0)
+			{
+				char *pos;
+				if ((pos = strstr(valstr, "\\0")) != NULL)
+					pos[0] = '\0';
+			}
+
+			/* Apply the input function even to nulls, to support domains */
+			nulls[i - 1] = (valstr == NULL);
+			values[i - 1] = InputFunctionCall(&attinmeta->attinfuncs[i - 1],
+										  valstr,
+										  attinmeta->attioparams[i - 1],
+										  attinmeta->atttypmods[i - 1]);
+			j++;
+		}
+	}
+
+	MemoryContextSwitchTo(oldcontext);
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+
+	/*
+	 * If we have a CTID to return, install it in both t_self and t_ctid.
+	 * t_self is the normal place, but if the tuple is converted to a
+	 * composite Datum, t_self will be lost; setting t_ctid allows CTID to be
+	 * preserved during EvalPlanQual re-evaluations (see ROW_MARK_COPY code).
+	 */
+	if (ctid)
+		tuple->t_self = tuple->t_data->t_ctid = *ctid;
+
+	/*
+	 * Stomp on the xmin, xmax, and cmin fields from the tuple created by
+	 * heap_form_tuple.  heap_form_tuple actually creates the tuple with
+	 * DatumTupleFields, not HeapTupleFields, but the executor expects
+	 * HeapTupleFields and will happily extract system columns on that
+	 * assumption.  If we don't do this then, for example, the tuple length
+	 * ends up in the xmin field, which isn't what we want.
+	 */
+	HeapTupleHeaderSetXmax(tuple->t_data, InvalidTransactionId);
+	HeapTupleHeaderSetXmin(tuple->t_data, InvalidTransactionId);
+	HeapTupleHeaderSetCmin(tuple->t_data, InvalidTransactionId);
+
+cleanup:
+	MemoryContextReset(fsstate->temp_cxt);
+	return tuple;
+}
+
+/*
+ * clickhouseIterateForeignScan
+ *		Retrieve next row from the result set, or clear tuple slot to indicate
+ *		EOF.
+ */
+static TupleTableSlot *
+clickhouseIterateForeignScan(ForeignScanState *node)
+{
+	HeapTuple		tup;
+	ChFdwScanState *fsstate = (ChFdwScanState *) node->fdw_state;
+	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
+	struct timeval time1,time2;
+	TupleDesc		tupdesc;
+
+	/* make query if needed */
+	if (fsstate->ch_cursor == NULL)
+	{
+		MemoryContext	old = MemoryContextSwitchTo(fsstate->batch_cxt);
+		fsstate->ch_cursor = fsstate->conn.methods->simple_query(fsstate->conn.conn,
+				fsstate->query);
+
+		time_used += fsstate->ch_cursor->request_time;
+		MemoryContextSwitchTo(old);
+	}
+
+	if (fsstate->rel)
+		tupdesc = RelationGetDescr(fsstate->rel);
+	else
+	{
+		Assert(fsstate);
+		tupdesc = node->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
+	}
+
+	gettimeofday(&time1, NULL);
+	tup = fetch_tuple(fsstate, tupdesc);
+	gettimeofday(&time2, NULL);
+	time_used += time_diff(&time1, &time2);
+
+	if (tup == NULL)
+		return ExecClearTuple(slot);
+
+	/*
+	 * Return the next tuple.
+	 */
+	ExecStoreHeapTuple(tup, slot, false);
+	return slot;
+}
+
+/*
+ * clickhouseEndForeignScan
+ *		Finish scanning foreign table and dispose objects used for this scan
+ */
+static void
+clickhouseEndForeignScan(ForeignScanState *node)
+{
+	ChFdwScanState *fsstate = (ChFdwScanState *) node->fdw_state;
+
+	time_used = 0;
+	if (fsstate && fsstate->ch_cursor)
+	{
+		MemoryContextDelete(fsstate->ch_cursor->memcxt);
+		fsstate->ch_cursor = NULL;
+	}
+}
+
+/*
+ * clickhousePlanForeignModify
+ *		Plan an insert operation on a foreign table
+ */
+static List *
+clickhousePlanForeignModify(PlannerInfo *root,
+                            ModifyTable *plan,
+                            Index resultRelation,
+                            int subplan_index)
+{
+	CmdType		operation = plan->operation;
+	RangeTblEntry *rte = planner_rt_fetch(resultRelation, root);
+	Relation	rel;
+	StringInfoData sql;
+	List	   *targetAttrs = NIL;
+
+	initStringInfo(&sql);
+
+	/*
+	 * Core code already has some lock on each rel being planned, so we can
+	 * use NoLock here.
+	 */
+	rel = table_open_compat(rte->relid, NoLock);
+	if (operation == CMD_INSERT)
+	{
+		TupleDesc	tupdesc = RelationGetDescr(rel);
+		int			attnum;
+
+		for (attnum = 1; attnum <= tupdesc->natts; attnum++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
+
+			if (!attr->attisdropped)
+				targetAttrs = lappend_int(targetAttrs, attnum);
+		}
+	}
+
+	/*
+	 * Construct the SQL command string.
+	 */
+	char *table_name;
+
+	switch (operation)
+	{
+	case CMD_INSERT:
+		table_name = chfdw_deparse_insert_sql(&sql, rte, resultRelation, rel, targetAttrs);
+		break;
+	case CMD_UPDATE:
+		elog(ERROR, "ClickHouse does not support updates");
+		break;
+	case CMD_DELETE:
+		elog(ERROR, "ClickHouse does not support deletes");
+		break;
+	default:
+		elog(ERROR, "unexpected operation: %d", (int) operation);
+		break;
+	}
+
+	table_close_compat(rel, NoLock);
+
+
+	/*
+	 * Build the fdw_private list that will be available to the executor.
+	 * Items in the list must match enum FdwModifyPrivateIndex, above.
+	 */
+	return list_make3(makeString(sql.data), targetAttrs, makeString(table_name));
+}
+
+/*
+ * clickhouseBeginForeignModify
+ *		Begin an insertoperation on a foreign table
+ */
+static void
+clickhouseBeginForeignModify(ModifyTableState *mtstate,
+                             ResultRelInfo *resultRelInfo,
+                             List *fdw_private,
+                             int subplan_index,
+                             int eflags)
+{
+	CHFdwModifyState *fmstate;
+	char	   *query;
+	List	   *target_attrs = NULL;
+	RangeTblEntry *rte;
+	char	   *table_name;
+
+	/*
+	 * Do nothing in EXPLAIN (no ANALYZE) case.  resultRelInfo->ri_FdwState
+	 * stays NULL.
+	 */
+	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
+		return;
+
+	/* Deconstruct fdw_private data. */
+	query = strVal(list_nth(fdw_private, FdwModifyPrivateInsertSQL));
+	target_attrs = (List *) list_nth(fdw_private, FdwModifyPrivateTargetAttnums);
+	table_name = strVal(list_nth(fdw_private, FdwModifyPrivateTableName));
+
+	/* Find RTE. */
+	rte = rt_fetch(resultRelInfo->ri_RangeTableIndex,
+	               mtstate->ps.state->es_range_table);
+
+	/* Construct an execution state. */
+	fmstate = create_foreign_modify(mtstate->ps.state,
+	                                rte,
+	                                resultRelInfo,
+	                                mtstate->operation,
+#if PG_VERSION_NUM < 140000
+	                                mtstate->mt_plans[subplan_index]->plan,
+#else
+	                                outerPlanState(mtstate)->plan,
+#endif
+	                                query,
+	                                target_attrs,
+									table_name);
+
+	resultRelInfo->ri_FdwState = fmstate;
+}
+
+ForeignServer *
+chfdw_get_foreign_server(Relation rel)
+{
+	ForeignServer       *server;
+	ForeignTable        *table;
+
+	table = GetForeignTable(RelationGetRelid(rel));
+	server = GetForeignServer(table->serverid);
+	return server;
+}
+
+/*
+ * clickhouseBeginForeignInsert
+ *		Begin an insert operation on a foreign table
+ */
+static void
+clickhouseBeginForeignInsert(ModifyTableState *mtstate,
+                             ResultRelInfo *resultRelInfo)
+{
+	CHFdwModifyState *fmstate;
+	EState	   *estate = mtstate->ps.state;
+	Index		resultRelation = resultRelInfo->ri_RangeTableIndex;
+	Relation	rel = resultRelInfo->ri_RelationDesc;
+	RangeTblEntry *rte;
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	int			attnum;
+	List	   *targetAttrs = NIL;
+	StringInfoData	sql;
+	char	   *table_name;
+
+	/* We transmit all columns that are defined in the foreign table. */
+	for (attnum = 1; attnum <= tupdesc->natts; attnum++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
+
+		if (!attr->attisdropped)
+			targetAttrs = lappend_int(targetAttrs, attnum);
+	}
+
+	/*
+	 * If the foreign table is a partition, we need to create a new RTE
+	 * describing the foreign table for use by chfdw_deparse_insert_sql and
+	 * create_foreign_modify() below, after first copying the parent's RTE and
+	 * modifying some fields to describe the foreign partition to work on.
+	 * However, if this is invoked by UPDATE, the existing RTE may already
+	 * correspond to this partition if it is one of the UPDATE subplan target
+	 * rels; in that case, we can just use the existing RTE as-is.
+	 */
+	rte = list_nth(estate->es_range_table, resultRelation - 1);
+	if (rte->relid != RelationGetRelid(rel))
+	{
+		rte = (RangeTblEntry *) copyObjectImpl(rte);
+		rte->relid = RelationGetRelid(rel);
+		rte->relkind = RELKIND_FOREIGN_TABLE;
+	}
+
+	initStringInfo(&sql);
+	table_name = chfdw_deparse_insert_sql(&sql, rte, resultRelation, rel, targetAttrs);
+
+	/* Construct an execution state. */
+	fmstate = create_foreign_modify(mtstate->ps.state,
+	                                rte,
+	                                resultRelInfo,
+	                                CMD_INSERT,
+	                                NULL,
+	                                sql.data,
+	                                targetAttrs,
+					table_name);
+
+	resultRelInfo->ri_FdwState = fmstate;
+}
+
+/*
+ * clickhouseExecForeignInsert
+ *		Put one row to buffer, if buffer is big enough push it to ClickHouse
+ */
+static TupleTableSlot *
+clickhouseExecForeignInsert(EState *estate,
+                            ResultRelInfo *resultRelInfo,
+                            TupleTableSlot *slot,
+                            TupleTableSlot *planSlot)
+{
+	MemoryContext oldcontext;
+
+	CHFdwModifyState *fmstate = (CHFdwModifyState *) resultRelInfo->ri_FdwState;
+
+	oldcontext = MemoryContextSwitchTo(fmstate->temp_cxt);
+
+	fmstate->conn.methods->insert_tuple(fmstate->state, slot);
+
+	MemoryContextSwitchTo(oldcontext);
+	MemoryContextReset(fmstate->temp_cxt);
+
+	return slot;
+}
+
+/*
+ * clickhouseEndForeignInsert
+ *		Finish an insert operation on a foreign table
+ */
+static void
+clickhouseEndForeignInsert(EState *estate,
+                           ResultRelInfo *resultRelInfo)
+{
+	MemoryContext oldcontext;
+
+	CHFdwModifyState *fmstate = (CHFdwModifyState *) resultRelInfo->ri_FdwState;
+
+	if (fmstate)
+	{
+		/* flush */
+		oldcontext = MemoryContextSwitchTo(fmstate->temp_cxt);
+		fmstate->conn.methods->insert_tuple(fmstate->state, NULL);
+		MemoryContextSwitchTo(oldcontext);
+		MemoryContextReset(fmstate->temp_cxt);
+
+		/* Destroy the execution state */
+		finish_foreign_modify(fmstate);
+	}
+}
+
+/*
+ * clickhouseRecheckForeignScan
+ *		Execute a local join execution plan for a foreign join
+ */
+static bool
+clickhouseRecheckForeignScan(ForeignScanState *node, TupleTableSlot *slot)
+{
+	Index		scanrelid = ((Scan *) node->ss.ps.plan)->scanrelid;
+	PlanState  *outerPlan = outerPlanState(node);
+	TupleTableSlot *result;
+
+	/* For base foreign relations, it suffices to set fdw_recheck_quals */
+	if (scanrelid > 0)
+		return true;
+
+	Assert(outerPlan != NULL);
+
+	/* Execute a local join execution plan */
+	result = ExecProcNode(outerPlan);
+	if (TupIsNull(result))
+		return false;
+
+	/* Store result in the given slot */
+	ExecCopySlot(slot, result);
+
+
+	return true;
+}
+
+/*
+ * clickhouseExplainForeignScan
+ *		Produce extra output for EXPLAIN of a ForeignScan on a foreign table
+ */
+static void
+clickhouseExplainForeignScan(ForeignScanState *node, ExplainState *es)
+{
+	List	   *fdw_private;
+	char	   *sql;
+	char	   *relations;
+
+	fdw_private = ((ForeignScan *) node->ss.ps.plan)->fdw_private;
+
+	/*
+	 * Add names of relation handled by the foreign scan when the scan is a
+	 * join
+	 */
+	if (list_length(fdw_private) > FdwScanPrivateRelations)
+	{
+		relations = strVal(list_nth(fdw_private, FdwScanPrivateRelations));
+		ExplainPropertyText("Relations", relations, es);
+	}
+
+	/*
+	 * Add remote query, when VERBOSE option is specified.
+	 */
+	if (es->verbose)
+	{
+		sql = strVal(list_nth(fdw_private, FdwScanPrivateSelectSql));
+		ExplainPropertyText("Remote SQL", sql, es);
+	}
+
+	if (es->timing && time_used > 0)
+		ExplainPropertyFloat("FDW Time", "ms", time_used, 3, es);
+}
+
+/*
+ * estimate_path_cost_size
+ *		Get cost and size estimates for a foreign scan on given foreign relation
+ *		either a base relation or a join between foreign relations or an upper
+ *		relation containing foreign relations.
+ *
+ * param_join_conds are the parameterization clauses with outer relations.
+ * pathkeys specify the expected sort order if any for given path being costed.
+ *
+ * The function returns the cost and size estimates in p_row, p_width,
+ * p_startup_cost and p_total_cost variables.
+ */
+static void
+estimate_path_cost_size(double *p_rows, int *p_width,
+                        Cost *p_startup_cost, Cost *p_total_cost, double coef)
+{
+	*p_rows = 1;
+	*p_width = 1;
+	*p_startup_cost = 1.0;
+	*p_total_cost = -1 + coef;
+}
+
+/*
+ * create_foreign_modify
+ *		Construct an execution state of a foreign insert
+ *		operation
+ */
+static CHFdwModifyState *
+create_foreign_modify(EState *estate,
+                      RangeTblEntry *rte,
+                      ResultRelInfo *rri,
+                      CmdType operation,
+                      Plan *subplan,
+                      char *query,
+                      List *target_attrs,
+					  char *table_name)
+{
+	CHFdwModifyState *fmstate;
+	Oid			userid;
+	ForeignTable *table;
+	UserMapping *user;
+	MemoryContext	old_mcxt;
+	Relation	rel = rri->ri_RelationDesc;
+
+	/* Begin constructing CHFdwModifyState. */
+	fmstate = (CHFdwModifyState *) palloc0(sizeof(CHFdwModifyState));
+	fmstate->rel = rel;
+
+	/*
+	 * Identify which user to do the remote access as.  This should match what
+	 * ExecCheckRTEPerms() does.
+	 */
+#if PG_VERSION_NUM >= 160000
+	userid = ExecGetResultRelCheckAsUser(rri, estate);
+#else
+	userid = rte->checkAsUser ? rte->checkAsUser : GetUserId();
+#endif
+
+	/* Get info about foreign table. */
+	table = GetForeignTable(RelationGetRelid(rel));
+	user = GetUserMapping(userid, table->serverid);
+
+	/* make a connection and prepare an insertion state */
+	fmstate->conn = chfdw_get_connection(user);
+
+	old_mcxt = MemoryContextSwitchTo(PortalContext);
+	fmstate->state = fmstate->conn.methods->prepare_insert(fmstate->conn.conn,
+			rri, target_attrs, query, table_name);
+	MemoryContextSwitchTo(old_mcxt);
+
+	/* Create context for per-query temp workspace. */
+	fmstate->temp_cxt = AllocSetContextCreate(estate->es_query_cxt,
+	                    "clickhouse_fdw temporary data",
+	                    ALLOCSET_SMALL_SIZES);
+
+	/* Set up remote query information. */
+	fmstate->query = query;
+	return fmstate;
+}
+
+/*
+ * finish_foreign_modify
+ *		Release resources for a foreign insert/delete operation
+ */
+static void
+finish_foreign_modify(CHFdwModifyState *fmstate)
+{
+	Assert(fmstate != NULL);
+	memset(&fmstate->conn, 0, sizeof(fmstate->conn));
+}
+
+/*
+ * Prepare for processing of parameters used in remote query.
+ */
+static void
+prepare_query_params(PlanState *node,
+                     List *fdw_exprs,
+                     int numParams,
+                     FmgrInfo **param_flinfo,
+                     List **param_exprs,
+                     const char ***param_values)
+{
+	int			i;
+	ListCell   *lc;
+
+	Assert(numParams > 0);
+
+	/* Prepare for output conversion of parameters used in remote query. */
+	*param_flinfo = (FmgrInfo *) palloc0(sizeof(FmgrInfo) * numParams);
+
+	i = 0;
+	foreach (lc, fdw_exprs)
+	{
+		Node	   *param_expr = (Node *) lfirst(lc);
+		Oid			typefnoid;
+		bool		isvarlena;
+
+		getTypeOutputInfo(exprType(param_expr), &typefnoid, &isvarlena);
+		fmgr_info(typefnoid, &(*param_flinfo)[i]);
+		i++;
+	}
+
+	/*
+	 * Prepare remote-parameter expressions for evaluation.  (Note: in
+	 * practice, we expect that all these expressions will be just Params, so
+	 * we could possibly do something more efficient than using the full
+	 * expression-eval machinery for this.  But probably there would be little
+	 * benefit, and it'd require postgres_fdw to know more than is desirable
+	 * about Param evaluation.)
+	 */
+	*param_exprs = ExecInitExprList(fdw_exprs, node);
+
+	/* Allocate buffer for text form of query parameters. */
+	*param_values = (const char **) palloc0(numParams * sizeof(char *));
+}
+
+/*
+ * clickhouseAnalyzeForeignTable
+ *		Test whether analyzing this foreign table is supported
+ */
+static bool
+clickhouseAnalyzeForeignTable(Relation relation,
+                              AcquireSampleRowsFunc *func,
+                              BlockNumber *totalpages)
+{
+	*func = clickhouseAcquireSampleRowsFunc;
+	return true;
+}
+
+/*
+ * Acquire a random sample of rows from foreign table managed by postgres_fdw.
+ *
+ * We fetch the whole table from the remote side and pick out some sample rows.
+ *
+ * Selected rows are returned in the caller-allocated array rows[],
+ * which must have at least targrows entries.
+ * The actual number of rows selected is returned as the function result.
+ * We also count the total number of rows in the table and return it into
+ * *totalrows.  Note that *totaldeadrows is always set to 0.
+ *
+ * Note that the returned list of rows is not always in order by physical
+ * position in the table.  Therefore, correlation estimates derived later
+ * may be meaningless, but it's OK because we don't use the estimates
+ * currently (the planner only pays attention to correlation for indexscans).
+ */
+static int
+clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
+                                HeapTuple *rows, int targrows,
+                                double *totalrows,
+                                double *totaldeadrows)
+{
+	return 0;
+}
+
+static bool
+is_simple_join_clause(Expr *expr)
+{
+	if (IsA(expr, RestrictInfo))
+	{
+		expr = ((RestrictInfo *) expr)->clause;
+	}
+
+	if (IsA(expr, OpExpr))
+	{
+		OpExpr	*opexpr = (OpExpr *) expr;
+		if (chfdw_is_equal_op(opexpr->opno) == 1
+				&& list_length(opexpr->args) == 2
+				&& IsA(list_nth(opexpr->args, 0), Var)
+				&& IsA(list_nth(opexpr->args, 1), Var))
+			return true;
+	}
+	return false;
+}
+
+static List *
+extract_join_equals(List *conds, List **to)
+{
+	ListCell *lc;
+	List *res = NIL;
+	foreach (lc, conds)
+	{
+		Expr	   *expr = (Expr *) lfirst(lc);
+		if (is_simple_join_clause(expr))
+			*to = lappend(*to, expr);
+		else
+			res = lappend(res, expr);
+	}
 	return res;
+}
+
+/*
+ * Assess whether the join between inner and outer relations can be pushed down
+ * to the foreign server. As a side effect, save information we obtain in this
+ * function to CHFdwRelationInfo passed in.
+ */
+static bool
+foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
+                RelOptInfo *outerrel, RelOptInfo *innerrel,
+                JoinPathExtraData *extra)
+{
+	CHFdwRelationInfo *fpinfo;
+	CHFdwRelationInfo *fpinfo_o;
+	CHFdwRelationInfo *fpinfo_i;
+	ListCell   *lc;
+	List	   *joinclauses;
+
+	/*
+	 * We support pushing down INNER, LEFT, RIGHT and FULL OUTER joins.
+	 * Constructing queries representing SEMI and ANTI joins is hard, hence
+	 * not considered right now.
+	 */
+	if (jointype != JOIN_INNER && jointype != JOIN_LEFT &&
+	        jointype != JOIN_RIGHT && jointype != JOIN_FULL)
+	{
+		return false;
+	}
+
+	/*
+	 * If either of the joining relations is marked as unsafe to pushdown, the
+	 * join can not be pushed down.
+	 */
+	fpinfo = (CHFdwRelationInfo *) joinrel->fdw_private;
+	fpinfo_o = (CHFdwRelationInfo *) outerrel->fdw_private;
+	fpinfo_i = (CHFdwRelationInfo *) innerrel->fdw_private;
+	if (!fpinfo_o || !fpinfo_o->pushdown_safe ||
+	        !fpinfo_i || !fpinfo_i->pushdown_safe)
+	{
+		return false;
+	}
+
+	/*
+	 * If joining relations have local conditions, those conditions are
+	 * required to be applied before joining the relations. Hence the join can
+	 * not be pushed down.
+	 */
+	if (fpinfo_o->local_conds || fpinfo_i->local_conds)
+	{
+		return false;
+	}
+
+	/*
+	 * Merge FDW options.  We might be tempted to do this after we have deemed
+	 * the foreign join to be OK.  But we must do this beforehand so that we
+	 * know which quals can be evaluated on the foreign server, which might
+	 * depend on shippable_extensions.
+	 */
+	fpinfo->server = fpinfo_o->server;
+	merge_fdw_options(fpinfo, fpinfo_o, fpinfo_i);
+
+	/*
+	 * Separate restrict list into join quals and pushed-down (other) quals.
+	 *
+	 * Join quals belonging to an outer join must all be shippable, else we
+	 * cannot execute the join remotely.  Add such quals to 'joinclauses'.
+	 *
+	 * Add other quals to fpinfo->remote_conds if they are shippable, else to
+	 * fpinfo->local_conds.  In an inner join it's okay to execute conditions
+	 * either locally or remotely; the same is true for pushed-down conditions
+	 * at an outer join.
+	 *
+	 * Note we might return failure after having already scribbled on
+	 * fpinfo->remote_conds and fpinfo->local_conds.  That's okay because we
+	 * won't consult those lists again if we deem the join unshippable.
+	 */
+	joinclauses = NIL;
+	foreach(lc, extra->restrictlist)
+	{
+		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+		bool		is_remote_clause = chfdw_is_foreign_expr(root, joinrel,
+													   rinfo->clause);
+
+		if (IS_OUTER_JOIN(jointype) &&
+			!RINFO_IS_PUSHED_DOWN(rinfo, joinrel->relids))
+		{
+			if (!is_remote_clause)
+				return false;
+			joinclauses = lappend(joinclauses, rinfo);
+		}
+		else
+		{
+			if (is_remote_clause)
+				fpinfo->remote_conds = lappend(fpinfo->remote_conds, rinfo);
+			else
+				fpinfo->local_conds = lappend(fpinfo->local_conds, rinfo);
+		}
+	}
+
+	/*
+	 * deparseExplicitTargetList() isn't smart enough to handle anything other
+	 * than a Var.  In particular, if there's some PlaceHolderVar that would
+	 * need to be evaluated within this join tree (because there's an upper
+	 * reference to a quantity that may go to NULL as a result of an outer
+	 * join), then we can't try to push the join down because we'll fail when
+	 * we get to deparseExplicitTargetList().  However, a PlaceHolderVar that
+	 * needs to be evaluated *at the top* of this join tree is OK, because we
+	 * can do that locally after fetching the results from the remote side.
+	 */
+	foreach (lc, root->placeholder_list)
+	{
+		PlaceHolderInfo *phinfo = lfirst(lc);
+		Relids		relids;
+
+		/* PlaceHolderInfo refers to parent relids, not child relids. */
+		relids = IS_OTHER_REL(joinrel) ?
+		         joinrel->top_parent_relids : joinrel->relids;
+
+		if (bms_is_subset(phinfo->ph_eval_at, relids) &&
+		        bms_nonempty_difference(relids, phinfo->ph_eval_at))
+		{
+			return false;
+		}
+	}
+
+	/* Save the join clauses, for later use. */
+	fpinfo->joinclauses = joinclauses;
+
+	fpinfo->outerrel = outerrel;
+	fpinfo->innerrel = innerrel;
+	fpinfo->jointype = jointype;
+
+	/*
+	 * By default, both the input relations are not required to be deparsed as
+	 * subqueries, but there might be some relations covered by the input
+	 * relations that are required to be deparsed as subqueries, so save the
+	 * relids of those relations for later use by the deparser.
+	 */
+	fpinfo->make_outerrel_subquery = false;
+	fpinfo->make_innerrel_subquery = false;
+	Assert(bms_is_subset(fpinfo_o->lower_subquery_rels, outerrel->relids));
+	Assert(bms_is_subset(fpinfo_i->lower_subquery_rels, innerrel->relids));
+	fpinfo->lower_subquery_rels = bms_union(fpinfo_o->lower_subquery_rels,
+	                                        fpinfo_i->lower_subquery_rels);
+
+	/*
+	 * Pull the other remote conditions from the joining relations into join
+	 * clauses or other remote clauses (remote_conds) of this relation
+	 * wherever possible. This avoids building subqueries at every join step.
+	 *
+	 * For an inner join, clauses from both the relations are added to the
+	 * other remote clauses. For LEFT and RIGHT OUTER join, the clauses from
+	 * the outer side are added to remote_conds since those can be evaluated
+	 * after the join is evaluated. The clauses from inner side are added to
+	 * the joinclauses, since they need to be evaluated while constructing the
+	 * join.
+	 *
+	 * For a FULL OUTER JOIN, the other clauses from either relation can not
+	 * be added to the joinclauses or remote_conds, since each relation acts
+	 * as an outer relation for the other.
+	 *
+	 * The joining sides can not have local conditions, thus no need to test
+	 * shippability of the clauses being pulled up.
+	 */
+	switch (jointype)
+	{
+	case JOIN_INNER:
+		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+		                                   list_copy(fpinfo_i->remote_conds));
+		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+		                                   list_copy(fpinfo_o->remote_conds));
+
+		/*
+		 * For an inner join, some restrictions can be treated alike. Treating the
+		 * pushed down conditions as join conditions allows a top level full outer
+		 * join to be deparsed without requiring subqueries.
+		 */
+		Assert(!fpinfo->joinclauses);
+		fpinfo->remote_conds = extract_join_equals(fpinfo->remote_conds,
+										&fpinfo->joinclauses);
+		break;
+
+	case JOIN_LEFT:
+		fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
+		                                  list_copy(fpinfo_i->remote_conds));
+		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+		                                   list_copy(fpinfo_o->remote_conds));
+		break;
+
+	case JOIN_RIGHT:
+		fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
+		                                  list_copy(fpinfo_o->remote_conds));
+		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+		                                   list_copy(fpinfo_i->remote_conds));
+		break;
+
+	case JOIN_FULL:
+
+		/*
+		 * In this case, if any of the input relations has conditions, we
+		 * need to deparse that relation as a subquery so that the
+		 * conditions can be evaluated before the join.  Remember it in
+		 * the fpinfo of this relation so that the deparser can take
+		 * appropriate action.  Also, save the relids of base relations
+		 * covered by that relation for later use by the deparser.
+		 */
+		if (fpinfo_o->remote_conds)
+		{
+			fpinfo->make_outerrel_subquery = true;
+			fpinfo->lower_subquery_rels =
+			    bms_add_members(fpinfo->lower_subquery_rels,
+			                    outerrel->relids);
+		}
+		if (fpinfo_i->remote_conds)
+		{
+			fpinfo->make_innerrel_subquery = true;
+			fpinfo->lower_subquery_rels =
+			    bms_add_members(fpinfo->lower_subquery_rels,
+			                    innerrel->relids);
+		}
+		break;
+
+	default:
+		/* Should not happen, we have just checked this above */
+		elog(ERROR, "unsupported join type %d", jointype);
+	}
+
+	/* Mark that this join can be pushed down safely */
+	fpinfo->pushdown_safe = true;
+
+	/* Get user mapping */
+	if (fpinfo->use_remote_estimate)
+	{
+		if (fpinfo_o->use_remote_estimate)
+			fpinfo->user = fpinfo_o->user;
+		else
+			fpinfo->user = fpinfo_i->user;
+	}
+	else
+		fpinfo->user = NULL;
+
+	/*
+	 * Set cached relation costs to some negative value, so that we can detect
+	 * when they are set to some sensible costs, during one (usually the
+	 * first) of the calls to estimate_path_cost_size().
+	 */
+	fpinfo->rel_startup_cost = -1;
+	fpinfo->rel_total_cost = -1;
+
+	/*
+	 * Set the string describing this join relation to be used in EXPLAIN
+	 * output of corresponding ForeignScan.
+	 */
+	fpinfo->relation_name = makeStringInfo();
+	appendStringInfo(fpinfo->relation_name, "(%s) %s JOIN (%s)",
+					 fpinfo_o->relation_name->data,
+					 chfdw_get_jointype_name(fpinfo->jointype),
+					 fpinfo_i->relation_name->data);
+
+	/*
+	 * Set the relation index.  This is defined as the position of this
+	 * joinrel in the join_rel_list list plus the length of the rtable list.
+	 * Note that since this joinrel is at the end of the join_rel_list list
+	 * when we are called, we can get the position by list_length.
+	 */
+	Assert(fpinfo->relation_index == 0);	/* shouldn't be set yet */
+	fpinfo->relation_index =
+		list_length(root->parse->rtable) + list_length(root->join_rel_list);
+
+	return true;
+}
+
+static void
+add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
+								Path *epq_path)
+{
+	List	   *useful_pathkeys_list = NIL; /* List of all pathkeys */
+	ListCell   *lc;
+
+	useful_pathkeys_list = get_useful_pathkeys_for_relation(root, rel);
+
+	/* Create one path for each set of pathkeys we found above. */
+	foreach(lc, useful_pathkeys_list)
+	{
+		double		rows;
+		int			width;
+		Cost		startup_cost;
+		Cost		total_cost;
+		List	   *useful_pathkeys = lfirst(lc);
+		Path	   *sorted_epq_path;
+
+		estimate_path_cost_size(&rows, &width, &startup_cost, &total_cost, 0.5);
+
+		/*
+		 * The EPQ path must be at least as well sorted as the path itself, in
+		 * case it gets used as input to a mergejoin.
+		 */
+		sorted_epq_path = epq_path;
+		if (sorted_epq_path != NULL &&
+			!pathkeys_contained_in(useful_pathkeys,
+								   sorted_epq_path->pathkeys))
+			sorted_epq_path = (Path *)
+				create_sort_path(root,
+								 rel,
+								 sorted_epq_path,
+								 useful_pathkeys,
+								 -1.0);
+
+		if (IS_SIMPLE_REL(rel))
+			add_path(rel, (Path *)
+					 create_foreignscan_path(root, rel,
+											 NULL,
+											 rows,
+											 startup_cost,
+											 total_cost,
+											 useful_pathkeys,
+											 NULL,
+											 sorted_epq_path,
+#if PG_VERSION_NUM >= 170000
+											 NIL,
+#endif
+											 NIL));
+		else
+			add_path(rel, (Path *)
+					 create_foreign_join_path(root, rel,
+											  NULL,
+											  rows,
+											  startup_cost,
+											  total_cost,
+											  useful_pathkeys,
+											  NULL,
+											  sorted_epq_path,
+#if PG_VERSION_NUM >= 170000
+											  NIL,
+#endif
+											  NIL));
+	}
+}
+
+/*
+ * Merge FDW options from input relations into a new set of options for a join
+ * or an upper rel.
+ *
+ * For a join relation, FDW-specific information about the inner and outer
+ * relations is provided using fpinfo_i and fpinfo_o.  For an upper relation,
+ * fpinfo_o provides the information for the input relation; fpinfo_i is
+ * expected to NULL.
+ */
+static void
+merge_fdw_options(CHFdwRelationInfo *fpinfo,
+                  const CHFdwRelationInfo *fpinfo_o,
+                  const CHFdwRelationInfo *fpinfo_i)
+{
+	/* We must always have fpinfo_o. */
+	Assert(fpinfo_o);
+
+	/* fpinfo_i may be NULL, but if present the servers must both match. */
+	Assert(!fpinfo_i ||
+		   fpinfo_i->server->serverid == fpinfo_o->server->serverid);
+
+	/*
+	 * Copy the server specific FDW options.  (For a join, both relations come
+	 * from the same server, so the server options should have the same value
+	 * for both relations.)
+	 */
+	fpinfo->fdw_startup_cost = fpinfo_o->fdw_startup_cost;
+	fpinfo->fdw_tuple_cost = fpinfo_o->fdw_tuple_cost;
+	fpinfo->shippable_extensions = fpinfo_o->shippable_extensions;
+	fpinfo->use_remote_estimate = fpinfo_o->use_remote_estimate;
+	fpinfo->fetch_size = fpinfo_o->fetch_size;
+
+	/* Merge the table level options from either side of the join. */
+	if (fpinfo_i)
+	{
+		/*
+		 * We'll prefer to use remote estimates for this join if any table
+		 * from either side of the join is using remote estimates.  This is
+		 * most likely going to be preferred since they're already willing to
+		 * pay the price of a round trip to get the remote EXPLAIN.  In any
+		 * case it's not entirely clear how we might otherwise handle this
+		 * best.
+		 */
+		fpinfo->use_remote_estimate = fpinfo_o->use_remote_estimate ||
+			fpinfo_i->use_remote_estimate;
+
+		/*
+		 * Set fetch size to maximum of the joining sides, since we are
+		 * expecting the rows returned by the join to be proportional to the
+		 * relation sizes.
+		 */
+		fpinfo->fetch_size = Max(fpinfo_o->fetch_size, fpinfo_i->fetch_size);
+	}
+}
+
+/*
+ * clickhouseGetForeignJoinPaths
+ *		Add possible ForeignPath to joinrel, if join is safe to push down.
+ */
+static void
+clickhouseGetForeignJoinPaths(PlannerInfo *root,
+                              RelOptInfo *joinrel,
+                              RelOptInfo *outerrel,
+                              RelOptInfo *innerrel,
+                              JoinType jointype,
+                              JoinPathExtraData *extra)
+{
+	CHFdwRelationInfo *fpinfo;
+	ForeignPath *joinpath;
+	double		rows;
+	int			width;
+	Cost		startup_cost;
+	Cost		total_cost;
+	Path	   *epq_path;		/* Path to create plan to be executed when
+					 * EvalPlanQual gets triggered. */
+
+	struct timeval time1,time2;
+	gettimeofday(&time1, NULL);
+
+	/*
+	 * Skip if this join combination has been considered already.
+	 */
+	if (joinrel->fdw_private)
+		return;
+
+	/*
+	 * Create unfinished CHFdwRelationInfo entry which is used to indicate
+	 * that the join relation is already considered, so that we won't waste
+	 * time in judging safety of join pushdown and adding the same paths again
+	 * if found safe. Once we know that this join can be pushed down, we fill
+	 * the entry.
+	 */
+	fpinfo = (CHFdwRelationInfo *) palloc0(sizeof(CHFdwRelationInfo));
+	fpinfo->pushdown_safe = false;
+	joinrel->fdw_private = fpinfo;
+	/* attrs_used is only for base relations. */
+	fpinfo->attrs_used = NULL;
+	epq_path = NULL;
+
+	if (!foreign_join_ok(root, joinrel, jointype, outerrel, innerrel, extra))
+	{
+		/* Free path required for EPQ if we copied one; we don't need it now */
+		if (epq_path)
+			pfree(epq_path);
+
+		return;
+	}
+
+	/*
+	 * Compute the selectivity and cost of the local_conds, so we don't have
+	 * to do it over again for each path. The best we can do for these
+	 * conditions is to estimate selectivity on the basis of local statistics.
+	 * The local conditions are applied after the join has been computed on
+	 * the remote side like quals in WHERE clause, so pass jointype as
+	 * JOIN_INNER.
+	 */
+	fpinfo->local_conds_sel = clauselist_selectivity(root,
+													 fpinfo->local_conds,
+													 0,
+													 JOIN_INNER,
+													 NULL);
+	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
+
+	/*
+	 * If we are going to estimate costs locally, estimate the join clause
+	 * selectivity here while we have special join info.
+	 */
+	if (!fpinfo->use_remote_estimate)
+		fpinfo->joinclause_sel = clauselist_selectivity(root, fpinfo->joinclauses,
+														0, fpinfo->jointype,
+														extra->sjinfo);
+
+	/* Estimate costs for bare join relation */
+	estimate_path_cost_size(&rows, &width, &startup_cost, &total_cost, 0);
+	/* Now update this information in the joinrel */
+	joinrel->rows = rows;
+	joinrel->reltarget->width = width;
+	fpinfo->rows = rows;
+	fpinfo->width = width;
+	fpinfo->startup_cost = startup_cost;
+	fpinfo->total_cost = total_cost;
+
+	/*
+	 * Create a new join path and add it to the joinrel which represents a
+	 * join between foreign tables.
+	 */
+	joinpath = create_foreign_join_path(root,
+										joinrel,
+										NULL,	/* default pathtarget */
+										rows,
+										startup_cost,
+										total_cost,
+										NIL,	/* no pathkeys */
+										NULL,
+										epq_path,
+#if PG_VERSION_NUM >= 170000
+										NIL,
+#endif
+										NIL);	/* no fdw_private */
+
+	/* Add generated path into joinrel by add_path(). */
+	add_path(joinrel, (Path *) joinpath);
+
+	/* Consider pathkeys for the join relation */
+	add_paths_with_pathkeys_for_rel(root, joinrel, epq_path);
+
+	gettimeofday(&time2, NULL);
+	time_used += time_diff(&time1, &time2);
+}
+
+/*
+ * Assess whether the aggregation, grouping and having operations can be pushed
+ * down to the foreign server.  As a side effect, save information we obtain in
+ * this function to CHFdwRelationInfo of the input relation.
+ */
+static bool
+foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
+                    Node *havingQual)
+{
+	Query	   *query = root->parse;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) grouped_rel->fdw_private;
+	PathTarget *grouping_target = grouped_rel->reltarget;
+	CHFdwRelationInfo *ofpinfo;
+	List	   *aggvars;
+	ListCell   *lc;
+	int			i;
+	List	   *tlist = NIL;
+
+	/* We currently don't support pushing Grouping Sets. */
+	if (query->groupingSets)
+		return false;
+
+	/* Get the fpinfo of the underlying scan relation. */
+	ofpinfo = (CHFdwRelationInfo *) fpinfo->outerrel->fdw_private;
+
+	/*
+	 * If underlying scan relation has any local conditions, those conditions
+	 * are required to be applied before performing aggregation.  Hence the
+	 * aggregate cannot be pushed down.
+	 */
+	if (ofpinfo->local_conds)
+		return false;
+
+	/*
+	 * Examine grouping expressions, as well as other expressions we'd need to
+	 * compute, and check whether they are safe to push down to the foreign
+	 * server.  All GROUP BY expressions will be part of the grouping target
+	 * and thus there is no need to search for them separately.  Add grouping
+	 * expressions into target list which will be passed to foreign server.
+	 */
+	i = 0;
+	foreach(lc, grouping_target->exprs)
+	{
+		Expr	   *expr = (Expr *) lfirst(lc);
+		Index		sgref = get_pathtarget_sortgroupref(grouping_target, i);
+		ListCell   *l;
+
+		/* Check whether this expression is part of GROUP BY clause */
+		if (sgref && get_sortgroupref_clause_noerr(sgref, query->groupClause))
+		{
+			TargetEntry *tle;
+
+			/*
+			 * If any GROUP BY expression is not shippable, then we cannot
+			 * push down aggregation to the foreign server.
+			 */
+			if (!chfdw_is_foreign_expr(root, grouped_rel, expr))
+				return false;
+
+			/*
+			 * Pushable, so add to tlist.  We need to create a TLE for this
+			 * expression and apply the sortgroupref to it.  We cannot use
+			 * add_to_flat_tlist() here because that avoids making duplicate
+			 * entries in the tlist.  If there are duplicate entries with
+			 * distinct sortgrouprefs, we have to duplicate that situation in
+			 * the output tlist.
+			 */
+			tle = makeTargetEntry(expr, list_length(tlist) + 1, NULL, false);
+			tle->ressortgroupref = sgref;
+			tlist = lappend(tlist, tle);
+		}
+		else
+		{
+			/*
+			 * Non-grouping expression we need to compute.  Is it shippable?
+			 */
+			if (chfdw_is_foreign_expr(root, grouped_rel, expr))
+			{
+				/* Yes, so add to tlist as-is; OK to suppress duplicates */
+				tlist = add_to_flat_tlist(tlist, list_make1(expr));
+			}
+			else
+			{
+				/* Not pushable as a whole; extract its Vars and aggregates */
+				aggvars = pull_var_clause((Node *) expr,
+				                          PVC_INCLUDE_AGGREGATES);
+
+				/*
+				 * If any aggregate expression is not shippable, then we
+				 * cannot push down aggregation to the foreign server.
+				 */
+				if (!chfdw_is_foreign_expr(root, grouped_rel, (Expr *) aggvars))
+					return false;
+
+				/*
+				 * Add aggregates, if any, into the targetlist.  Plain Vars
+				 * outside an aggregate can be ignored, because they should be
+				 * either same as some GROUP BY column or part of some GROUP
+				 * BY expression.  In either case, they are already part of
+				 * the targetlist and thus no need to add them again.  In fact
+				 * including plain Vars in the tlist when they do not match a
+				 * GROUP BY column would cause the foreign server to complain
+				 * that the shipped query is invalid.
+				 */
+				foreach(l, aggvars)
+				{
+					Expr	*first_expr = (Expr *) lfirst(l);
+
+					if (IsA(first_expr, Aggref))
+						tlist = add_to_flat_tlist(tlist, list_make1(first_expr));
+				}
+			}
+		}
+
+		i++;
+	}
+
+	/*
+	 * Classify the pushable and non-pushable HAVING clauses and save them in
+	 * remote_conds and local_conds of the grouped rel's fpinfo.
+	 */
+	if (havingQual)
+	{
+		ListCell   *having_lc;
+
+		foreach(having_lc, (List *) havingQual)
+		{
+			Expr	   *expr = (Expr *) lfirst(having_lc);
+			RestrictInfo *rinfo;
+
+			/*
+			 * Currently, the core code doesn't wrap havingQuals in
+			 * RestrictInfos, so we must make our own.
+			 */
+			Assert(!IsA(expr, RestrictInfo));
+			rinfo = make_restrictinfo(
+#if PG_VERSION_NUM >= 140000
+									  root,
+#endif
+									  expr,
+									  true,
+									  false,
+#if PG_VERSION_NUM >= 160000
+									  false,
+#endif
+									  false,
+									  root->qual_security_level,
+									  grouped_rel->relids,
+									  NULL,
+									  NULL);
+			if (chfdw_is_foreign_expr(root, grouped_rel, expr))
+				fpinfo->remote_conds = lappend(fpinfo->remote_conds, rinfo);
+			else
+				fpinfo->local_conds = lappend(fpinfo->local_conds, rinfo);
+		}
+	}
+
+	/*
+	 * If there are any local conditions, pull Vars and aggregates from it and
+	 * check whether they are safe to pushdown or not.
+	 */
+	if (fpinfo->local_conds)
+	{
+		List	   *local_aggvars = NIL;
+		ListCell   *agg_lc;
+
+		foreach(agg_lc, fpinfo->local_conds)
+		{
+			RestrictInfo *rinfo = lfirst_node(RestrictInfo, agg_lc);
+
+			local_aggvars = list_concat(local_aggvars,
+								  pull_var_clause((Node *) rinfo->clause,
+												  PVC_INCLUDE_AGGREGATES));
+		}
+
+		foreach(agg_lc, local_aggvars)
+		{
+			Expr	   *expr = (Expr *) lfirst(agg_lc);
+
+			/*
+			 * If aggregates within local conditions are not safe to push
+			 * down, then we cannot push down the query.  Vars are already
+			 * part of GROUP BY clause which are checked above, so no need to
+			 * access them again here.
+			 */
+			if (IsA(expr, Aggref))
+			{
+				if (!chfdw_is_foreign_expr(root, grouped_rel, expr))
+					return false;
+
+				tlist = add_to_flat_tlist(tlist, list_make1(expr));
+			}
+		}
+	}
+
+	/* Store generated targetlist */
+	fpinfo->grouped_tlist = tlist;
+
+	/* Safe to pushdown */
+	fpinfo->pushdown_safe = true;
+
+	/*
+	 * Set cached relation costs to some negative value, so that we can detect
+	 * when they are set to some sensible costs, during one (usually the
+	 * first) of the calls to estimate_path_cost_size().
+	 */
+	fpinfo->rel_startup_cost = -1;
+	fpinfo->rel_total_cost = -1;
+
+	/*
+	 * Set the string describing this grouped relation to be used in EXPLAIN
+	 * output of corresponding ForeignScan.
+	 */
+	fpinfo->relation_name = makeStringInfo();
+	appendStringInfo(fpinfo->relation_name, "Aggregate on (%s)",
+					 ofpinfo->relation_name->data);
+
+	return true;
+}
+
+/*
+ * clickhouseGetForeignUpperPaths
+ *		Add paths for post-join operations like aggregation, grouping etc. if
+ *		corresponding operations are safe to push down.
+ *
+ * Right now, we only support aggregate, grouping and having clause pushdown.
+ */
+static void
+clickhouseGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
+                               RelOptInfo *input_rel, RelOptInfo *output_rel,
+                               void *extra)
+{
+	CHFdwRelationInfo *fpinfo;
+	struct timeval time1,time2;
+
+	gettimeofday(&time1, NULL);
+
+	/*
+	 * If input rel is not safe to pushdown, then simply return as we cannot
+	 * perform any post-join operations on the foreign server.
+	 */
+	if (!input_rel->fdw_private ||
+	        !((CHFdwRelationInfo *) input_rel->fdw_private)->pushdown_safe)
+		return;
+
+	/* Ignore stages we don't support; and skip any duplicate calls. */
+	if ((stage != UPPERREL_GROUP_AGG &&
+		 stage != UPPERREL_ORDERED &&
+		 stage != UPPERREL_FINAL) ||
+		output_rel->fdw_private)
+		return;
+
+	fpinfo = (CHFdwRelationInfo *) palloc0(sizeof(CHFdwRelationInfo));
+	fpinfo->pushdown_safe = false;
+	fpinfo->stage = stage;
+	output_rel->fdw_private = fpinfo;
+
+	switch (stage)
+	{
+		case UPPERREL_GROUP_AGG:
+			add_foreign_grouping_paths(root, input_rel, output_rel,
+									   (GroupPathExtraData *) extra);
+			break;
+		case UPPERREL_ORDERED:
+			add_foreign_ordered_paths(root, input_rel, output_rel);
+			break;
+		case UPPERREL_FINAL:
+			add_foreign_final_paths(root, input_rel, output_rel, extra);
+			break;
+		default:
+			elog(ERROR, "unexpected upper relation: %d", (int) stage);
+			break;
+	}
+
+	gettimeofday(&time2, NULL);
+	time_used += time_diff(&time1, &time2);
+}
+
+/*
+ * add_foreign_grouping_paths
+ *		Add foreign path for grouping and/or aggregation.
+ *
+ * Given input_rel represents the underlying scan.  The paths are added to the
+ * given grouped_rel.
+ */
+static void
+add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
+                           RelOptInfo *grouped_rel,
+                           GroupPathExtraData *extra)
+{
+	Query	   *parse = root->parse;
+	CHFdwRelationInfo *ifpinfo = input_rel->fdw_private;
+	CHFdwRelationInfo *fpinfo = grouped_rel->fdw_private;
+	ForeignPath *grouppath;
+	double		rows;
+	int			width;
+	Cost		startup_cost;
+	Cost		total_cost;
+
+	/* Nothing to be done, if there is no grouping or aggregation required. */
+	if (!parse->groupClause && !parse->groupingSets && !parse->hasAggs &&
+		!root->hasHavingQual)
+		return;
+
+	Assert(extra->patype == PARTITIONWISE_AGGREGATE_NONE ||
+		   extra->patype == PARTITIONWISE_AGGREGATE_FULL);
+
+	/* save the input_rel as outerrel in fpinfo */
+	fpinfo->outerrel = input_rel;
+
+	/*
+	 * Copy foreign table, foreign server, user mapping, FDW options etc.
+	 * details from the input relation's fpinfo.
+	 */
+	fpinfo->table = ifpinfo->table;
+	fpinfo->server = ifpinfo->server;
+	fpinfo->user = ifpinfo->user;
+	merge_fdw_options(fpinfo, ifpinfo, NULL);
+
+	/*
+	 * Assess if it is safe to push down aggregation and grouping.
+	 *
+	 * Use HAVING qual from extra. In case of child partition, it will have
+	 * translated Vars.
+	 */
+	if (!foreign_grouping_ok(root, grouped_rel, extra->havingQual))
+		return;
+
+	/* Estimate the cost of push down */
+	estimate_path_cost_size(&rows, &width, &startup_cost, &total_cost, 0.1);
+
+	/* Now update this information in the fpinfo */
+	fpinfo->rows = rows;
+	fpinfo->width = width;
+	fpinfo->startup_cost = startup_cost;
+	fpinfo->total_cost = total_cost;
+
+	/* Create and add foreign path to the grouping relation. */
+#if (PG_VERSION_NUM < 120000)
+	grouppath = create_foreignscan_path(root,
+	                                    grouped_rel,
+	                                    grouped_rel->reltarget,
+	                                    rows,
+	                                    startup_cost,
+	                                    total_cost,
+	                                    NIL,	/* no pathkeys */
+	                                    NULL,	/* no required_outer */
+	                                    NULL,
+	                                    NIL);	/* no fdw_private */
+#else
+	grouppath = create_foreign_upper_path(root,
+										  grouped_rel,
+										  grouped_rel->reltarget,
+										  rows,
+										  startup_cost,
+										  total_cost,
+										  NIL,	/* no pathkeys */
+										  NULL,
+#if PG_VERSION_NUM >= 170000
+										  NIL,
+#endif
+										  NIL); /* no fdw_private */
+#endif
+
+	/* Add generated path into grouped_rel by add_path(). */
+	add_path(grouped_rel, (Path *) grouppath);
+}
+
+/*
+ * add_foreign_ordered_paths
+ *		Add foreign paths for performing the final sort remotely.
+ *
+ * Given input_rel contains the source-data Paths.  The paths are added to the
+ * given ordered_rel.
+ */
+static void
+add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
+						  RelOptInfo *ordered_rel)
+{
+	Query	   *parse = root->parse;
+	CHFdwRelationInfo *ifpinfo = input_rel->fdw_private;
+	CHFdwRelationInfo *fpinfo = ordered_rel->fdw_private;
+	ChFdwPathExtraData *fpextra;
+	double		rows;
+	int			width;
+	Cost		startup_cost;
+	Cost		total_cost;
+	List	   *fdw_private;
+	ForeignPath *ordered_path;
+	ListCell   *lc;
+
+	/* Shouldn't get here unless the query has ORDER BY */
+	Assert(parse->sortClause);
+
+	/* We don't support cases where there are any SRFs in the targetlist */
+	if (parse->hasTargetSRFs)
+		return;
+
+	/* Save the input_rel as outerrel in fpinfo */
+	fpinfo->outerrel = input_rel;
+
+	/*
+	 * Copy foreign table, foreign server, user mapping, FDW options etc.
+	 * details from the input relation's fpinfo.
+	 */
+	fpinfo->table = ifpinfo->table;
+	fpinfo->server = ifpinfo->server;
+	fpinfo->user = ifpinfo->user;
+	merge_fdw_options(fpinfo, ifpinfo, NULL);
+
+	/*
+	 * If the input_rel is a base or join relation, we would already have
+	 * considered pushing down the final sort to the remote server when
+	 * creating pre-sorted foreign paths for that relation, because the
+	 * query_pathkeys is set to the root->sort_pathkeys in that case (see
+	 * standard_qp_callback()).
+	 */
+	if (input_rel->reloptkind == RELOPT_BASEREL ||
+		input_rel->reloptkind == RELOPT_JOINREL)
+	{
+		Assert(root->query_pathkeys == root->sort_pathkeys);
+
+		/* Safe to push down if the query_pathkeys is safe to push down */
+		fpinfo->pushdown_safe = ifpinfo->qp_is_pushdown_safe;
+
+		return;
+	}
+
+	/* The input_rel should be a grouping relation */
+	Assert(input_rel->reloptkind == RELOPT_UPPER_REL &&
+		   ifpinfo->stage == UPPERREL_GROUP_AGG);
+
+	/*
+	 * We try to create a path below by extending a simple foreign path for
+	 * the underlying grouping relation to perform the final sort remotely,
+	 * which is stored into the fdw_private list of the resulting path.
+	 */
+
+	/* Assess if it is safe to push down the final sort */
+	foreach(lc, root->sort_pathkeys)
+	{
+		PathKey    *pathkey = (PathKey *) lfirst(lc);
+		EquivalenceClass *pathkey_ec = pathkey->pk_eclass;
+		Expr	   *sort_expr;
+
+		/*
+		 * chfdw_is_foreign_expr would detect volatile expressions as well, but
+		 * checking ec_has_volatile here saves some cycles.
+		 */
+		if (pathkey_ec->ec_has_volatile)
+			return;
+
+		/* Get the sort expression for the pathkey_ec */
+		sort_expr = chfdw_find_em_expr_for_input_target(root,
+												  pathkey_ec,
+												  input_rel->reltarget);
+
+		/* If it's unsafe to remote, we cannot push down the final sort */
+		if (!chfdw_is_foreign_expr(root, input_rel, sort_expr))
+			return;
+	}
+
+	/* Safe to push down */
+	fpinfo->pushdown_safe = true;
+
+	/* Construct ChFdwPathExtraData */
+	fpextra = (ChFdwPathExtraData *) palloc0(sizeof(ChFdwPathExtraData));
+	fpextra->target = root->upper_targets[UPPERREL_ORDERED];
+	fpextra->has_final_sort = true;
+
+	estimate_path_cost_size(&rows, &width, &startup_cost, &total_cost, 0.1);
+
+	/*
+	 * Build the fdw_private list that will be used by postgresGetForeignPlan.
+	 * Items in the list must match order in enum FdwPathPrivateIndex.
+	 */
+	fdw_private = list_make2(makeInteger(true), makeInteger(false));
+
+	/* Create foreign ordering path */
+#if (PG_VERSION_NUM < 120000)
+	ordered_path = create_foreignscan_path(root,
+											input_rel,
+											root->upper_targets[UPPERREL_ORDERED],
+											rows,
+											startup_cost,
+											total_cost,
+											root->sort_pathkeys,
+											NULL,	/* no required_outer */
+											NULL,
+											fdw_private);
+#else
+	ordered_path = create_foreign_upper_path(root,
+											 input_rel,
+											 root->upper_targets[UPPERREL_ORDERED],
+											 rows,
+											 startup_cost,
+											 total_cost,
+											 root->sort_pathkeys,
+											 NULL,	/* no extra plan */
+#if PG_VERSION_NUM >= 170000
+											 NIL,
+#endif
+											 fdw_private);
+#endif
+
+	/* and add it to the ordered_rel */
+	add_path(ordered_rel, (Path *) ordered_path);
+}
+
+/*
+ * add_foreign_final_paths
+ *		Add foreign paths for performing the final processing remotely.
+ *
+ * Given input_rel contains the source-data Paths.  The paths are added to the
+ * given final_rel.
+ */
+static void
+add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
+						RelOptInfo *final_rel,
+						void *fextra)
+{
+#if (PG_VERSION_NUM < 120000)
+	// final paths supported only on pg >= v12
+	return;
+#else
+	Query	   *parse = root->parse;
+	CHFdwRelationInfo *ifpinfo = (CHFdwRelationInfo *) input_rel->fdw_private;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) final_rel->fdw_private;
+	bool		has_final_sort = false;
+	List	   *pathkeys = NIL;
+	ChFdwPathExtraData *fpextra;
+	List	   *fdw_private;
+	ForeignPath *final_path;
+	FinalPathExtraData *extra = (FinalPathExtraData *) fextra;
+
+	/*
+	 * Currently, we only support this for SELECT commands
+	 */
+	if (parse->commandType != CMD_SELECT)
+		return;
+
+	/*
+	 * No work if there is no FOR UPDATE/SHARE clause and if there is no need
+	 * to add a LIMIT node
+	 */
+	if (!extra->limit_needed)
+		return;
+
+	/* We don't support cases where there are any SRFs in the targetlist */
+	if (parse->hasTargetSRFs)
+		return;
+
+	/* Save the input_rel as outerrel in fpinfo */
+	fpinfo->outerrel = input_rel;
+
+	/*
+	 * Copy foreign table, foreign server, user mapping, FDW options etc.
+	 * details from the input relation's fpinfo.
+	 */
+	fpinfo->table = ifpinfo->table;
+	fpinfo->server = ifpinfo->server;
+	fpinfo->user = ifpinfo->user;
+	merge_fdw_options(fpinfo, ifpinfo, NULL);
+
+	Assert(extra->limit_needed);
+
+	/*
+	 * If the input_rel is an ordered relation, replace the input_rel with its
+	 * input relation
+	 */
+	if (input_rel->reloptkind == RELOPT_UPPER_REL &&
+		ifpinfo->stage == UPPERREL_ORDERED)
+	{
+		input_rel = ifpinfo->outerrel;
+		ifpinfo = (CHFdwRelationInfo *) input_rel->fdw_private;
+		has_final_sort = true;
+		pathkeys = root->sort_pathkeys;
+	}
+
+	/* The input_rel should be a base, join, or grouping relation */
+	Assert(input_rel->reloptkind == RELOPT_BASEREL ||
+		   input_rel->reloptkind == RELOPT_JOINREL ||
+		   (input_rel->reloptkind == RELOPT_UPPER_REL &&
+			ifpinfo->stage == UPPERREL_GROUP_AGG));
+
+	/*
+	 * We try to create a path below by extending a simple foreign path for
+	 * the underlying base, join, or grouping relation to perform the final
+	 * sort (if has_final_sort) and the LIMIT restriction remotely, which is
+	 * stored into the fdw_private list of the resulting path.  (We
+	 * re-estimate the costs of sorting the underlying relation, if
+	 * has_final_sort.)
+	 */
+
+	/*
+	 * Assess if it is safe to push down the LIMIT and OFFSET to the remote
+	 * server
+	 */
+
+	/*
+	 * If the underlying relation has any local conditions, the LIMIT/OFFSET
+	 * cannot be pushed down.
+	 */
+	if (ifpinfo->local_conds)
+		return;
+
+	/*
+	 * Also, the LIMIT/OFFSET cannot be pushed down, if their expressions are
+	 * not safe to remote.
+	 */
+	if (!chfdw_is_foreign_expr(root, input_rel, (Expr *) parse->limitOffset) ||
+		!chfdw_is_foreign_expr(root, input_rel, (Expr *) parse->limitCount))
+		return;
+
+	/* Safe to push down */
+	fpinfo->pushdown_safe = true;
+
+	/* Construct ChFdwPathExtraData */
+	fpextra = (ChFdwPathExtraData *) palloc0(sizeof(ChFdwPathExtraData));
+	fpextra->target = root->upper_targets[UPPERREL_FINAL];
+	fpextra->has_final_sort = has_final_sort;
+	fpextra->has_limit = extra->limit_needed;
+	fpextra->limit_tuples = extra->limit_tuples;
+	fpextra->count_est = extra->count_est;
+	fpextra->offset_est = extra->offset_est;
+	ifpinfo->use_remote_estimate = false;
+
+	/*
+	 * Build the fdw_private list that will be used by postgresGetForeignPlan.
+	 * Items in the list must match order in enum FdwPathPrivateIndex.
+	 */
+	fdw_private = list_make2(makeInteger(has_final_sort),
+							 makeInteger(extra->limit_needed));
+
+	/*
+	 * Create foreign final path; this gets rid of a no-longer-needed outer
+	 * plan (if any), which makes the EXPLAIN output look cleaner
+	 */
+	final_path = create_foreign_upper_path(root,
+										   input_rel,
+										   root->upper_targets[UPPERREL_FINAL],
+										   1,
+										   0,
+										   -10,
+										   pathkeys,
+										   NULL,	/* no extra plan */
+#if PG_VERSION_NUM >= 170000
+										   NIL,
+#endif
+										   fdw_private);
+
+	/* and add it to the final_rel */
+	add_path(final_rel, (Path *) final_path);
+#endif
+}
+
+/*
+ * Find an equivalence class member expression, all of whose Vars, come from
+ * the indicated relation.
+ */
+Expr *
+chfdw_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
+{
+	ListCell   *lc_em;
+
+	foreach(lc_em, ec->ec_members)
+	{
+		EquivalenceMember *em = lfirst(lc_em);
+
+		if (bms_is_subset(em->em_relids, rel->relids) &&
+			!bms_is_empty(em->em_relids))
+		{
+			/*
+			 * If there is more than one equivalence member whose Vars are
+			 * taken entirely from this relation, we'll be content to choose
+			 * any one of those.
+			 */
+			return em->em_expr;
+		}
+	}
+
+	/* We didn't find any suitable equivalence class expression */
+	return NULL;
+}
+
+/*
+ * Find an equivalence class member expression to be computed as a sort column
+ * in the given target.
+ */
+Expr *
+chfdw_find_em_expr_for_input_target(PlannerInfo *root,
+							  EquivalenceClass *ec,
+							  PathTarget *target)
+{
+	ListCell   *lc1;
+	int			i;
+
+	i = 0;
+	foreach(lc1, target->exprs)
+	{
+		Expr	   *expr = (Expr *) lfirst(lc1);
+		Index		sgref = get_pathtarget_sortgroupref(target, i);
+		ListCell   *lc2;
+
+		/* Ignore non-sort expressions */
+		if (sgref == 0 ||
+			get_sortgroupref_clause_noerr(sgref,
+										  root->parse->sortClause) == NULL)
+		{
+			i++;
+			continue;
+		}
+
+		/* We ignore binary-compatible relabeling on both ends */
+		while (expr && IsA(expr, RelabelType))
+			expr = ((RelabelType *) expr)->arg;
+
+		/* Locate an EquivalenceClass member matching this expr, if any */
+		foreach(lc2, ec->ec_members)
+		{
+			EquivalenceMember *em = (EquivalenceMember *) lfirst(lc2);
+			Expr	   *em_expr;
+
+			/* Don't match constants */
+			if (em->em_is_const)
+				continue;
+
+			/* Ignore child members */
+			if (em->em_is_child)
+				continue;
+
+			/* Match if same expression (after stripping relabel) */
+			em_expr = em->em_expr;
+			while (em_expr && IsA(em_expr, RelabelType))
+				em_expr = ((RelabelType *) em_expr)->arg;
+
+			if (equal(em_expr, expr))
+				return em->em_expr;
+		}
+
+		i++;
+	}
+
+	elog(ERROR, "could not find pathkey item to sort");
+	return NULL;				/* keep compiler quiet */
+}
+
+static List *
+clickhouseImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
+{
+	ForeignServer       *server;
+
+	server = GetForeignServer(serverOid);
+	return chfdw_construct_create_tables(stmt, server);
+}
+
+
+/*
+ * Foreign-data wrapper handler function: return a struct with pointers
+ * to my callback routines.
+ */
+Datum
+clickhouse_fdw_handler(PG_FUNCTION_ARGS)
+{
+	FdwRoutine *routine = makeNode(FdwRoutine);
+
+	/* Functions for scanning foreign tables */
+	routine->GetForeignRelSize = clickhouseGetForeignRelSize;
+	routine->GetForeignPaths = clickhouseGetForeignPaths;
+	routine->GetForeignPlan = clickhouseGetForeignPlan;
+	routine->BeginForeignScan = clickhouseBeginForeignScan;
+	routine->IterateForeignScan = clickhouseIterateForeignScan;
+	routine->ReScanForeignScan = clickhouseEndForeignScan;
+	routine->EndForeignScan = clickhouseEndForeignScan;
+
+	/* Functions for updating foreign tables */
+	routine->PlanForeignModify = clickhousePlanForeignModify;
+	routine->BeginForeignModify = clickhouseBeginForeignModify;
+	routine->ExecForeignInsert = clickhouseExecForeignInsert;
+	routine->BeginForeignInsert = clickhouseBeginForeignInsert;
+
+	routine->EndForeignInsert = clickhouseEndForeignInsert;
+	routine->EndForeignModify = clickhouseEndForeignInsert;
+
+	/* Function for EvalPlanQual rechecks */
+	routine->RecheckForeignScan = clickhouseRecheckForeignScan;
+
+	/* Support functions for EXPLAIN */
+	routine->ExplainForeignScan = clickhouseExplainForeignScan;
+
+	/* Support functions for ANALYZE */
+	routine->AnalyzeForeignTable = clickhouseAnalyzeForeignTable;
+
+	/* Support functions for join push-down */
+	routine->GetForeignJoinPaths = clickhouseGetForeignJoinPaths;
+
+	/* Support functions for upper relation push-down */
+	routine->GetForeignUpperPaths = clickhouseGetForeignUpperPaths;
+
+	/* IMPORT FOREIGN SCHEMA */
+	routine->ImportForeignSchema = clickhouseImportForeignSchema;
+
+	PG_RETURN_POINTER(routine);
+}
+
+Datum
+clickhouse_mock(PG_FUNCTION_ARGS)
+{
+	elog(ERROR, "clickhouse_fdw: mocked function should be pushed down");
 }

--- a/src/http.c
+++ b/src/http.c
@@ -1,0 +1,220 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+#include <uuid/uuid.h>
+#include <http.h>
+#include <internal.h>
+
+static char curl_error_buffer[CURL_ERROR_SIZE];
+static bool curl_error_happened = false;
+static long	curl_verbose = 0;
+static void *curl_progressfunc = NULL;
+static bool curl_initialized = false;
+static char ch_query_id_prefix[5];
+
+void ch_http_init(int verbose, uint32_t query_id_prefix)
+{
+	curl_verbose = verbose;
+	snprintf(ch_query_id_prefix, 5, "%x", query_id_prefix);
+
+	if (!curl_initialized)
+	{
+		curl_initialized = true;
+		curl_global_init(CURL_GLOBAL_ALL);
+	}
+}
+
+void ch_http_set_progress_func(void *progressfunc)
+{
+	curl_progressfunc = progressfunc;
+}
+
+static size_t write_data(void *contents, size_t size, size_t nmemb, void *userp)
+{
+	size_t realsize			= size * nmemb;
+	ch_http_response_t *res	= userp;
+
+	if (res->data == NULL)
+		res->data = malloc(realsize + 1);
+	else
+		res->data = realloc(res->data, res->datasize + realsize + 1);
+
+	memcpy(&(res->data[res->datasize]), contents, realsize);
+	res->datasize += realsize;
+	res->data[res->datasize] = 0;
+
+	return realsize;
+}
+
+ch_http_connection_t *ch_http_connection(char *host, int port, char *username, char *password)
+{
+	int n;
+	char *connstring = NULL;
+	size_t len = 20; /* all symbols from url string + some extra */
+
+	curl_error_happened = false;
+	ch_http_connection_t *conn = calloc(sizeof(ch_http_connection_t), 1);
+	if (!conn)
+		goto cleanup;
+
+	conn->curl = curl_easy_init();
+	if (!conn->curl)
+		goto cleanup;
+
+	len += strlen(host) + snprintf(NULL, 0, "%d", port);
+
+	if (username) {
+		username = curl_easy_escape(conn->curl, username, 0);
+		len += strlen(username);
+	}
+
+	if (password) {
+		password = curl_easy_escape(conn->curl, password, 0);
+		len += strlen(password);
+	}
+
+	connstring = calloc(len, 1);
+	if (!connstring)
+		goto cleanup;
+
+	if (username && password)
+	{
+		n = snprintf(connstring, len, "http://%s:%s@%s:%d/", username, password, host, port);
+		curl_free(username);
+		curl_free(password);
+	}
+	else if (username)
+	{
+		n = snprintf(connstring, len, "http://%s@%s:%d/", username, host, port);
+		curl_free(username);
+	}
+	else
+		n = snprintf(connstring, len, "http://%s:%d/", host, port);
+
+	if (n < 0)
+		goto cleanup;
+
+	conn->base_url = connstring;
+	conn->base_url_len = strlen(conn->base_url);
+
+	return conn;
+
+cleanup:
+	snprintf(curl_error_buffer, CURL_ERROR_SIZE, "OOM");
+	curl_error_happened = true;
+	if (connstring)
+		free(connstring);
+
+	if (conn)
+		free(conn);
+
+	return NULL;
+}
+
+static void set_query_id(ch_http_response_t *resp)
+{
+	uuid_t	id;
+	uuid_generate(id);
+	uuid_unparse(id, resp->query_id);
+}
+
+ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char *query)
+{
+	char		*url;
+	CURLcode	errcode;
+	static char errbuffer[CURL_ERROR_SIZE];
+
+	ch_http_response_t	*resp = calloc(sizeof(ch_http_response_t), 1);
+	if (resp == NULL)
+		return NULL;
+
+	set_query_id(resp);
+
+	assert(conn && conn->curl);
+
+	/* construct url */
+	url = malloc(conn->base_url_len + 37 + 12 /* query_id + ?query_id= */);
+	sprintf(url, "%s?query_id=%s", conn->base_url, resp->query_id);
+
+	/* constant */
+	errbuffer[0] = '\0';
+	curl_easy_reset(conn->curl);
+	curl_easy_setopt(conn->curl, CURLOPT_WRITEFUNCTION, write_data);
+	curl_easy_setopt(conn->curl, CURLOPT_ERRORBUFFER, errbuffer);
+	curl_easy_setopt(conn->curl, CURLOPT_PATH_AS_IS, 1L);
+	curl_easy_setopt(conn->curl, CURLOPT_URL, url);
+	curl_easy_setopt(conn->curl, CURLOPT_NOSIGNAL, 1L);
+
+	/* variable */
+	curl_easy_setopt(conn->curl, CURLOPT_WRITEDATA, resp);
+	curl_easy_setopt(conn->curl, CURLOPT_POSTFIELDS, query);
+	curl_easy_setopt(conn->curl, CURLOPT_VERBOSE, curl_verbose);
+	if (curl_progressfunc)
+	{
+		curl_easy_setopt(conn->curl, CURLOPT_NOPROGRESS, 0L);
+		curl_easy_setopt(conn->curl, CURLOPT_XFERINFOFUNCTION, curl_progressfunc);
+		curl_easy_setopt(conn->curl, CURLOPT_XFERINFODATA, conn);
+	}
+	else
+		curl_easy_setopt(conn->curl, CURLOPT_NOPROGRESS, 1L);
+
+	curl_error_happened = false;
+	errcode = curl_easy_perform(conn->curl);
+	free(url);
+
+	if (errcode == CURLE_ABORTED_BY_CALLBACK)
+	{
+		resp->http_status = 418; /* I'm teapot */
+		return resp;
+	}
+	else if (errcode != CURLE_OK)
+	{
+		resp->http_status = 419; /* unlegal http status */
+		resp->data = strdup(errbuffer);
+		resp->datasize = strlen(errbuffer);
+		return resp;
+	}
+
+	errcode = curl_easy_getinfo(conn->curl, CURLINFO_PRETRANSFER_TIME,
+			&resp->pretransfer_time);
+	if (errcode != CURLE_OK)
+		resp->pretransfer_time = 0;
+
+	errcode = curl_easy_getinfo(conn->curl, CURLINFO_TOTAL_TIME, &resp->total_time);
+	if (errcode != CURLE_OK)
+		resp->total_time = 0;
+
+	// all good with request, but we need http status to make sure
+	// query went ok
+	curl_easy_getinfo(conn->curl, CURLINFO_RESPONSE_CODE, &resp->http_status);
+	if (curl_verbose && resp->http_status != 200)
+		fprintf(stderr, "%s", resp->data);
+
+	return resp;
+}
+
+void ch_http_close(ch_http_connection_t *conn)
+{
+	free(conn->base_url);
+	curl_easy_cleanup(conn->curl);
+}
+
+char *ch_http_last_error(void)
+{
+	if (curl_error_happened)
+		return curl_error_buffer;
+
+	return NULL;
+}
+
+void ch_http_response_free(ch_http_response_t *resp)
+{
+	if (resp->data)
+		free(resp->data);
+
+	free(resp);
+}

--- a/src/include/binary.hh
+++ b/src/include/binary.hh
@@ -1,9 +1,6 @@
 #ifndef CLICKHOUSE_BINARY_H
 #define CLICKHOUSE_BINARY_H
 
-#include "postgres.h"
-#include "funcapi.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -92,4 +89,4 @@ void ch_binary_do_output_convertion(ch_binary_insert_state *insert_state,
 }
 #endif
 
-#endif
+#endif   /* CLICKHOUSE_BINARY_H */

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -1,0 +1,56 @@
+#ifndef CLICKHOUSE_HTTP_H
+#define CLICKHOUSE_HTTP_H
+
+#include "postgres.h"
+#include "nodes/pg_list.h"
+#include "lib/stringinfo.h"
+
+typedef struct ch_http_connection_t ch_http_connection_t;
+typedef struct ch_http_response_t
+{
+	char			   *data;
+	size_t				datasize;
+	long				http_status;
+	char				query_id[37];
+	double				pretransfer_time;
+	double				total_time;
+} ch_http_response_t;
+
+typedef enum
+{
+	CH_CONT,
+	CH_EOL,
+	CH_EOF
+} ch_read_status;
+
+typedef struct {
+	char   *data;
+	size_t	buflen;
+	size_t	curpos;
+	size_t	maxpos;
+	char   *val;
+	bool	done;
+} ch_http_read_state;
+
+typedef struct {
+	StringInfoData	sql;
+	char		   *sql_begin;		/* beginning part of constructed sql */
+	List		   *target_attrs;	/* list of target attribute numbers */
+	int				p_nums;			/* number of parameters to transmit */
+	ch_http_connection_t *conn;
+} ch_http_insert_state;
+
+void ch_http_init(int verbose, uint32_t query_id_prefix);
+void ch_http_set_progress_func(void *progressfunc);
+ch_http_connection_t *ch_http_connection(char *, int, char *, char *);
+void ch_http_close(ch_http_connection_t *conn);
+ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char *query);
+char *ch_http_last_error(void);
+
+/* read */
+void ch_http_read_state_init(ch_http_read_state *state, char *data, size_t datalen);
+void ch_http_read_state_free(ch_http_read_state *state);
+int ch_http_read_next(ch_http_read_state *state);
+void ch_http_response_free(ch_http_response_t *resp);
+
+#endif  /* CLICKHOUSE_HTTP_H */

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -17,4 +17,4 @@ typedef struct ch_binary_connection_t
 	char			  *error;
 } ch_binary_connection_t;
 
-#endif
+#endif /* CLICKHOUSE_INTERNAL_H */

--- a/src/option.c
+++ b/src/option.c
@@ -1,0 +1,287 @@
+/*-------------------------------------------------------------------------
+ *
+ * option.c
+ *		  FDW option handling for clickhouse_fdw
+ *
+ * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2019-2022, Adjust GmbH
+ * Copyright (c) 2025, ClickHouse, Inc.
+ *
+ * IDENTIFICATION
+ *		  github.com/clickhouse/clickhouse_fdw/src/option.c
+*
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "fdw.h"
+
+#include "access/reloptions.h"
+#include "catalog/pg_foreign_server.h"
+#include "catalog/pg_foreign_table.h"
+#include "catalog/pg_user_mapping.h"
+#include "commands/defrem.h"
+#include "commands/extension.h"
+#include "utils/builtins.h"
+#include "utils/varlena.h"
+
+static char *DEFAULT_DBNAME = "default";
+
+
+/*
+ * Describes the valid options for objects that this wrapper uses.
+ */
+typedef struct ChFdwOption
+{
+	const char *keyword;
+	Oid			optcontext;		/* OID of catalog in which option may appear */
+	bool		is_ch_opt;	  /* true if it's used in clickhouseclient */
+	char    dispchar[10];
+} ChFdwOption;
+
+/*
+ * Valid options for clickhouse_fdw.
+ * Allocated and filled in InitChFdwOptions.
+ */
+static ChFdwOption *clickhouse_fdw_options;
+
+/*
+ * Valid options for clickhouseclient.
+ * Allocated and filled in InitChFdwOptions.
+ */
+static const ChFdwOption ch_options[] =
+{
+	{"host", 0, false},
+	{"port", 0, false},
+	{"dbname", 0, false},
+	{"user", 0, false},
+	{"password", 0, false},
+	{NULL}
+};
+
+/*
+ * Helper functions
+ */
+static void InitChFdwOptions(void);
+static bool is_valid_option(const char *keyword, Oid context);
+static bool is_ch_option(const char *keyword);
+
+/*
+ * Validate the generic options given to a FOREIGN DATA WRAPPER, SERVER,
+ * USER MAPPING or FOREIGN TABLE that uses clickhouse_fdw.
+ *
+ * Raise an ERROR if the option or its value is considered invalid.
+ */
+PG_FUNCTION_INFO_V1(clickhouse_fdw_validator);
+
+Datum
+clickhouse_fdw_validator(PG_FUNCTION_ARGS)
+{
+	List	   *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
+	Oid			catalog = PG_GETARG_OID(1);
+	ListCell   *cell;
+
+	/* Build our options lists if we didn't yet. */
+	InitChFdwOptions();
+
+	/*
+	 * Check that only options supported by clickhouse_fdw, and allowed for the
+	 * current object type, are given.
+	 */
+	foreach (cell, options_list)
+	{
+		DefElem    *def = (DefElem *) lfirst(cell);
+
+		if (!is_valid_option(def->defname, catalog))
+		{
+			/*
+			 * Unknown option specified, complain about it. Provide a hint
+			 * with list of valid options for the object.
+			 */
+			ChFdwOption *opt;
+			StringInfoData buf;
+
+			initStringInfo(&buf);
+			for (opt = clickhouse_fdw_options; opt->keyword; opt++)
+			{
+				if (catalog == opt->optcontext)
+					appendStringInfo(&buf, "%s%s", (buf.len > 0) ? ", " : "",
+									 opt->keyword);
+			}
+
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+					 errmsg("invalid option \"%s\"", def->defname),
+					 errhint("Valid options in this context are: %s",
+							 buf.data)));
+		}
+	}
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * Initialize option lists.
+ */
+static void
+InitChFdwOptions(void)
+{
+	int			num_ch_opts;
+	const ChFdwOption *lopt;
+	ChFdwOption *popt;
+
+	/* non-clickhouseclient FDW-specific FDW options */
+	static const ChFdwOption non_ch_options[] =
+	{
+		{"database", ForeignTableRelationId, false},
+		{"table_name", ForeignTableRelationId, false},
+		{"engine", ForeignTableRelationId, false},
+		{"driver", ForeignServerRelationId, false},
+		{"aggregatefunction", AttributeRelationId, false},
+		{"simpleaggregatefunction", AttributeRelationId, false},
+		{"column_name", AttributeRelationId, false},
+		{"arrays", AttributeRelationId, false},
+		{NULL, InvalidOid, false}
+	};
+
+	/* Prevent redundant initialization. */
+	if (clickhouse_fdw_options)
+	{
+		return;
+	}
+
+
+	/* Count how many clickhouseclient options are available. */
+	num_ch_opts = 0;
+	for (lopt = ch_options; lopt->keyword; lopt++)
+	{
+		num_ch_opts++;
+	}
+
+	/*
+	 * We use plain malloc here to allocate clickhouse_fdw_options because it
+	 * lives as long as the backend process does.  Besides, keeping
+	 * ch_options in memory allows us to avoid copying every keyword
+	 * string.
+	 */
+	clickhouse_fdw_options = (ChFdwOption *) malloc(sizeof(
+								   ChFdwOption) * num_ch_opts + sizeof(non_ch_options));
+	if (clickhouse_fdw_options == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
+				 errmsg("out of memory")));
+
+	popt = clickhouse_fdw_options;
+	for (lopt = ch_options; lopt->keyword; lopt++)
+	{
+		/* We don't have to copy keyword string, as described above. */
+		popt->keyword = lopt->keyword;
+
+		/*
+		 * "user" and any secret options are allowed only on user mappings.
+		 * Everything else is a server option.
+		 */
+		if (strcmp(lopt->keyword, "user") == 0 ||
+				strcmp(lopt->keyword, "password") == 0 ||
+				strchr(lopt->dispchar, '*'))
+		{
+			popt->optcontext = UserMappingRelationId;
+		}
+		else
+		{
+			popt->optcontext = ForeignServerRelationId;
+		}
+		popt->is_ch_opt = true;
+
+		popt++;
+	}
+
+	/* Append FDW-specific options and dummy terminator. */
+	memcpy(popt, non_ch_options, sizeof(non_ch_options));
+	popt->is_ch_opt = true;
+	popt++;
+}
+
+/*
+ * Check whether the given option is one of the valid clickhouse_fdw options.
+ * context is the Oid of the catalog holding the object the option is for.
+ */
+static bool
+is_valid_option(const char *keyword, Oid context)
+{
+	ChFdwOption *opt;
+
+	Assert(clickhouse_fdw_options);	/* must be initialized already */
+
+	for (opt = clickhouse_fdw_options; opt->keyword; opt++)
+	{
+		if (context == opt->optcontext && strcmp(opt->keyword, keyword) == 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Check whether the given option is one of the valid clickhouseclient options.
+ */
+static bool
+is_ch_option(const char *keyword)
+{
+	ChFdwOption *opt;
+
+	Assert(clickhouse_fdw_options);	/* must be initialized already */
+
+	for (opt = clickhouse_fdw_options; opt->keyword; opt++)
+	{
+		if (opt->is_ch_opt && strcmp(opt->keyword, keyword) == 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Generate key-value arrays which include only clickhouseclient options from the
+ * given list (which can contain any kind of options).  Caller must have
+ * allocated large-enough arrays.  Returns number of options found.
+ */
+void
+chfdw_extract_options(List *defelems, char **driver,  char **host, int *port,
+                         char **dbname, char **username, char **password)
+{
+	ListCell   *lc;
+
+	/* Build our options lists if we didn't yet. */
+	InitChFdwOptions();
+
+	foreach (lc, defelems)
+	{
+		DefElem *def = (DefElem *) lfirst(lc);
+
+		if (driver && strcmp(def->defname, "driver") == 0)
+			*driver = defGetString(def);
+
+		if (is_ch_option(def->defname))
+		{
+			if (host && strcmp(def->defname, "host") == 0)
+				*host = defGetString(def);
+			else if (port && strcmp(def->defname, "port") == 0)
+				*port = atoi(defGetString(def));
+			else if (username && strcmp(def->defname, "user") == 0)
+				*username = defGetString(def);
+			else if (password && strcmp(def->defname, "password") == 0)
+				*password = defGetString(def);
+			else if (dbname && strcmp(def->defname, "dbname") == 0)
+            {
+				*dbname = defGetString(def);
+                if (*dbname[0] == '\0')
+                    *dbname = DEFAULT_DBNAME;
+            }
+		}
+	}
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <curl/curl.h>
+
+#include <http.h>
+#include <internal.h>
+
+void ch_http_read_state_init(ch_http_read_state *state, char *data, size_t datalen)
+{
+	state->data = datalen > 0 ? data : NULL;
+	state->maxpos = datalen - 1;
+	state->buflen = 1024;
+	state->val = malloc(state->buflen);
+	state->done = false;
+}
+
+void ch_http_read_state_free(ch_http_read_state *state)
+{
+	free(state->val);
+}
+
+int ch_http_read_next(ch_http_read_state *state)
+{
+	size_t pos = state->curpos,
+		   len = 0;
+	char  *data = state->data;
+
+	state->val[0] = '\0';
+	if (state->done)
+		return CH_EOF;
+
+	while (pos < state->maxpos && data[pos] != '\t' && data[pos] != '\n')
+	{
+		if (data[pos] == '\\')
+		{
+			// unescape some sequences
+			switch (data[pos+1]) {
+				case '\\': state->val[len] = '\\'; break;
+				case '\'': state->val[len] = '\''; break;
+				case 'n': state->val[len] = '\n'; break;
+				case 't': state->val[len] = '\t'; break;
+				case '0': state->val[len] = '\0'; break;
+				case 'r': state->val[len] = '\r'; break;
+				case 'b': state->val[len] = '\b'; break;
+				case 'f': state->val[len] = '\f'; break;
+				default:
+					goto copy;
+			}
+			len++;
+			pos += 2;
+		}
+		else
+copy:
+			state->val[len++] = data[pos++];
+
+		/* extend the value size if needed */
+		if (len == state->buflen)
+		{
+			state->buflen *= 2;
+			state->val = realloc(state->val, state->buflen);
+		}
+	}
+
+	state->val[len] = '\0';
+	state->curpos = pos + 1;
+
+	if (data[pos] == '\t')
+		return CH_CONT;
+
+	assert(data[pos] == '\n');
+	int res = pos < state->maxpos ? CH_EOL : CH_EOF;
+	state->done = (res == CH_EOF);
+
+	return res;
+}

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -1,0 +1,1085 @@
+#include "postgres.h"
+
+#include "access/htup_details.h"
+#include "access/tupdesc.h"
+#include "catalog/pg_type_d.h"
+#include "funcapi.h"
+#include "mb/pg_wchar.h"
+#include "miscadmin.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_type.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "utils/timestamp.h"
+#include "utils/typcache.h"
+#include "utils/uuid.h"
+
+#include "fdw.h"
+#include "http.h"
+#include "binary.hh"
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static bool		initialized = false;
+
+static void http_disconnect(void *conn);
+static ch_cursor *http_simple_query(void *conn, const char *query);
+static void http_simple_insert(void *conn, const char *query);
+static void http_cursor_free(void *);
+static void **http_fetch_row(ch_cursor *, List *, TupleDesc, Datum *, bool *);
+static void *http_prepare_insert(void *, ResultRelInfo *, List *, char *, char *);
+static void http_insert_tuple(void *, TupleTableSlot *);
+
+static libclickhouse_methods http_methods = {
+	.disconnect=http_disconnect,
+	.simple_query=http_simple_query,
+	.fetch_row=http_fetch_row,
+	.prepare_insert=http_prepare_insert,
+	.insert_tuple=http_insert_tuple
+};
+
+static void binary_disconnect(void *conn);
+static ch_cursor *binary_simple_query(void *conn, const char *query);
+static void binary_cursor_free(void *cursor);
+// static void binary_simple_insert(void *conn, const char *query);
+static void **binary_fetch_row(ch_cursor *cursor, List* attrs, TupleDesc tupdesc,
+		Datum *values, bool *nulls);
+static void binary_insert_tuple(void *, TupleTableSlot *slot);
+static void *binary_prepare_insert(void *, ResultRelInfo *, List *,
+		char *query, char *table_name);
+
+static size_t escape_string(char *to, const char *from, size_t length);
+
+static libclickhouse_methods binary_methods = {
+	.disconnect=binary_disconnect,
+	.simple_query=binary_simple_query,
+	.fetch_row=binary_fetch_row,
+	.prepare_insert=binary_prepare_insert,
+	.insert_tuple=binary_insert_tuple
+};
+
+static int http_progress_callback(void *clientp, double dltotal, double dlnow,
+		double ultotal, double ulnow)
+{
+	if (ProcDiePending || QueryCancelPending)
+		return 1;
+
+	return 0;
+}
+
+static bool is_canceled(void)
+{
+	/* this variable is bool on pg < 12, but sig_atomic_t on above versions */
+	if (QueryCancelPending)
+		return true;
+
+	return false;
+}
+
+ch_connection
+chfdw_http_connect(ch_connection_details *details)
+{
+	ch_connection res;
+	ch_http_connection_t *conn = ch_http_connection(details->host, details->port,
+            details->username, details->password);
+	if (!initialized)
+	{
+		initialized = true;
+		ch_http_init(0, (uint32_t) MyProcPid);
+	}
+
+	if (conn == NULL)
+	{
+		char *error = ch_http_last_error();
+		if (error == NULL)
+			error = "undefined";
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("could not connect to server: %s", error)));
+	}
+
+	res.conn = conn;
+	res.methods = &http_methods;
+	res.is_binary = false;
+	return res;
+}
+
+/*
+ * Disconnect any open connection for a connection cache entry.
+ */
+static void
+http_disconnect(void *conn)
+{
+	if (conn != NULL)
+		ch_http_close((ch_http_connection_t *) conn);
+}
+
+/*
+ * Return text before version mentioning
+ */
+static char *
+format_error(char *errstring)
+{
+	int n = strlen(errstring);
+
+	for (int i = 0; i < n; i++)
+	{
+		if (strncmp(errstring + i, "version", 7) == 0)
+			return pnstrdup(errstring, i - 2);
+	}
+
+	return errstring;
+}
+
+static void
+kill_query(void *conn, const char *query_id)
+{
+	ch_http_response_t *resp;
+	char *query = psprintf("kill query where query_id='%s'", query_id);
+
+	ch_http_set_progress_func(NULL);
+	resp = ch_http_simple_query(conn, query);
+	if (resp != NULL)
+		ch_http_response_free(resp);
+	pfree(query);
+}
+
+static ch_cursor *
+http_simple_query(void *conn, const char *query)
+{
+	int			attempts = 0;
+	MemoryContext	tempcxt,
+					oldcxt;
+	ch_cursor	*cursor;
+	ch_http_response_t *resp;
+
+	ch_http_set_progress_func(http_progress_callback);
+
+again:
+	resp = ch_http_simple_query(conn, query);
+	if (resp == NULL)
+		elog(ERROR, "out of memory");
+
+	attempts++;
+	if (resp->http_status == 419)
+	{
+		char *error = pnstrdup(resp->data, resp->datasize);
+		ch_http_response_free(resp);
+
+		if (attempts < 3)
+			goto again;
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("clickhouse_fdw: communication error: %s", error)));
+	}
+	else if (resp->http_status == 418)
+	{
+		kill_query(conn, resp->query_id);
+		ch_http_response_free(resp);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+				 errmsg("clickhouse_fdw: query was aborted")));
+	}
+	else if (resp->http_status != 200)
+	{
+		char *error = pnstrdup(resp->data, resp->datasize);
+		ch_http_response_free(resp);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+				 errmsg("clickhouse_fdw:%s\nQUERY:%.10000s", format_error(error), query)));
+	}
+
+	/* we could not control properly deallocation of libclickhouse memory, so
+	 * we use memory context callbacks for that */
+	tempcxt = AllocSetContextCreate(PortalContext, "clickhouse_fdw cursor",
+										ALLOCSET_DEFAULT_SIZES);
+	oldcxt = MemoryContextSwitchTo(tempcxt);
+
+	cursor = palloc0(sizeof(ch_cursor));
+	cursor->query_response = resp;
+	cursor->read_state = palloc0(sizeof(ch_http_read_state));
+	cursor->query = pstrdup(query);
+	cursor->request_time = resp->pretransfer_time * 1000;
+	cursor->total_time = resp->total_time * 1000;
+	ch_http_read_state_init(cursor->read_state, resp->data, resp->datasize);
+
+	cursor->memcxt = tempcxt;
+	cursor->callback.func = http_cursor_free;
+	cursor->callback.arg = cursor;
+	MemoryContextRegisterResetCallback(tempcxt, &cursor->callback);
+	MemoryContextSwitchTo(oldcxt);
+
+	return cursor;
+}
+
+static void
+http_simple_insert(void *conn, const char *query)
+{
+	ch_http_response_t *resp = ch_http_simple_query(conn, query);
+	if (resp == NULL)
+	{
+		char *error = ch_http_last_error();
+		if (error == NULL)
+			error = "undefined";
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("clickhouse_fdw: communication error: %s", error)));
+	}
+
+	if (resp->http_status != 200)
+	{
+		char *error = pnstrdup(resp->data, resp->datasize);
+		ch_http_response_free(resp);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+				 errmsg("clickhouse_fdw:%s", format_error(error)),
+				 errdetail("query: %.1024s", query)));
+	}
+
+	ch_http_response_free(resp);
+}
+
+static void
+http_cursor_free(void *c)
+{
+	ch_cursor *cursor = c;
+
+	ch_http_read_state_free(cursor->read_state);
+	ch_http_response_free(cursor->query_response);
+}
+
+static void **
+http_fetch_row(ch_cursor *cursor, List *attrs, TupleDesc tupdesc, Datum *v, bool *n)
+{
+	int		rc = CH_CONT;
+	size_t	attcount = list_length(attrs);
+
+	if (attcount == 0)
+		/* SELECT NULL */
+		attcount = 1;
+
+	ch_http_read_state *state = cursor->read_state;
+
+	/* all rows or empty table */
+	if (state->done || state->data == NULL)
+		return NULL;
+
+	char **values = palloc(attcount * sizeof(char *));
+
+	for (int i=0; i < attcount; i++)
+	{
+		rc = ch_http_read_next(state);
+		if (state->val[0] == '\\' && state->val[1] == 'N')
+			values[i] = NULL;
+		else if (state->val[0] != '\0')
+			values[i] = pstrdup(state->val);
+		else
+			values[i] = NULL;
+	}
+
+	if (attcount > 0 && rc != CH_EOL && rc != CH_EOF)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg_internal("clickhouse_fdw: columns mismatch"),
+				 errdetail("Number of returned columns does not match "
+						   "expected column count (%lu).", attcount)));
+	}
+
+	return (void **) values;
+}
+
+text *
+chfdw_http_fetch_raw_data(ch_cursor *cursor)
+{
+	ch_http_read_state *state = cursor->read_state;
+	if (state->data == NULL)
+		return NULL;
+
+	return cstring_to_text_with_len(state->data, state->maxpos + 1);
+}
+
+/*
+ * extend_insert_query
+ *		Construct values part of INSERT query
+ */
+static void
+extend_insert_query(ch_http_insert_state *state, TupleTableSlot *slot)
+{
+	bool first = true;
+
+	if (state->sql.len == 0)
+		appendStringInfoString(&state->sql, state->sql_begin);
+
+	/* get following parameters from slot */
+	if (slot != NULL && state->target_attrs != NIL)
+	{
+		ListCell   *lc;
+
+		foreach (lc, state->target_attrs)
+		{
+			int			attnum = lfirst_int(lc);
+			Datum		value;
+			Oid			type;
+			bool		isnull;
+
+			value = slot_getattr(slot, attnum, &isnull);
+			type = TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1)->atttypid;
+
+			if (!first)
+				appendStringInfoChar(&state->sql, '\t');
+			first = false;
+
+			if (isnull)
+			{
+				appendStringInfoString(&state->sql, "\\N");
+				continue;
+			}
+
+			switch (type)
+			{
+			case BOOLOID:
+			case INT2OID:
+			case INT4OID:
+				appendStringInfo(&state->sql, "%d", DatumGetInt32(value));
+			break;
+			case INT8OID:
+				appendStringInfo(&state->sql, INT64_FORMAT, DatumGetInt64(value));
+			break;
+			case FLOAT4OID:
+				appendStringInfo(&state->sql, "%f", DatumGetFloat4(value));
+			break;
+			case FLOAT8OID:
+				appendStringInfo(&state->sql, "%f", DatumGetFloat8(value));
+			break;
+			case NUMERICOID:
+			{
+				Datum  valueDatum;
+				float8 f;
+
+				valueDatum = DirectFunctionCall1(numeric_float8, value);
+				f = DatumGetFloat8(valueDatum);
+				appendStringInfo(&state->sql, "%f", f);
+			}
+			break;
+			case BPCHAROID:
+			case VARCHAROID:
+			case TEXTOID:
+			case JSONOID:
+			case NAMEOID:
+			case BITOID:
+			case BYTEAOID:
+			{
+				char   *strin, *strout;
+				size_t  len;
+				bool	tl = false;
+				Oid		typoutput = InvalidOid;
+
+				getTypeOutputInfo(type, &typoutput, &tl);
+				strin = OidOutputFunctionCall(typoutput, value);
+				len = strlen(strin) + 1;
+				strout = palloc(len * 3 + 1);
+				escape_string(strout, strin, len);
+				appendStringInfo(&state->sql, "%s", strout);
+				pfree(strout);
+			}
+			break;
+			case DATEOID:
+			{
+				/* we expect Date on other side */
+				char *extval = DatumGetCString(DirectFunctionCall1(ch_date_out, value));
+				appendStringInfoString(&state->sql, extval);
+				pfree(extval);
+				break;
+			}
+			case TIMEOID:
+			{
+				/* we expect DateTime on other side */
+				char *extval = DatumGetCString(DirectFunctionCall1(ch_time_out, value));
+				appendStringInfo(&state->sql, "1970-01-01 %s", extval);
+				pfree(extval);
+				break;
+			}
+			case TIMESTAMPOID:
+			case TIMESTAMPTZOID:
+			{
+				/* we expect DateTime on other side */
+				char *extval = DatumGetCString(DirectFunctionCall1(ch_timestamp_out, value));
+				appendStringInfoString(&state->sql, extval);
+				pfree(extval);
+				break;
+			}
+			default:
+				ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+								errmsg("cannot convert constant value to clickhouse value"),
+								errhint("Constant value data type: %u", type)));
+			}
+		}
+		appendStringInfoChar(&state->sql, '\n');
+
+		Assert(pindex == state->p_nums);
+	}
+}
+
+static void *
+http_prepare_insert(void *conn, ResultRelInfo *rri, List *target_attrs,
+		char *query, char *table_name)
+{
+	ch_http_insert_state *state = palloc0(sizeof(ch_http_insert_state));
+
+	initStringInfo(&state->sql);
+	state->sql_begin = psprintf("%s FORMAT TSV\n", query);
+	state->target_attrs = target_attrs;
+	state->p_nums = list_length(state->target_attrs);
+	state->conn = conn;
+
+	return state;
+}
+
+static void
+http_insert_tuple(void *istate, TupleTableSlot *slot)
+{
+	ch_http_insert_state *state = istate;
+
+	extend_insert_query(state, slot);
+
+	if ((slot == NULL && state->sql.len > 0)
+			|| state->sql.len > (MaxAllocSize / 2 /* 512MB */))
+	{
+		http_simple_insert(state->conn, state->sql.data);
+		resetStringInfo(&state->sql);
+	}
+}
+
+/*** BINARY PROTOCOL ***/
+
+ch_connection
+chfdw_binary_connect(ch_connection_details *details)
+{
+	char *ch_error = NULL;
+	ch_connection res;
+	ch_binary_connection_t *conn = ch_binary_connect(details->host, details->port,
+			details->dbname, details->username, details->password, &ch_error);
+
+	if (conn == NULL)
+	{
+		Assert(ch_error);
+		char *error = pstrdup(ch_error);
+		free(ch_error);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("clickhouse_fdw: connection error: %s", error)));
+	}
+
+	res.conn = conn;
+	res.methods = &binary_methods;
+	res.is_binary = true;
+	return res;
+}
+
+static void
+binary_disconnect(void *conn)
+{
+	if (conn != NULL)
+		ch_binary_close((ch_binary_connection_t *) conn);
+}
+
+static ch_cursor *
+binary_simple_query(void *conn, const char *query)
+{
+	MemoryContext	tempcxt,
+					oldcxt;
+	ch_cursor	*cursor;
+	ch_binary_read_state_t *state;
+
+	ch_binary_response_t *resp = ch_binary_simple_query(conn, query, &is_canceled);
+
+	if (!resp->success)
+	{
+		char *error = pstrdup(resp->error);
+		ch_binary_response_free(resp);
+
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("clickhouse_fdw: %s", error)));
+	}
+
+	tempcxt = AllocSetContextCreate(PortalContext, "clickhouse_fdw cursor",
+										ALLOCSET_DEFAULT_SIZES);
+
+	oldcxt = MemoryContextSwitchTo(tempcxt);
+	cursor = palloc0(sizeof(ch_cursor));
+	cursor->query_response = resp;
+	state = (ch_binary_read_state_t *) palloc0(sizeof(ch_binary_read_state_t));
+	cursor->query = pstrdup(query);
+	cursor->read_state = state;
+	cursor->columns_count = resp->columns_count;
+	ch_binary_read_state_init(cursor->read_state, resp);
+	cursor->conversion_states = palloc0(sizeof(uintptr_t) * cursor->columns_count);
+
+	cursor->memcxt = tempcxt;
+	cursor->callback.func = binary_cursor_free;
+	cursor->callback.arg = cursor;
+	MemoryContextRegisterResetCallback(tempcxt, &cursor->callback);
+	MemoryContextSwitchTo(oldcxt);
+
+	if (state->error)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+				 errmsg("clickhouse_fdw: could not initialize read state: %s",
+					 state->error)));
+	}
+
+	return cursor;
+}
+
+static void **
+binary_fetch_row(ch_cursor *cursor, List *attrs, TupleDesc tupdesc,
+	Datum *values, bool *nulls)
+{
+	ListCell   *lc;
+	ch_binary_read_state_t *state = cursor->read_state;
+	bool		have_data = ch_binary_read_row(state);
+	size_t		attcount = list_length(attrs);
+
+	if (state->error)
+		ereport(ERROR,
+				(errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+				 errmsg("clickhouse_fdw: error while reading row: %s",
+					 state->error)));
+
+	if (!have_data)
+		return NULL;
+
+	if (attcount == 0)
+	{
+		if (state->resp->columns_count == 1 && state->nulls[0])
+		{
+			nulls[0] = true;
+			goto ok;
+		}
+		else
+			elog(ERROR, "clickhouse_fdw: unexpected state: atttributes "
+					"count == 0 and haven't got NULL in the response");
+	}
+	else if (attcount != state->resp->columns_count)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg_internal("clickhouse_fdw: columns mismatch"),
+				 errdetail("Number of returned columns (%lu) does not match "
+						   "expected column count (%lu).",
+						   state->resp->columns_count, attcount)));
+	}
+
+	if (tupdesc)
+	{
+		size_t j = 0;
+		Assert(values && nulls);
+
+		foreach(lc, attrs)
+		{
+			int		i = lfirst_int(lc);
+			bool	isnull = state->nulls[j];
+			intptr_t	convstate;
+
+
+			if (isnull)
+				values[i - 1] = (Datum) 0;
+			else
+			{
+again:
+				convstate = cursor->conversion_states[j];
+				switch (convstate)
+				{
+					case 0:
+					{
+						MemoryContext old_mcxt;
+
+						Oid outtype = TupleDescAttr(tupdesc, i - 1)->atttypid;
+						void *s;
+
+						/*
+						 * now we're should be in temporary memory context,
+						 * so make sure conversion states outlive it.
+						 */
+						old_mcxt = MemoryContextSwitchTo(cursor->memcxt);
+						s = ch_binary_init_convert_state(state->values[j],
+								state->coltypes[j], outtype);
+						MemoryContextSwitchTo(old_mcxt);
+
+						if (s == NULL)
+							/* no conversion but state is initalized */
+							cursor->conversion_states[j] = 1;
+						else
+							cursor->conversion_states[j] = (uintptr_t) s;
+						goto again;
+					}
+					case 1:
+						/* no conversion */
+						values[i - 1] = state->values[j];
+						break;
+					default:
+						values[i - 1] = ch_binary_convert_datum((void *) convstate,
+								state->values[j]);
+				}
+			}
+
+			nulls[i - 1] = isnull;
+			j++;
+		}
+	}
+
+ok:
+	return (void **) state->values;
+}
+
+static void
+binary_cursor_free(void *c)
+{
+	ch_cursor *cursor = c;
+	for (size_t i = 0; i < cursor->columns_count; i++)
+	{
+		if (cursor->conversion_states[i] > 1)
+			ch_binary_free_convert_state((void *) cursor->conversion_states[i]);
+	}
+
+	ch_binary_read_state_free(cursor->read_state);
+	ch_binary_response_free(cursor->query_response);
+}
+
+static void *
+binary_prepare_insert(void *conn, ResultRelInfo *rri, List *target_attrs,
+		char *query, char *table_name)
+{
+	ch_binary_insert_state *state = NULL;
+	MemoryContext	tempcxt,
+					oldcxt;
+
+	if (table_name == NULL)
+		elog(ERROR, "expected table name");
+
+	tempcxt = AllocSetContextCreate(CurrentMemoryContext,
+		"clickhouse_fdw binary insert state", ALLOCSET_DEFAULT_SIZES);
+
+	/* prepare cleanup */
+	oldcxt = MemoryContextSwitchTo(tempcxt);
+	state = (ch_binary_insert_state *) palloc0(sizeof(ch_binary_insert_state));
+	state->memcxt = tempcxt;
+	state->callback.func = ch_binary_insert_state_free;
+	state->callback.arg = state;
+	state->conn = conn;
+	state->table_name = pstrdup(table_name);
+	MemoryContextRegisterResetCallback(tempcxt, &state->callback);
+
+	/* time for c++ stuff */
+	ch_binary_prepare_insert(conn, query, state);
+
+	/* buffers */
+	state->values = (Datum *) palloc0(sizeof(Datum) * state->len);
+	state->nulls = (bool *) palloc0(sizeof(bool) * state->len);
+	MemoryContextSwitchTo(oldcxt);
+
+	return state;
+}
+
+static void
+binary_insert_tuple(void *istate, TupleTableSlot *slot)
+{
+	ch_binary_insert_state *state = istate;
+
+	if (state->conversion_states == NULL)
+	{
+		MemoryContext	old_mcxt;
+
+		old_mcxt = MemoryContextSwitchTo(state->memcxt);
+		state->conversion_states = ch_binary_make_tuple_map(
+				slot->tts_tupleDescriptor, state->outdesc);
+		MemoryContextSwitchTo(old_mcxt);
+	}
+
+	if (slot)
+	{
+		ch_binary_do_output_convertion(state, slot);
+
+		for (size_t i = 0; i < state->outdesc->natts; i++)
+			ch_binary_column_append_data(state, i);
+	}
+	else
+	{
+		ch_binary_insert_columns(state);
+		state->success = true;
+	}
+}
+
+static char *str_types_map[][2] = {
+	{"Int8", "INT2"},
+	{"UInt8", "INT2"},
+	{"Int16", "INT2"},
+	{"UInt16", "INT4"},
+	{"Int32", "INT4"},
+	{"UInt32", "INT8"},
+	{"Int64", "INT8"},
+	{"UInt64", "INT8"}, //overflow risk
+	{"Float32", "REAL"},
+	{"Float64", "DOUBLE PRECISION"},
+	{"Decimal", "NUMERIC"},
+	{"Boolean", "BOOLEAN"},
+	{"String", "TEXT"},
+	{"DateTime", "TIMESTAMP"},
+	{"Date", "DATE"}, // important that this one is after other Date types
+	{"UUID", "UUID"},
+	{"IPv4", "inet"},
+	{"IPv6", "inet"},
+	{NULL, NULL},
+};
+
+static char *
+readstr(ch_connection conn, char *val)
+{
+	if (conn.is_binary)
+		return TextDatumGetCString(PointerGetDatum(val));
+	else
+		return val;
+}
+
+static char *
+parse_type(char *colname, char *typepart, bool *is_nullable, List **options)
+{
+	char *pos = strstr(typepart, "(");
+
+	if (pos != NULL)
+	{
+		char *insidebr = pnstrdup(pos + 1, strrchr(typepart, ')') - pos - 1);
+
+		if (strncmp(typepart, "Decimal", strlen("Decimal")) == 0)
+		{
+			if (strstr(insidebr, ",") == NULL)
+				elog(ERROR, "clickhouse_fdw: could not import Decimal field, "
+					"should be two parameters on definition");
+
+			return psprintf("NUMERIC(%s)", insidebr);
+		}
+		else if (strncmp(typepart, "FixedString", strlen("FixedString")) == 0)
+			return psprintf("VARCHAR(%s)", insidebr);
+		else if (strncmp(typepart, "Enum8", strlen("Enum8")) == 0)
+			return "TEXT";
+		else if (strncmp(typepart, "Enum16", strlen("Enum16")) == 0)
+			return "TEXT";
+		else if (strncmp(typepart, "DateTime64", strlen("DateTime64")) == 0)
+			return "TIMESTAMP";
+		else if (strncmp(typepart, "DateTime", strlen("DateTime")) == 0)
+			return "TIMESTAMP";
+		else if (strncmp(typepart, "Tuple", strlen("Tuple")) == 0)
+		{
+			elog(NOTICE, "clickhouse_fdw: ClickHouse <Tuple> type was "
+				"translated to <TEXT> type for column \"%s\", please create composite type and alter the column if needed", colname);
+			return "TEXT";
+		}
+		else if (strncmp(typepart, "Array", strlen("Array")) == 0)
+		{
+			return psprintf("%s[]", parse_type(colname, insidebr, NULL, options));
+		}
+		else if (strncmp(typepart, "Nullable", strlen("Nullable")) == 0)
+		{
+			if (is_nullable == NULL)
+				elog(ERROR, "clickhouse_fdw: nested Nullable is not supported");
+
+			*is_nullable = true;
+			return parse_type(colname, insidebr, NULL, options);
+		}
+		else if (strncmp(typepart, "LowCardinality", strlen("LowCardinality")) == 0)
+		{
+			return parse_type(colname, insidebr, is_nullable, options);
+		}
+		else if (strncmp(typepart, "AggregateFunction", strlen("AggregateFunction")) == 0 ||
+				 strncmp(typepart, "SimpleAggregateFunction", strlen("SimpleAggregateFunction")) == 0)
+		{
+			char *pos2 = strstr(pos, ",");
+			if (pos2 == NULL)
+				elog(ERROR, "clickhouse_fdw: expected comma in AggregateFunction");
+
+			char *func = pnstrdup(pos + 1, strstr(pos + 1, ",") - pos - 1);
+
+			if (options != NULL)
+			{
+				int val = typepart[0] == 'A' ? 1 : 2;
+				*options = lappend(*options, makeInteger(val));
+				*options = lappend(*options, makeString(func));
+			}
+
+			if (strncmp(func, "sumMap", 6) == 0)
+				return "istore";
+
+			return parse_type(colname, pos2 + 2, is_nullable, options);
+		}
+
+		typepart = pos + 1;
+	}
+
+	size_t i = 0;
+	while (str_types_map[i][0] != NULL)
+	{
+		if (strncmp(str_types_map[i][0], typepart, strlen(str_types_map[i][0])) == 0)
+		{
+			if (strcmp(typepart, "UInt8") == 0)
+			{
+				elog(NOTICE, "clickhouse_fdw: ClickHouse <UInt8> type was "
+					"translated to <INT2> type for column \"%s\", change it to BOOLEAN if needed", colname);
+			}
+			return pstrdup(str_types_map[i][1]);
+		}
+
+		i++;
+	}
+
+	ereport(ERROR, (errmsg("clickhouse_fdw: could not map type <%s>", typepart)));
+}
+
+List *
+chfdw_construct_create_tables(ImportForeignSchemaStmt *stmt, ForeignServer *server)
+{
+	Oid				userid = GetUserId();
+	UserMapping	   *user = GetUserMapping(userid, server->serverid);
+	ch_connection	conn = chfdw_get_connection(user);
+	ch_cursor	   *cursor;
+	char		   *query;
+	List		   *result = NIL,
+				   *datts = NIL;
+	char		  **row_values;
+
+	query = psprintf("SELECT name, engine, engine_full "
+			"FROM system.tables WHERE database='%s' and name not like '.inner%%'", stmt->remote_schema);
+	cursor = conn.methods->simple_query(conn.conn, query);
+
+	datts = list_make2_int(1,2);
+
+	while ((row_values = (char **) conn.methods->fetch_row(cursor,
+				list_make3_int(1,2,3), NULL, NULL, NULL)) != NULL)
+	{
+		StringInfoData	buf;
+		ch_cursor  *table_def;
+		char	   *table_name = readstr(conn, row_values[0]);
+		char	   *engine = readstr(conn, row_values[1]);
+		char	   *engine_full = readstr(conn, row_values[2]);
+		char	  **dvalues;
+		bool		first = true;
+
+		if (table_name == NULL)
+			continue;
+
+		if (list_length(stmt->table_list))
+		{
+			ListCell *lc;
+			bool found = false;
+
+			foreach(lc, stmt->table_list)
+			{
+				RangeVar   *rv = (RangeVar *) lfirst(lc);
+				if (strcmp(rv->relname, table_name) == 0)
+					found = true;
+			}
+
+			if (stmt->list_type == FDW_IMPORT_SCHEMA_EXCEPT && found)
+				continue;
+			else if (stmt->list_type == FDW_IMPORT_SCHEMA_LIMIT_TO && !found)
+				continue;
+		}
+
+		initStringInfo(&buf);
+		appendStringInfo(&buf, "CREATE FOREIGN TABLE IF NOT EXISTS \"%s\".\"%s\" (\n",
+			stmt->local_schema, table_name);
+		query = psprintf("select name, type from system.columns where database='%s' and table='%s'",
+            stmt->remote_schema, table_name);
+		table_def = conn.methods->simple_query(conn.conn, query);
+
+		while ((dvalues = (char **) conn.methods->fetch_row(table_def,
+			datts, NULL, NULL, NULL)) != NULL)
+		{
+			List   *options = NIL;
+			bool	is_nullable = false;
+			char   *colname = readstr(conn, dvalues[0]);
+			char   *remote_type = parse_type(colname, readstr(conn, dvalues[1]), &is_nullable, &options);
+
+			if (!first)
+				appendStringInfoString(&buf, ",\n");
+			first = false;
+
+			/* name */
+			appendStringInfo(&buf, "\t\"%s\" ", colname);
+
+			/* type */
+			appendStringInfoString(&buf, remote_type);
+
+			if (options != NIL)
+			{
+				bool first_opt = true;
+				ListCell *lc;
+
+				appendStringInfoString(&buf, " OPTIONS (");
+				foreach(lc, options)
+				{
+					Node	*val = lfirst(lc);
+					if (IsA(val, Integer))
+					{
+						if (!first_opt)
+							appendStringInfoString(&buf, ", ");
+						first_opt = false;
+						switch intVal(val) {
+							case 1:
+								appendStringInfoString(&buf, "AggregateFunction");
+								break;
+							case 2:
+								appendStringInfoString(&buf, "SimpleAggregateFunction");
+								break;
+							default:
+								elog(ERROR, "programming error");
+						}
+					}
+					else
+						appendStringInfo(&buf, " '%s'", strVal(val));
+				}
+				appendStringInfoString(&buf, ")");
+				list_free_deep(options);
+			}
+
+			if (!is_nullable)
+				appendStringInfoString(&buf, " NOT NULL");
+		}
+
+		appendStringInfo(&buf, "\n) SERVER %s OPTIONS (database '%s', table_name '%s'",
+			server->servername, stmt->remote_schema, table_name);
+
+		if (engine && engine_full && strcmp(engine, "CollapsingMergeTree") == 0)
+		{
+			char *sub = strstr(engine_full, ")");
+			if (sub)
+			{
+				sub[1] = '\0';
+				appendStringInfo(&buf, ", engine '%s'", engine_full);
+			}
+		}
+		else if (engine)
+			appendStringInfo(&buf, ", engine '%s'", engine);
+
+		appendStringInfoString(&buf, ");\n");
+		result = lappend(result, buf.data);
+		MemoryContextDelete(table_def->memcxt);
+	}
+
+	MemoryContextDelete(cursor->memcxt);
+	return result;
+}
+
+
+/*
+ * Escaping arbitrary strings to get valid SQL literal strings.
+ *
+ * length is the length of the source string.  (Note: if a terminating NUL
+ * is encountered sooner, escape_string stops short of "length"; the behavior
+ * is thus rather like strncpy.)
+ *
+ * For safety the buffer at "to" must be at least 2*length + 1 bytes long.
+ * A terminating NUL character is added to the output string, whether the
+ * input is NUL-terminated or not.
+ *
+ * Returns the actual length of the output (not counting the terminating NUL).
+ */
+static size_t
+escape_string(char *to, const char *from, size_t length)
+{
+	const char *source = from;
+	char	   *target = to;
+	size_t		remaining = length;
+
+	while (remaining > 0 && *source != '\0')
+	{
+		char		c = *source;
+		int			len;
+		int			i;
+
+		/* Fast path for plain ASCII */
+		if (!IS_HIGHBIT_SET(c))
+		{
+			/* Apply quoting if needed */
+			if (c == '\\')
+			{
+				*target++ = c;
+				*target++ = c;
+			}
+			else if (c == '\'')
+			{
+				*target++ = '\\';
+				*target++ = c;
+			}
+			else if (c == '\n')
+			{
+				*target++ = '\\';
+				*target++ = 'n';
+			}
+			else if (c == '\t')
+			{
+				*target++ = '\\';
+				*target++ = 't';
+			}
+			else if (c == '\0')
+			{
+				*target++ = '\\';
+				*target++ = '0';
+			}
+			else if (c == '\r')
+			{
+				*target++ = '\\';
+				*target++ = 'r';
+			}
+			else if (c == '\b')
+			{
+				*target++ = '\\';
+				*target++ = 'b';
+			}
+			else if (c == '\f')
+			{
+				*target++ = '\\';
+				*target++ = 'f';
+			}
+			else
+				*target++ = c;
+
+			source++;
+			remaining--;
+			continue;
+		}
+
+		/* Slow path for possible multibyte characters */
+		len = pg_encoding_mblen(PG_SQL_ASCII, source);
+
+		/* Copy the character */
+		for (i = 0; i < len; i++)
+		{
+			if (remaining == 0 || *source == '\0')
+				break;
+			*target++ = *source++;
+			remaining--;
+		}
+
+		if (i < len)
+			elog(ERROR, "clickhouse_fdw: incomplete multibyte character");
+	}
+
+	/* Write the terminating NUL character. */
+	*target = '\0';
+
+	return target - to;
+}

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -1,0 +1,229 @@
+/*-------------------------------------------------------------------------
+ *
+ * shippable.c
+ *	  Determine which database objects are shippable to a remote server.
+ *
+ * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 2019-2022, Adjust GmbH
+ * Copyright (c) 2025, ClickHouse, Inc.
+ *
+ * IDENTIFICATION
+ *		  github.com/clickhouse/clickhouse_fdw/src/shippable.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "fdw.h"
+
+#include "access/transam.h"
+#include "catalog/dependency.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
+#include "catalog/pg_operator.h"
+#include "utils/hsearch.h"
+#include "utils/inval.h"
+#include "utils/syscache.h"
+
+
+/* Hash table for caching the results of shippability lookups */
+static HTAB *ShippableCacheHash = NULL;
+
+/*
+ * Hash key for shippability lookups.  We include the FDW server OID because
+ * decisions may differ per-server.  Otherwise, objects are identified by
+ * their (local!) OID and catalog OID.
+ */
+typedef struct
+{
+	/* XXX we assume this struct contains no padding bytes */
+	Oid			objid;			/* function/operator/type OID */
+	Oid			classid;		/* OID of its catalog (pg_proc, etc) */
+	Oid			serverid;		/* FDW server we are concerned with */
+} ShippableCacheKey;
+
+typedef struct
+{
+	ShippableCacheKey key;		/* hash key - must be first */
+	bool		shippable;
+} ShippableCacheEntry;
+
+
+/*
+ * Flush cache entries when pg_foreign_server is updated.
+ *
+ * We do this because of the possibility of ALTER SERVER being used to change
+ * a server's extensions option.  We do not currently bother to check whether
+ * objects' extension membership changes once a shippability decision has been
+ * made for them, however.
+ */
+static void
+InvalidateShippableCacheCallback(Datum arg, int cacheid, uint32 hashvalue)
+{
+	HASH_SEQ_STATUS status;
+	ShippableCacheEntry *entry;
+
+	/*
+	 * In principle we could flush only cache entries relating to the
+	 * pg_foreign_server entry being outdated; but that would be more
+	 * complicated, and it's probably not worth the trouble.  So for now, just
+	 * flush all entries.
+	 */
+	hash_seq_init(&status, ShippableCacheHash);
+	while ((entry = (ShippableCacheEntry *) hash_seq_search(&status)) != NULL)
+	{
+		if (hash_search(ShippableCacheHash,
+		                (void *) &entry->key,
+		                HASH_REMOVE,
+		                NULL) == NULL)
+		{
+			elog(ERROR, "hash table corrupted");
+		}
+	}
+}
+
+/*
+ * Initialize the backend-lifespan cache of shippability decisions.
+ */
+static void
+InitializeShippableCache(void)
+{
+	HASHCTL		ctl;
+
+	/* Create the hash table. */
+	MemSet(&ctl, 0, sizeof(ctl));
+	ctl.keysize = sizeof(ShippableCacheKey);
+	ctl.entrysize = sizeof(ShippableCacheEntry);
+	ShippableCacheHash =
+	    hash_create("Shippability cache", 256, &ctl, HASH_ELEM | HASH_BLOBS);
+
+	/* Set up invalidation callback on pg_foreign_server. */
+	CacheRegisterSyscacheCallback(FOREIGNSERVEROID,
+	                              InvalidateShippableCacheCallback,
+	                              (Datum) 0);
+}
+
+/*
+ * Returns true if given object (operator/function/type) is shippable
+ * according to the server options.
+ *
+ * Right now "shippability" is exclusively a function of whether the object
+ * belongs to an extension declared by the user.  In the future we could
+ * additionally have a whitelist of functions/operators declared one at a time.
+ */
+static bool
+lookup_shippable(Oid objectId, Oid classId, CHFdwRelationInfo *fpinfo)
+{
+	Oid			extensionOid;
+
+	/*
+	 * Is object a member of some extension?  (Note: this is a fairly
+	 * expensive lookup, which is why we try to cache the results.)
+	 */
+	extensionOid = getExtensionOfObject(classId, objectId);
+
+	/* If so, is that extension in fpinfo->shippable_extensions? */
+	if (OidIsValid(extensionOid) &&
+	        list_member_oid(fpinfo->shippable_extensions, extensionOid))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * Return true if given object is one of PostgreSQL's built-in objects.
+ *
+ * We use FirstUnpinnedObjectId as the cutoff, so that we only consider
+ * objects with hand-assigned OIDs to be "built in", not for instance any
+ * function or type defined in the information_schema.
+ *
+ * Our constraints for dealing with types are tighter than they are for
+ * functions or operators: we want to accept only types that are in pg_catalog,
+ * else deparse_type_name might incorrectly fail to schema-qualify their names.
+ * Thus we must exclude information_schema types.
+ *
+ * XXX there is a problem with this, which is that the set of built-in
+ * objects expands over time.  Something that is built-in to us might not
+ * be known to the remote server, if it's of an older version.  But keeping
+ * track of that would be a huge exercise.
+ */
+bool
+chfdw_is_builtin(Oid objectId)
+{
+	return (objectId < FirstUnpinnedObjectId);
+}
+
+/*
+ * chfdw_is_shippable
+ *	   Is this object (function/operator/type) shippable to foreign server?
+ */
+bool
+chfdw_is_shippable(Oid objectId, Oid classId, CHFdwRelationInfo *fpinfo,
+		CustomObjectDef **outcdef)
+{
+	ShippableCacheKey key;
+	ShippableCacheEntry *entry;
+
+	/* Built-in objects are presumed shippable. */
+	if (chfdw_is_builtin(objectId))
+		return true;
+
+	if (classId == ProcedureRelationId)
+	{
+		CustomObjectDef *cdef = chfdw_check_for_custom_function(objectId);
+		if (outcdef != NULL)
+			*outcdef = cdef;
+
+		return (cdef && cdef->cf_type != CF_UNSHIPPABLE);
+	}
+	else if (classId == TypeRelationId && chfdw_check_for_custom_type(objectId) != NULL)
+		return true;
+	else if (classId == OperatorRelationId && chfdw_check_for_custom_operator(objectId, NULL) != NULL)
+		return true;
+
+	/* Otherwise, give up if user hasn't specified any shippable extensions. */
+	if (fpinfo->shippable_extensions == NIL)
+		return false;
+
+	/* Initialize cache if first time through. */
+	if (!ShippableCacheHash)
+	{
+		InitializeShippableCache();
+	}
+
+	/* Set up cache hash key */
+	key.objid = objectId;
+	key.classid = classId;
+	key.serverid = fpinfo->server->serverid;
+
+	/* See if we already cached the result. */
+	entry = (ShippableCacheEntry *)
+	        hash_search(ShippableCacheHash,
+	                    (void *) &key,
+	                    HASH_FIND,
+	                    NULL);
+
+	if (!entry)
+	{
+		/* Not found in cache, so perform shippability lookup. */
+		bool		shippable = lookup_shippable(objectId, classId, fpinfo);
+
+		/*
+		 * Don't create a new hash entry until *after* we have the shippable
+		 * result in hand, as the underlying catalog lookups might trigger a
+		 * cache invalidation.
+		 */
+		entry = (ShippableCacheEntry *)
+		        hash_search(ShippableCacheHash,
+		                    (void *) &key,
+		                    HASH_ENTER,
+		                    NULL);
+
+		entry->shippable = shippable;
+	}
+
+	return entry->shippable;
+}


### PR DESCRIPTION
Fix various warnings from the previous code, mostly unused or shadowed variables. Also detect the `.c.in` file and append it to a sorted (and therefor de-duped) list of object files to be sure it gets compiled, as well. Add `libuuid` to the list of dependencies.

The old clickhouse_fdw uses an old and hacked copy of yandex/clickhouse-cpp, but here we want to use the latest version of `clickhouse/clickhouse-cpp`, instead. It varies in a few ways, some of which are fixed here, others which are commented-out for now with "XXX" markers.

Also add proper `libcurl` configuration to the `Makefile`.

Features currently disabled:

*  `binary_prepare_insert` — uses API not in clickhouse/clickhouse-cpp. Unsure of its purpose
*   Low cardinality column: — generates a type not able to be used as a column
*   Arrays — Accesses array internal not exposed in clickhouse/clickhouse-cpp