### PR TITLE
Add SQL to create the extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ regression.diffs
 regression.out
 /clickhouse_fdw-*
 .vscode/
-/build/
+_build/
 /latest-changes.md
 /src/fdw.c
 /sql/*--*.sql

--- a/sql/clickhouse_fdw--2.0.0.sql
+++ b/sql/clickhouse_fdw--2.0.0.sql
@@ -1,2 +1,0 @@
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION clickhouse_fdw" to load this file. \quit

--- a/sql/clickhouse_fdw.sql
+++ b/sql/clickhouse_fdw.sql
@@ -1,2 +1,56 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION clickhouse_fdw" to load this file. \quit
+
+-- Set up the FDW.
+CREATE FUNCTION clickhouse_fdw_handler()
+RETURNS fdw_handler
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION clickhouse_raw_query(TEXT, TEXT DEFAULT 'host=localhost port=8123')
+RETURNS TEXT
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION clickhouse_fdw_validator(text[], oid)
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER clickhouse_fdw
+	HANDLER clickhouse_fdw_handler
+	VALIDATOR clickhouse_fdw_validator;
+
+-- Create error-raising argMax aggregate that should be pushed down to
+-- ClickHouse.
+CREATE FUNCTION ch_argmax(anyelement, anyelement, anyelement) RETURNS anyelement
+AS $$ BEGIN
+	RAISE EXCEPTION 'argMax should be pushed down to ClickHouse';
+END $$ LANGUAGE 'plpgsql' IMMUTABLE;
+
+CREATE AGGREGATE argMax(anyelement, anyelement)
+(
+    sfunc = ch_argmax,
+    stype = anyelement
+);
+
+-- Create error-raising argMin aggregates that should be pushed down to
+-- ClickHouse.
+CREATE FUNCTION ch_argmin(anyelement, anyelement, anyelement) RETURNS anyelement
+AS $$ BEGIN
+	RAISE EXCEPTION 'argMin should be pushed down to ClickHouse';
+END $$ LANGUAGE 'plpgsql' IMMUTABLE;
+
+CREATE AGGREGATE argMin(anyelement, anyelement)
+(
+    sfunc = ch_argmin,
+    stype = anyelement
+);
+
+-- Create error-raising dictGet function that should be pushed down to
+-- ClickHouse.
+CREATE FUNCTION dictGet(text, text, anyelement)
+RETURNS text
+AS $$ BEGIN
+	RAISE EXCEPTION 'dictGet should be pushed down to ClickHouse';
+END $$ LANGUAGE 'plpgsql' IMMUTABLE;


### PR DESCRIPTION
And also a few aggregate functions from the previous version of the extension.

This change causes `installcheck` to actually load the extension, which failed for a dynamic install, because it wants the symlinked file, and for static install, because `libcityhash` was missing from `SHLIB_LINK`. So also change `install-ch-cpp` to use `cp -a` to copy all library files and preserve symlinks and add `libcityhash` to `SHLIB_LINK`.