### PR TITLE
Omit * arg for `COUNT(*)`

### DIFF
--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -707,6 +707,28 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC
 (5 rows)
 
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+ count 
+-------
+    19
+(1 row)
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (c1 < 20)))
+   Relations: Aggregate on (ft2)
+   Remote SQL: SELECT countIf((((c1 < 20)) > 0)) FROM binary_queries_test.t2
+(4 rows)
+
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
+ count 
+-------
+     9
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/sql/binary_queries.sql
+++ b/test/sql/binary_queries.sql
@@ -181,6 +181,11 @@ SELECT COUNT(DISTINCT c1) FROM ft2;
 
 /* DISTINCT with IF */
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
+
+/* https://github.com/ClickHouse/clickhouse_fdw/issues/25 */
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
+SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
 
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
 


### PR DESCRIPTION
Avoid the `Aggregate function COUNT requires zero or one argument` error from ClickHouse when converting a filtered `COUNT(*)` to the ClickHouse [-If suffix] variant. Works around ClickHouse/ClickHouse#89372. Resolves #25.

  [-If suffix]: https://clickhouse.com/docs/sql-reference/aggregate-functions/combinators#-if