### PR TITLE
Add `regexp_like` pushdown and document functions

### DIFF
--- a/doc/clickhouse_fdw.md
+++ b/doc/clickhouse_fdw.md
@@ -70,15 +70,51 @@ SELECT clickhouse_raw_query(
 
 ### Pushdown Functions
 
-These functions are designed to be pushed down to ClickHouse. If they're not,
-they will raise an exception.
+All PostgreSQL builtin functions used in conditionals (`HAVING` and `WHERE`
+clauses) automatically push down to ClickHouse with the same names and
+signatures. However, some have different names or signatures and must be
+mapped to their equivalents. `clickhouse_fdw` maps the following functions:
+
+*   `date_part`:
+    *   `date_part('day')`: [toDayOfMonth](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toDayOfMonth)
+    *   `date_part('doy')`: [toDayOfYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toDayOfYear)
+    *   `date_part('dow')`: [toDayOfWeek](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toDayOfWeek)
+    *   `date_part('year')`: [toYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toYear)
+    *   `date_part('month')`: [toMonth](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toMonth)
+    *   `date_part('hour')`: [toHour](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toHour)
+    *   `date_part('minute')`: [toMinute](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toMinute)
+    *   `date_part('second')`: [toSecond](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toSecond)
+    *   `date_part('quarter')`: [toQuarter](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toQuarter)
+    *   `date_part('isoyear')`: [toISOYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toISOYear)
+    *   `date_part('week')`: [toISOYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toISOWeek)
+    *   `date_part('epoch')`: [toISOYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toUnixTimestamp)
+*   `date_trunc`:
+    *   `date_trunc('week')`: [toMonday](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toMonday)
+    *   `date_trunc('second')`: [toStartOfSecond](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfSecond)
+    *   `date_trunc('minute')`: [toStartOfMinute](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfMinute)
+    *   `date_trunc('hour')`: [toStartOfHour](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfHour)
+    *   `date_trunc('day')`: [toStartOfDay](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfDay)
+    *   `date_trunc('month')`: [toStartOfMonth](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfMonth)
+    *   `date_trunc('quarter')`: [toStartOfQuarter](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfQuarter)
+    *   `date_trunc('year')`: [toStartOfYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfYear)
+*   `array_position`: [toTimeZone](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf)
+*   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
+*   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
+*   `regexp_like` => [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+
+### Custom Functions
+
+These custom functions created by `clickhouse_fdw` provide pushdown for select
+ClickHouse functions with no PostgreSQL equivalents. If any of these functions
+cannot be pushed down they will raise an exception.
 
 *   [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictget-dictgetordefault-dictgetornull)
 
 ### Pushdown Aggregates
 
-These aggregate functions are designed to be pushed down to ClickHouse. If they're not,
-they will raise an exception.
+These custom aggregate functions created by `clickhouse_fdw` provide pushdown
+for select ClickHouse aggregate functions with no PostgreSQL equivalents. If
+any of these functions cannot be pushed down they will raise an exception.
 
 *   [argMax](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/argmax)
 *   [argMin](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/argmin)

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1782,16 +1782,6 @@ deparseStringLiteral(StringInfo buf, const char *val, bool quote)
 {
 	const char *valptr;
 
-	/*
-	 * Rather than making assumptions about the remote server's value of
-	 * standard_conforming_strings, always use E'foo' syntax if there are any
-	 * backslashes.  This will fail on remote servers before 8.1, but those
-	 * are long out of support.
-	 */
-	if (strchr(val, '\\') != NULL)
-	{
-		appendStringInfoChar(buf, ESCAPE_STRING_SYNTAX);
-	}
 	if (quote)
 		appendStringInfoChar(buf, '\'');
 	for (valptr = val; *valptr; valptr++)
@@ -2610,6 +2600,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		if (!context->func)
 			appendStringInfoChar(buf, ')');
 	}
+
 	appendStringInfoChar(buf, '(');
 	if (cdef && cdef->cf_type == CF_AJTIME_DAY_DIFF)
 	{
@@ -2620,7 +2611,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		appendStringInfoString(buf, ") / 86400)");
 		return;
 	}
-	else if (cdef && cdef->cf_type == CF_TIMEZONE)
+	else if (cdef && (cdef->cf_type == CF_TIMEZONE || cdef->cf_type == CF_MATCH))
 	{
 		deparseExpr((Expr *) list_nth(node->args, 1), context);
 		appendStringInfoString(buf, ", ");

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -282,7 +282,8 @@ typedef enum {
 	CF_AJBOOL_OUT,
 	CF_HSTORE_FETCHVAL,		/* -> operation on hstore */
 	CF_INTARRAY_IDX,
-	CF_CH_FUNCTION		/* adapted clickhouse function */
+	CF_CH_FUNCTION,		/* adapted clickhouse function */
+	CF_MATCH,		/* regexp_match function */
 } custom_object_type;
 
 typedef enum {

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -632,11 +632,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -65,11 +65,32 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t5 VALUES
+		('2025-10-15T20:12:25'),
+		('2026-11-16T32:13:26'),
+		('2027-12-17T22:14:27'),
+		('2028-01-18T23:15:28'),
+		('2029-02-19T01:16:29'),
+		('2030-03-20T02:16:30')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
 CREATE FOREIGN TABLE t3_map (key1 int, key2 text, val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
+CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -441,7 +462,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('dAy'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
 (4 rows)
@@ -457,7 +478,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('day'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
 (4 rows)
@@ -552,7 +573,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') a
                                                                                                                 QUERY PLAN                                                                                                                
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('SeCond'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC
 (4 rows)
@@ -648,6 +669,304 @@ SELECT a, dictGet('functions_test.t3_dict', 'val', (1, 'key' || a::text)) as val
  3 |      |   4
 (3 rows)
 
+-- Check date_part mappings.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('year', ts) = '2023';
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toYear(ts) = 2023))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('year', ts) = '2027';
+         ts          
+---------------------
+ 2027-12-17 22:14:27
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('month', ts) = '11';
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonth(ts) = 11))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('month', ts) = '11';
+         ts          
+---------------------
+ 2026-11-17 08:13:26
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('day', ts) = '18';
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfMonth(ts) = 18))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('day', ts) = '18';
+         ts          
+---------------------
+ 2028-01-18 23:15:28
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('hour', ts) = '20';
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toHour(ts) = 20))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('hour', ts) = '20';
+         ts          
+---------------------
+ 2025-10-15 20:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('minute', ts) = '16';
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMinute(ts) = 16))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('minute', ts) = '16';
+         ts          
+---------------------
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('second', ts) = '26';
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toSecond(ts) = 26))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('second', ts) = '26';
+         ts          
+---------------------
+ 2026-11-17 08:13:26
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfYear(ts) = 351))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
+         ts          
+---------------------
+ 2027-12-17 22:14:27
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
+         ts          
+---------------------
+ 2026-11-17 08:13:26
+ 2028-01-18 23:15:28
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toQuarter(ts) = 1))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
+         ts          
+---------------------
+ 2028-01-18 23:15:28
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('isoyear', ts) = '2025';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toISOYear(ts) = 2025))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('isoyear', ts) = '2025';
+         ts          
+---------------------
+ 2025-10-15 20:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('week', ts) = '47';
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toISOWeek(ts) = 47))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('week', ts) = '47';
+         ts          
+---------------------
+ 2026-11-17 08:13:26
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('epoch', ts) > '1866158180';
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toUnixTimestamp(ts) > 1866158180))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_part('epoch', ts) > '1866158180';
+         ts          
+---------------------
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(2 rows)
+
+-- Check date_trunc mappings.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('year', ts) = '2026-01-01'::date;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfYear(ts) = '2026-01-01'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('year', ts) = '2026-01-01'::date;
+         ts          
+---------------------
+ 2026-11-17 08:13:26
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('month', ts) = '2027-12-01'::date;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfMonth(ts) = '2027-12-01'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('month', ts) = '2027-12-01'::date;
+         ts          
+---------------------
+ 2027-12-17 22:14:27
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('day', ts) = '2028-01-18'::date;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfDay(ts) = '2028-01-18'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('day', ts) = '2028-01-18'::date;
+         ts          
+---------------------
+ 2028-01-18 23:15:28
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('hour', ts) = '2029-02-19T01:00:00';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfHour(ts) = '2029-02-19 01:00:00'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('hour', ts) = '2029-02-19T01:00:00';
+         ts          
+---------------------
+ 2029-02-19 01:16:29
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('minute', ts) = '2025-10-15T20:12:00';
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfMinute(ts) = '2025-10-15 20:12:00'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('minute', ts) = '2025-10-15T20:12:00';
+         ts          
+---------------------
+ 2025-10-15 20:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('second', ts) = '2027-12-17T22:14:27';
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfSecond(toDateTime64(ts, 1)) = '2027-12-17 22:14:27'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('second', ts) = '2027-12-17T22:14:27';
+         ts          
+---------------------
+ 2027-12-17 22:14:27
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('week', ts) = '2028-01-17'::date;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonday(ts) = '2028-01-17'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('week', ts) = '2028-01-17'::date;
+         ts          
+---------------------
+ 2028-01-18 23:15:28
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toStartOfQuarter(ts) = '2027-10-01'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
+         ts          
+---------------------
+ 2027-12-17 22:14:27
+(1 row)
+
+-- check regexp_like.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+ERROR:  function regexp_like(unknown, text) does not exist
+LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+ERROR:  function regexp_like(unknown, text) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+                                 ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 
@@ -656,9 +975,10 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
 drop cascades to foreign table t3_map
 drop cascades to foreign table t4
