### PR TITLE
Set default host name in `ch_http_connection()`

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -69,6 +69,8 @@ ch_http_connection_t *ch_http_connection(char *host, int port, char *username, c
 	if (!conn->curl)
 		goto cleanup;
 
+	if (!host || !*host) host = "localhost";
+
 	if (!port)
 		port = ch_is_cloud_host(host) ? CLICKHOUSE_TLS_PORT : CLICKHOUSE_PORT;
 

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -9,7 +9,7 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -6,7 +6,7 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
-SELECT clickhouse_raw_query('CREATE DATABASE http_test');
+SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
 SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);


### PR DESCRIPTION
Otherwise, calls to `clickhouse_raw_query()` with a connection string that omits the host name causes an error. Using "localhost" as the default to match the default specified in the `CREATE FUNCTION` default. Add an empty connection string argument to a call to `clickhouse_raw_query()` in `tests/sql/http.sql` to test it.

Resolves #18.