### PR TITLE
Map `count()` to BIGINT

### DIFF
--- a/src/pglink.c
+++ b/src/pglink.c
@@ -817,8 +817,12 @@ parse_type(char *colname, char *typepart, bool *is_nullable, List **options)
 				 strncmp(typepart, "SimpleAggregateFunction", strlen("SimpleAggregateFunction")) == 0)
 		{
 			char *pos2 = strstr(pos, ",");
-			if (pos2 == NULL)
+			if (pos2 == NULL) {
+				// Detect COUNT with no params.
+				if (strncmp(insidebr, "count", strlen("count")) == 0)
+					return "BIGINT";
 				elog(ERROR, "clickhouse_fdw: expected comma in AggregateFunction");
+			}
 
 			char *func = pnstrdup(pos + 1, strstr(pos + 1, ",") - pos - 1);
 

--- a/test/expected/engines.out
+++ b/test/expected/engines.out
@@ -83,7 +83,8 @@ SELECT clickhouse_raw_query('
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
-		d SimpleAggregateFunction(sum, Int64))
+		d SimpleAggregateFunction(sum, Int64),
+		e AggregateFunction(count))
 	engine = AggregatingMergeTree()
 	order by a');
  clickhouse_raw_query 
@@ -162,11 +163,13 @@ FDW options: (database 'engines_test', table_name 't3_aggr', engine 'Materialize
  b      | integer |           | not null |         | (aggregatefunction 'sum')       | plain   |              | 
  c      | integer |           | not null |         | (aggregatefunction '1')         | plain   |              | 
  d      | bigint  |           | not null |         | (simpleaggregatefunction 'sum') | plain   |              | 
+ e      | bigint  |           | not null |         |                                 | plain   |              | 
 Not-null constraints:
     "t4_a_not_null" NOT NULL "a"
     "t4_b_not_null" NOT NULL "b"
     "t4_c_not_null" NOT NULL "c"
     "t4_d_not_null" NOT NULL "d"
+    "t4_e_not_null" NOT NULL "e"
 Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't4', engine 'AggregatingMergeTree')
 

--- a/test/expected/engines_1.out
+++ b/test/expected/engines_1.out
@@ -83,7 +83,8 @@ SELECT clickhouse_raw_query('
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
-		d SimpleAggregateFunction(sum, Int64))
+		d SimpleAggregateFunction(sum, Int64),
+		e AggregateFunction(count))
 	engine = AggregatingMergeTree()
 	order by a');
  clickhouse_raw_query 
@@ -146,6 +147,7 @@ FDW options: (database 'engines_test', table_name 't3_aggr', engine 'Materialize
  b      | integer |           | not null |         | (aggregatefunction 'sum')       | plain   |              | 
  c      | integer |           | not null |         | (aggregatefunction '1')         | plain   |              | 
  d      | bigint  |           | not null |         | (simpleaggregatefunction 'sum') | plain   |              | 
+ e      | bigint  |           | not null |         |                                 | plain   |              | 
 Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't4', engine 'AggregatingMergeTree')
 

--- a/test/sql/engines.sql
+++ b/test/sql/engines.sql
@@ -42,7 +42,8 @@ SELECT clickhouse_raw_query('
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
-		d SimpleAggregateFunction(sum, Int64))
+		d SimpleAggregateFunction(sum, Int64),
+		e AggregateFunction(count))
 	engine = AggregatingMergeTree()
 	order by a');
 


### PR DESCRIPTION
When parsing the type of materialized view column, detect `AggregateFunction(count)` and return its data type, `BIGINT`. Without this change, the import would fail with the error, `clickhouse_fdw: expected comma in AggregateFunction`. But since `count()` is valid just return its type.