+drop cascades to foreign table t5

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -462,7 +462,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('dAy'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
 (4 rows)
@@ -478,7 +478,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('day'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
 (4 rows)
@@ -573,7 +573,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') a
                                                                                                                 QUERY PLAN                                                                                                                
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('SeCond'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC
 (4 rows)
@@ -958,20 +958,15 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 
 -- check regexp_like.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
- Foreign Scan on public.t4
-   Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
-(3 rows)
-
+ERROR:  function regexp_like(unknown, text) does not exist
+LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 SELECT val FROM t4 WHERE regexp_like('^val\d', val);
- val  
-------
- val1
- val2
-(2 rows)
-
+ERROR:  function regexp_like(unknown, text) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+                                 ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -676,11 +676,11 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 (110 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = E'foo''s\\bar'))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -53,8 +53,9 @@ functions.sql
 
  Postgres | File
 ----------|---------------
- 14-18    | functions.out
- 13       | functions_1.out
+ 15-18    | functions.out
+ 14       | functions_1.out
+ 13       | functions_2.out
 
  ClickHouse | File
 ------------|---------------


### PR DESCRIPTION
Document the builtin PostgreSQL functions that `clickhouse_fdw` pushes down to ClickHouse equivalents. Add a new one, `regexp_like` (on Postgres 15+ only), which pushes down to `match`. While at it, revamp the backward compatibility of function OID constants to use their newer names, populated from the old for older versions.

Add explicit tests `date_part`, `date_trunc`, and `regexp_like` and document that they're pushed down in filter expressions but not select expressions. As a result of the `regexp_like` test returning an error from ClickHouse, remove `E''` quoting from `deparseStringLiteral()`, a leftover from `postgresql_fdw` that isn't relevant to ClickHouse, indeed breaks it. This also requires updating the `binary_queries` and `http` expected output, both of which had `E''` quotes they no longer require.