### PR TITLE
Detect and use TLS port and host configurations

### DIFF
--- a/.github/ubuntu/clickhouse.sh
+++ b/.github/ubuntu/clickhouse.sh
@@ -33,7 +33,6 @@ for pkg in clickhouse-common-static clickhouse-server; do
         # Prior to v22, the server package supported all architectures.
         ARCH=all
     fi
-    echo "${base_url}/${pkg}_${CH_VERSION}_${ARCH}.deb"
     curl -sLo "${pkg}.deb" "${base_url}/${pkg}_${CH_VERSION}_${ARCH}.deb"
     dpkg -i "${pkg}.deb"
     rm "${pkg}.deb"

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 # We'll need the clickhouse-cpp library and rpath so it can be found.
-SHLIB_LINK += -Wl,-rpath,$(pkglibdir)/ $(CH_CPP_LIB)
+SHLIB_LINK += -Wl,-rpath,$(pkglibdir)/
 
 # PostgresSQL 15 and earlier violate a C++ v17 storage specifier error.
 ifeq ($(shell test $(MAJORVERSION) -lt 16; echo $$?),0)

--- a/src/connection.c
+++ b/src/connection.c
@@ -45,7 +45,7 @@ clickhouse_connect(ForeignServer *server, UserMapping *user)
 	char	   *driver = "http";
 
 	/* default settings */
-	ch_connection_details	details = {"127.0.0.1", 8123, NULL, NULL, "default"};
+	ch_connection_details	details = {"127.0.0.1", 0, NULL, NULL, "default"};
 
 	chfdw_extract_options(server->options, &driver, &details.host,
 		&details.port, &details.dbname, &details.username, &details.password);
@@ -58,9 +58,6 @@ clickhouse_connect(ForeignServer *server, UserMapping *user)
 	}
 	else if (strcmp(driver, "binary") == 0)
 	{
-		if (details.port == 8123)
-			details.port = 9000;
-
 		return chfdw_binary_connect(&details);
 	}
 	else

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -17,4 +17,10 @@ typedef struct ch_binary_connection_t
 	char			  *error;
 } ch_binary_connection_t;
 
+/*
+ * Check whether the given string matches a ClickHouse Cloud host name.
+ */
+extern int ch_is_cloud_host(const char *host);
+int ends_with(const char *s, const char *suffix);
+
 #endif /* CLICKHOUSE_INTERNAL_H */

--- a/src/internal.c
+++ b/src/internal.c
@@ -1,0 +1,19 @@
+#include <string.h>
+#include <internal.h>
+
+int ends_with(const char *s, const char *suffix) {
+	size_t slen = strlen(s);
+	size_t suffix_len = strlen(suffix);
+	return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
+}
+
+/*
+ * Check whether the given string matches a ClickHouse Cloud host name.
+ */
+int ch_is_cloud_host(const char *host)
+{
+	if (!host) return 0;
+	return ends_with(host, ".clickhouse.cloud")
+		|| ends_with(host, ".clickhouse-staging.com")
+		|| ends_with(host, ".clickhouse-dev.com");
+}

--- a/src/option.c
+++ b/src/option.c
@@ -27,7 +27,6 @@
 
 static char *DEFAULT_DBNAME = "default";
 
-
 /*
  * Describes the valid options for objects that this wrapper uses.
  */
@@ -46,7 +45,7 @@ typedef struct ChFdwOption
 static ChFdwOption *clickhouse_fdw_options;
 
 /*
- * Valid options for clickhouseclient.
+ * Valid options for clickhouse client.
  * Allocated and filled in InitChFdwOptions.
  */
 static const ChFdwOption ch_options[] =


### PR DESCRIPTION
Inspect the host name and port to determine whether to make a TLS connection to ClickHouse. The new internal function `ch_is_cloud_host()` returns a value other than `0` if the host name argument is a ClickHouse cloud host, matching any of the ClickHouse cloud environment host names.

For binary connections, set the port to the ClickHouse secure port if `ch_is_cloud_host()` returns true for the host name and enable TLS if the port, whether explicitly specified for the connection or set by matching the host name, is the ClickHouse secure port.

For HTTP connections, set the port to the ClickHouse TLS HTTP port if `ch_is_cloud_host()` returns true for the host name. Then set the URL scheme to "https" if the port, whether explicitly specified for the connection or set by matching the host name, is the ClickHouse TLS secure port or the standard HTTPS port.

Tested both patterns against a `.clickhouse.cloud` host name and used it to successfully import a schema.

In passing, remove a debugging `printf` statement from `.github/ubuntu/clickhouse.sh` and a duplicate library argument to `SHLIB_LINK` in the `Makefile`.