### PR TITLE
Properly implement functions and aggregates

### DIFF
--- a/sql/clickhouse_fdw.sql
+++ b/sql/clickhouse_fdw.sql
@@ -21,36 +21,72 @@ CREATE FOREIGN DATA WRAPPER clickhouse_fdw
 	HANDLER clickhouse_fdw_handler
 	VALIDATOR clickhouse_fdw_validator;
 
+-- Function used for by functions and aggregates to fall back on when pushdown
+--fails. The first argument should describe the operation that should have
+--been pushed down.
+CREATE FUNCTION clickhouse_pushdown(TEXT, VARIADIC "any") RETURNS TEXT
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+-- No-op function used for aggregate final functions that return BIGINT.
+-- Allows their state to be text. Returns NULL.
+CREATE FUNCTION ch_noop_bigint(TEXT) RETURNS BIGINT
+AS 'MODULE_PATHNAME', 'clickhouse_noop'
+LANGUAGE C STRICT;
+
 -- Create error-raising argMax aggregate that should be pushed down to
 -- ClickHouse.
-CREATE FUNCTION ch_argmax(anyelement, anyelement, anyelement) RETURNS anyelement
-AS $$ BEGIN
-	RAISE EXCEPTION 'argMax should be pushed down to ClickHouse';
-END $$ LANGUAGE 'plpgsql' IMMUTABLE;
+CREATE FUNCTION ch_argmax(anyelement, anyelement, anycompatible)
+RETURNS anyelement AS $$ SELECT clickhouse_pushdown('aggregate argMax()') $$
+LANGUAGE 'plpgsql' IMMUTABLE;
 
-CREATE AGGREGATE argMax(anyelement, anyelement)
+CREATE AGGREGATE argMax(anyelement, anycompatible)
 (
     sfunc = ch_argmax,
     stype = anyelement
 );
 
--- Create error-raising argMin aggregates that should be pushed down to
+-- Create error-raising argMin aggregate that should be pushed down to
 -- ClickHouse.
-CREATE FUNCTION ch_argmin(anyelement, anyelement, anyelement) RETURNS anyelement
-AS $$ BEGIN
-	RAISE EXCEPTION 'argMin should be pushed down to ClickHouse';
-END $$ LANGUAGE 'plpgsql' IMMUTABLE;
+CREATE FUNCTION ch_argmin(anyelement, anyelement, anycompatible)
+RETURNS anyelement AS $$ SELECT clickhouse_pushdown('aggregate argMin()') $$
+LANGUAGE 'plpgsql' IMMUTABLE;
 
-CREATE AGGREGATE argMin(anyelement, anyelement)
+CREATE AGGREGATE argMin(anyelement, anycompatible)
 (
     sfunc = ch_argmin,
     stype = anyelement
 );
 
+-- Variadic aggregate that takes any number of arguments of any type.
+CREATE AGGREGATE uniqExact(VARIADIC "any")
+(
+    SFUNC     = clickhouse_pushdown,     -- raises error
+	INITCOND  = 'aggregate uniqExact()', -- what to push down
+	STYPE     = TEXT,                    -- state type
+	FINALFUNC = ch_noop_bigint           -- returns NULL
+);
+
+/*
+ * XXX Other variadic aggregates to add:
+ *
+ * ❯ rg -Fl. 'variable number of parameters'
+ * docs/en/sql-reference/aggregate-functions/reference/uniqhll12.md
+ * docs/en/sql-reference/aggregate-functions/reference/uniqcombined64.md
+ * docs/en/sql-reference/aggregate-functions/reference/uniqcombined.md
+ * docs/en/sql-reference/aggregate-functions/reference/corrmatrix.md
+ * docs/en/sql-reference/aggregate-functions/reference/covarsampmatrix.md
+ * docs/en/sql-reference/aggregate-functions/reference/covarpopmatrix.md
+ * docs/en/sql-reference/aggregate-functions/reference/uniqexact.md
+ * docs/en/sql-reference/aggregate-functions/reference/uniq.md
+ * docs/en/sql-reference/aggregate-functions/reference/uniqthetasketch.md
+ *
+ * Plus variadic hashing functions:
+ * https://clickhouse.com/docs/sql-reference/functions/hash-functions
+*/
+
 -- Create error-raising dictGet function that should be pushed down to
 -- ClickHouse.
 CREATE FUNCTION dictGet(text, text, anyelement)
