### PR TITLE
Flesh out and test PGXN distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 .gitignore export-ignore
 .gitattributes export-ignore
 .github export-ignore
+.gitmodules export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,35 @@
-name: 🚀 Release
-on:
-  push:
-    tags: [v*]
+name: 🚀 Bundle & Release
+on: [push, pull_request]
 jobs:
   release:
     name: Release on GitHub and PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
-      PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-        with: { submodules: true }
+      - name: Start Postgres
+        run: pg-start 18 libcurl4-openssl-dev uuid-dev
+      - name: Start ClickHouse
+        env: { CH_RELEASE: "${{ matrix.ch }}" }
+        run: .github/ubuntu/clickhouse.sh
       - name: Bundle the Release
+        env: { GIT_ARCHIVE_CMD: archive-all }
         id: bundle
         run: pgxn-bundle
+      - name: Test the Bundle
+        env: { PGUSER: postgres }
+        run: make dist-test
       - name: Release on PGXN
+        if: startsWith( github.ref, 'refs/tags/v' )
+        env:
+          PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+          PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
         run: pgxn-release
       - name: Generate Release Changes
         run: make latest-changes.md
       - name: Create GitHub Release
+        if: startsWith( github.ref, 'refs/tags/v' )
         uses: softprops/action-gh-release@v2
         with:
           name: "Release ${{ github.ref_name }}"

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,16 @@ endif
 install: install-ch-cpp
 
 # Build a PGXN distribution bundle.
-dist:
-	git archive --format zip --prefix=$(EXTENSION)-$(DISTVERSION)/ -o $(EXTENSION)-$(DISTVERSION).zip HEAD
+dist: $(EXTENSION)-$(DISTVERSION).zip
+
+$(EXTENSION)-$(DISTVERSION).zip:
+	git archive-all -v --prefix "$(EXTENSION)-$(DISTVERSION)/" --force-submodules $(EXTENSION)-$(DISTVERSION).zip
+
+# Test the PGXN distribution.
+dist-test: $(EXTENSION)-$(DISTVERSION).zip
+	unzip $(EXTENSION)-$(DISTVERSION).zip
+	cd $(EXTENSION)-$(DISTVERSION)
+	make && make install && make installcheck
 
 # Generate a list of the changes just for the current version.
 latest-changes.md: Changes


### PR DESCRIPTION
Update the `Makefile` target to use `git-archive-all` to create the archive in order to include `clickhouse-cpp` in the release zip file and add the `dist-test` target to test a release.

Flesh out `.github/workflows/release.yml` to also use `archive-all` and also to start Postgres and ClickHouse and test the new release zip file for every push. Only release on a tag starting with "v".