-RETURNS text
-AS $$ BEGIN
-	RAISE EXCEPTION 'dictGet should be pushed down to ClickHouse';
-END $$ LANGUAGE 'plpgsql' IMMUTABLE;
+RETURNS TEXT AS $$ SELECT clickhouse_pushdown('dictGet()') $$
+LANGUAGE 'plpgsql' IMMUTABLE;

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -275,7 +275,7 @@ CustomObjectDef *chfdw_check_for_custom_function(Oid funcid)
 					strcpy(entry->custom_name, "argMin");
 				else if (strcmp(proname, "dictget") == 0)
 					strcpy(entry->custom_name, "dictGet");
-				else if (strcmp(proname, "uniq_exact") == 0)
+				else if (strcmp(proname, "uniqexact") == 0)
 					strcpy(entry->custom_name, "uniqExact");
 				else
 					strcpy(entry->custom_name, proname);

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -180,7 +180,8 @@ typedef struct
  */
 PG_FUNCTION_INFO_V1(clickhouse_fdw_handler);
 PG_FUNCTION_INFO_V1(clickhouse_raw_query);
-PG_FUNCTION_INFO_V1(clickhouse_mock);
+PG_FUNCTION_INFO_V1(clickhouse_pushdown);
+PG_FUNCTION_INFO_V1(clickhouse_noop);
 extern PGDLLEXPORT void _PG_init(void);
 static double time_used = 0;
 
@@ -2863,8 +2864,24 @@ clickhouse_fdw_handler(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(routine);
 }
 
+/*
+ * No-op function to use for the final function of a variadic function that
+ * takes any number of values of any type.
+*/
 Datum
-clickhouse_mock(PG_FUNCTION_ARGS)
+clickhouse_noop(PG_FUNCTION_ARGS)
 {
-	elog(ERROR, "clickhouse_fdw: mocked function should be pushed down");
+	PG_RETURN_NULL();
+}
+
+/*
+ * Function that simply raises an exception reporting that the first argument
+ * should have been pushed down.
+*/
+Datum
+clickhouse_pushdown(PG_FUNCTION_ARGS)
+{
+	text* name = PG_GETARG_TEXT_PP(0);
+	elog(ERROR, "clickhouse_fdw: failed to push down %s",
+		text_to_cstring(name));
 }

--- a/test/expected/binary_queries.txt
+++ b/test/expected/binary_queries.txt
@@ -1,6 +1,0 @@
- Versions | File
-----------|----------------------
- 18       | binary_queries.out
- 17       | binary_queries_1.out
- 16       | binary_queries_2.out
- 13-15    | binary_queries_3.out

--- a/test/expected/deparse_checks.txt
+++ b/test/expected/deparse_checks.txt
@@ -1,4 +1,0 @@
- Versions | File
-----------|----------------------
- 18       | deparse_checks.out
- 13-17    | deparse_checks_1.out

--- a/test/expected/engines.txt
+++ b/test/expected/engines.txt
@@ -1,4 +1,0 @@
- Versions | File
-----------|---------------
- 18       | engines.out
- 13-17    | engines_1.out

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1,0 +1,501 @@
+SET datestyle = 'ISO';
+CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'functions_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- argMax, argMin
+SELECT clickhouse_raw_query($$
+	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t1 VALUES
+		(1, 1, '2019-01-01 10:00:00'),
+		(2, 2, '2019-01-02 10:00:00'),
+		(2, 2, '2019-01-02 11:00:00'),
+		(2, 3, '2019-01-02 10:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	drop dictionary if exists functions_test.t3_dict
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('
+	create table functions_test.t3 (a Int32, b Nullable(Int32))
+	engine = MergeTree()
+	order by a');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+        val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
+CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
+CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
+CREATE FOREIGN TABLE t3_map (key1 int, key2 text, val text) SERVER functions_loopback;
+CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3
+	SELECT number+1, number+2
+	  FROM numbers(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3_map
+	SELECT number+1, 'key'|| number+1, 'val' || number+1
+	  FROM numbers(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t4
+	SELECT 'val' || number+1
+	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	create dictionary functions_test.t3_dict
+    (key1 Int32, key2 String, val String)
+    primary key key1, key2
+    source(clickhouse(host '127.0.0.1' port 9000 db 'functions_test' table 't3_map' user 'default' password ''))
+    layout(complex_key_hashed())
+    lifetime(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- check coalesce((cast as Nullable...
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: COALESCE((a)::text, (b)::text, (c)::text), a, b, c
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT COALESCE(CAST(a AS Nullable(String)), CAST(b AS Nullable(String)), CAST(c AS String)), a, b, c FROM functions_test.t1 GROUP BY a, b, c
+(4 rows)
+
+SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+ coalesce 
+----------
+ 2
+ 1
+ 2
+ 2
+(4 rows)
+
+-- check IN functions
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (sum(b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT a, sum(b) FROM functions_test.t1 WHERE ((a IN (1,2,3))) GROUP BY a
+(4 rows)
+
+SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+ a | sum 
+---+-----
+ 2 |   7
+ 1 |   1
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (sum(b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT a, sum(b) FROM functions_test.t1 WHERE ((a NOT IN (1,2,3))) GROUP BY a
+(4 rows)
+
+SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+ a | sum 
+---+-----
+(0 rows)
+
+-- check argMin, argMax, uniqExact
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmin(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMin(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT argMin(a, b) FROM t1;
+ argmin 
+--------
+      1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, b) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmax(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMax(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT argMax(a, b) FROM t1;
+ argmax 
+--------
+      2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, c) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmin(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMin(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT argMin(a, c) FROM t1;
+ argmin 
+--------
+      1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, c) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmax(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMax(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT argMax(a, c) FROM t1;
+ argmax 
+--------
+      2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a) FROM t1;
+ uniqexact 
+-----------
+         2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a) FILTER (WHERE (b > 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExactIf(a,(((b > 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+ uniqexact 
+-----------
+         1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, b) FROM t1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a, b) FROM t1;
+ uniqexact 
+-----------
+         3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, c) FROM t1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a, c) FROM t1;
+ uniqexact 
+-----------
+         3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('dAy'::text, (c AT TIME ZONE 'UTC'::text)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+           d1           
+------------------------
+ 2019-01-01 00:00:00-08
+ 2019-01-02 00:00:00-08
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('day'::text, (c AT TIME ZONE 'UTC'::text)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+         d1          
+---------------------
+ 2019-01-01 00:00:00
+ 2019-01-02 00:00:00
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('day'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toDayOfMonth(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfMonth(toTimeZone(c, 'UTC'))) ORDER BY toDayOfMonth(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('day'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfMonth(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfMonth(toTimeZone(c, 'UTC'))) ORDER BY toDayOfMonth(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('doy'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfYear(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfYear(toTimeZone(c, 'UTC'))) ORDER BY toDayOfYear(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  2
+  3
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('minuTe'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toMinute(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toMinute(toTimeZone(c, 'UTC'))) ORDER BY toMinute(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                                                QUERY PLAN                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('SeCond'::text, (c AT TIME ZONE 'UTC'::text)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC
+(4 rows)
+
+SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+           d1           
+------------------------
+ 2019-01-01 10:00:00-08
+ 2019-01-02 10:00:00-08
+ 2019-01-02 11:00:00-08
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('ePoch'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toUnixTimestamp(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toUnixTimestamp(toTimeZone(c, 'UTC'))) ORDER BY toUnixTimestamp(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+     d1     
+------------
+ 1546336800
+ 1546423200
+ 1546426800
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (ltrim(val)), (btrim(val)), (rtrim(val))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT ltrim(val), trimBoth(val), rtrim(val) FROM functions_test.t4 GROUP BY (ltrim(val)), (trimBoth(val)), (rtrim(val)) ORDER BY ltrim(val) ASC
+(4 rows)
+
+SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+  a   |  b   |  c   
+------+------+------
+ val1 | val1 | val1
+ val2 | val2 | val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (strpos(val, 'val'::text))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC
+(4 rows)
+
+SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+ a 
+---
+ 1
+(1 row)
+
+--- check dictGet
+-- dictGet is broken for now
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (dictget('functions_test.t3_dict'::text, 'val'::text, ROW(a, ('key'::text || (a)::text)))), (sum(b))
+   Relations: Aggregate on (t3)
+   Remote SQL: SELECT a, dictGet('functions_test.t3_dict', 'val', (a,('key' || CAST(a AS String)))), sum(b) FROM functions_test.t3 GROUP BY a, (dictGet('functions_test.t3_dict', 'val', (a,('key' || CAST(a AS String))))) ORDER BY a ASC
+(4 rows)
+
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (dictget('functions_test.t3_dict'::text, 'val'::text, ROW(1, ('key'::text || (a)::text)))), (sum(b))
+   Relations: Aggregate on (t3)
+   Remote SQL: SELECT a, dictGet('functions_test.t3_dict', 'val', (cast(1 as Int32),('key' || CAST(a AS String)))), sum(b) FROM functions_test.t3 GROUP BY a, (dictGet('functions_test.t3_dict', 'val', (cast(1 as Int32),('key' || CAST(a AS String))))) ORDER BY a ASC
+(4 rows)
+
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP SERVER functions_loopback CASCADE;
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to foreign table t1
+drop cascades to foreign table t2
+drop cascades to foreign table t3
+drop cascades to foreign table t3_map
+drop cascades to foreign table t4

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1,0 +1,501 @@
+SET datestyle = 'ISO';
+CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'functions_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- argMax, argMin
+SELECT clickhouse_raw_query($$
+	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t1 VALUES
+		(1, 1, '2019-01-01 10:00:00'),
+		(2, 2, '2019-01-02 10:00:00'),
+		(2, 2, '2019-01-02 11:00:00'),
+		(2, 3, '2019-01-02 10:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	drop dictionary if exists functions_test.t3_dict
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('
+	create table functions_test.t3 (a Int32, b Nullable(Int32))
+	engine = MergeTree()
+	order by a');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+        val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
+CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
+CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
+CREATE FOREIGN TABLE t3_map (key1 int, key2 text, val text) SERVER functions_loopback;
+CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3
+	SELECT number+1, number+2
+	  FROM numbers(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3_map
+	SELECT number+1, 'key'|| number+1, 'val' || number+1
+	  FROM numbers(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t4
+	SELECT 'val' || number+1
+	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	create dictionary functions_test.t3_dict
+    (key1 Int32, key2 String, val String)
+    primary key key1, key2
+    source(clickhouse(host '127.0.0.1' port 9000 db 'functions_test' table 't3_map' user 'default' password ''))
+    layout(complex_key_hashed())
+    lifetime(10);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- check coalesce((cast as Nullable...
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: COALESCE((a)::text, (b)::text, (c)::text), a, b, c
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT COALESCE(CAST(a AS Nullable(String)), CAST(b AS Nullable(String)), CAST(c AS String)), a, b, c FROM functions_test.t1 GROUP BY a, b, c
+(4 rows)
+
+SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+ coalesce 
+----------
+ 2
+ 1
+ 2
+ 2
+(4 rows)
+
+-- check IN functions
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (sum(b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT a, sum(b) FROM functions_test.t1 WHERE ((a IN (1,2,3))) GROUP BY a
+(4 rows)
+
+SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+ a | sum 
+---+-----
+ 2 |   7
+ 1 |   1
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (sum(b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT a, sum(b) FROM functions_test.t1 WHERE ((a NOT IN (1,2,3))) GROUP BY a
+(4 rows)
+
+SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+ a | sum 
+---+-----
+(0 rows)
+
+-- check argMin, argMax, uniqExact
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmin(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMin(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT argMin(a, b) FROM t1;
+ argmin 
+--------
+      1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, b) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmax(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMax(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT argMax(a, b) FROM t1;
+ argmax 
+--------
+      2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, c) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmin(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMin(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT argMin(a, c) FROM t1;
+ argmin 
+--------
+      1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, c) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (argmax(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT argMax(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT argMax(a, c) FROM t1;
+ argmax 
+--------
+      2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FROM t1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a) FROM t1;
+ uniqexact 
+-----------
+         2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a) FILTER (WHERE (b > 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExactIf(a,(((b > 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+ uniqexact 
+-----------
+         1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, b) FROM t1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a, b))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a, b) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a, b) FROM t1;
+ uniqexact 
+-----------
+         3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, c) FROM t1;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan
+   Output: (uniqexact(a, c))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT uniqExact(a, c) FROM functions_test.t1
+(4 rows)
+
+SELECT uniqExact(a, c) FROM t1;
+ uniqexact 
+-----------
+         3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+           d1           
+------------------------
+ 2019-01-01 00:00:00-08
+ 2019-01-02 00:00:00-08
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+         d1          
+---------------------
+ 2019-01-01 00:00:00
+ 2019-01-02 00:00:00
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('day'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toDayOfMonth(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfMonth(toTimeZone(c, 'UTC'))) ORDER BY toDayOfMonth(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('day'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfMonth(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfMonth(toTimeZone(c, 'UTC'))) ORDER BY toDayOfMonth(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('doy'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfYear(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfYear(toTimeZone(c, 'UTC'))) ORDER BY toDayOfYear(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  2
+  3
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('minuTe'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toMinute(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toMinute(toTimeZone(c, 'UTC'))) ORDER BY toMinute(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+ d1 
+----
+  0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                                                QUERY PLAN                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC
+(4 rows)
+
+SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+           d1           
+------------------------
+ 2019-01-01 10:00:00-08
+ 2019-01-02 10:00:00-08
+ 2019-01-02 11:00:00-08
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('ePoch'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t2)
+   Remote SQL: SELECT toUnixTimestamp(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toUnixTimestamp(toTimeZone(c, 'UTC'))) ORDER BY toUnixTimestamp(toTimeZone(c, 'UTC')) ASC
+(4 rows)
+
+SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+     d1     
+------------
+ 1546336800
+ 1546423200
+ 1546426800
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (ltrim(val)), (btrim(val)), (rtrim(val))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT ltrim(val), trimBoth(val), rtrim(val) FROM functions_test.t4 GROUP BY (ltrim(val)), (trimBoth(val)), (rtrim(val)) ORDER BY ltrim(val) ASC
+(4 rows)
+
+SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+  a   |  b   |  c   
+------+------+------
+ val1 | val1 | val1
+ val2 | val2 | val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (strpos(val, 'val'::text))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC
+(4 rows)
+
+SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+ a 
+---
+ 1
+(1 row)
+
+--- check dictGet
+-- dictGet is broken for now
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (dictget('functions_test.t3_dict'::text, 'val'::text, ROW(a, ('key'::text || (a)::text)))), (sum(b))
+   Relations: Aggregate on (t3)
+   Remote SQL: SELECT a, dictGet('functions_test.t3_dict', 'val', (a,('key' || CAST(a AS String)))), sum(b) FROM functions_test.t3 GROUP BY a, (dictGet('functions_test.t3_dict', 'val', (a,('key' || CAST(a AS String))))) ORDER BY a ASC
+(4 rows)
+
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (dictget('functions_test.t3_dict'::text, 'val'::text, ROW(1, ('key'::text || (a)::text)))), (sum(b))
+   Relations: Aggregate on (t3)
+   Remote SQL: SELECT a, dictGet('functions_test.t3_dict', 'val', (cast(1 as Int32),('key' || CAST(a AS String)))), sum(b) FROM functions_test.t3 GROUP BY a, (dictGet('functions_test.t3_dict', 'val', (cast(1 as Int32),('key' || CAST(a AS String))))) ORDER BY a ASC
+(4 rows)
+
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE functions_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP SERVER functions_loopback CASCADE;
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to foreign table t1
+drop cascades to foreign table t2
+drop cascades to foreign table t3
+drop cascades to foreign table t3_map
+drop cascades to foreign table t4

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -1,0 +1,21 @@
+ Versions | File
+----------|----------------------
+ 18       | binary_queries.out
+ 17       | binary_queries_1.out
+ 16       | binary_queries_2.out
+ 13-15    | binary_queries_3.out
+
+ Versions | File
+----------|----------------------
+ 18       | deparse_checks.out
+ 13-17    | deparse_checks_1.out
+
+ Versions | File
+----------|---------------
+ 18       | engines.out
+ 13-17    | engines_1.out
+
+ Versions | File
+----------|---------------
+ 14-18    | functions.out
+ 13       | functions_1.out

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -1,0 +1,142 @@
+SET datestyle = 'ISO';
+CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'functions_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
+SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
+
+-- argMax, argMin
+SELECT clickhouse_raw_query($$
+	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
+$$);
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t1 VALUES
+		(1, 1, '2019-01-01 10:00:00'),
+		(2, 2, '2019-01-02 10:00:00'),
+		(2, 2, '2019-01-02 11:00:00'),
+		(2, 3, '2019-01-02 10:00:00')
+$$);
+
+SELECT clickhouse_raw_query($$
+	drop dictionary if exists functions_test.t3_dict
+$$);
+
+SELECT clickhouse_raw_query('
+	create table functions_test.t3 (a Int32, b Nullable(Int32))
+	engine = MergeTree()
+	order by a');
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+        val String) engine=TinyLog();');
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+
+CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
+CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
+CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
+CREATE FOREIGN TABLE t3_map (key1 int, key2 text, val text) SERVER functions_loopback;
+CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3
+	SELECT number+1, number+2
+	  FROM numbers(10);
+$$);
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t3_map
+	SELECT number+1, 'key'|| number+1, 'val' || number+1
+	  FROM numbers(10);
+$$);
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t4
+	SELECT 'val' || number+1
+	  FROM numbers(2);
+$$);
+
+SELECT clickhouse_raw_query($$
+	create dictionary functions_test.t3_dict
+    (key1 Int32, key2 String, val String)
+    primary key key1, key2
+    source(clickhouse(host '127.0.0.1' port 9000 db 'functions_test' table 't3_map' user 'default' password ''))
+    layout(complex_key_hashed())
+    lifetime(10);
+$$);
+
+-- check coalesce((cast as Nullable...
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
+
+-- check IN functions
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+SELECT a, sum(b) FROM t1 WHERE a IN (1,2,3) GROUP BY a;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+	SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
+
+-- check argMin, argMax, uniqExact
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
+SELECT argMin(a, b) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, b) FROM t1;
+SELECT argMax(a, b) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, c) FROM t1;
+SELECT argMin(a, c) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, c) FROM t1;
+SELECT argMax(a, c) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FROM t1;
+SELECT uniqExact(a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+SELECT uniqExact(a) FILTER(WHERE b>1) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, b) FROM t1;
+SELECT uniqExact(a, b) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqExact(a, c) FROM t1;
+SELECT uniqExact(a, c) FROM t1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_part('day'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_part('minuTe'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
+
+--- check dictGet
+-- dictGet is broken for now
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (a, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+-- SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val, sum(b) FROM t3 GROUP BY a, val ORDER BY a;
+
+DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE functions_test');
+DROP SERVER functions_loopback CASCADE;


### PR DESCRIPTION
Add a new C function, `clickhouse_pushdown`, to be called by functions and aggregates that fail to be pushed down. The first argument should describe the thing not pushed down and all other args are optional and may be of any type.

Use this function in the custom aggregates and functions that should be pushed down to ClickHouse. `ch_argmax`, `ch_argmin`, and `dictGet` call it directly.

Change the signatures of `ch_argmax` and `ch_argmin` and the aggregate that use them, `argMax()` and `argMin()`, to allow two arguments of any type, as supported by ClickHouse.

Add the `uniqExact` aggregate, which allows any number of arguments of a variety of types. Coerce it to use the `clickhouse_pushdown` when pushdown fails by setting the initial value `aggregate uniqExact()` so that it will be reported as a failed pushdown. Since the aggregate always returns BIGINT but it uses TEXT for the initial value, add the `ch_noop_bigint` function which takes a TEXT argument (for the state being aggregated) and returns a BIGINT. It maps to the new `clickhouse_noop` function, which simply returns `NULL`.

Since `uniqExact` is a variadic aggregate, remove the code that marked variadic functions as unsupported and add `deparseArrayList` to rewrite a variadic array value to a list of values to be passed to ClickHouse.

Change the deparser to match `uniqexact` rather than `uniq_exact`; the latter seems to have been a custom name used by the previous version of the FDW, but it seems better to use the exact name that ClickHouse expects.

Finally, port `test/sql/functions.sql` from the old FDW and update it to better test the `uniqExact` variadic aggregate. While at it, merge the files listing expected output files to Postgres versions from files named for each test to a single file, `test/expected/result_map.txt`.
