### PR TITLE
Add quantile(), params() for parametric aggregates

### DIFF
--- a/doc/clickhouse_fdw.md
+++ b/doc/clickhouse_fdw.md
@@ -13,8 +13,6 @@ This library contains a single PostgreSQL extension, a [foreign data wrapper]
 for [ClickHouse] databases. It supports PostgreSQL 13 and higher and
 ClickHouse 22 and higher.
 
-
-
 ## Usage
 
 ### Functions
@@ -124,6 +122,26 @@ any of these functions cannot be pushed down they will raise an exception.
 *   [uniqExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/uniqexact)
 *   [uniqHLL12](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/uniqhll12)
 *   [uniqTheta](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/uniqthetasketch)
+*   [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
+
+#### Parametric Aggregates
+
+To pass parameters to ClickHouse [Parametric aggregate functions], pass a call
+to the special `params()` function as the first argument. For example, a
+ClickHouse query such as
+
+```sql
+SELECT quantile(0.25)(val) FROM t;
+```
+
+Should be written in PostgreSQL as:
+
+```sql
+SELECT quantile(params(0.25), val) FROM t;
+```
+
+Omit `params()` to get the default value, where relevant.
 
 ## Authors
 
@@ -141,3 +159,4 @@ any of these functions cannot be pushed down they will raise an exception.
   [foreign data wrapper]: https://www.postgresql.org/docs/current/fdwhandler.html
     "PostgreSQL Docs: Writing a Foreign Data Wrapper"
   [ClickHouse]: https://clickhouse.com/clickhouse
+  [Parametric aggregate functions]: https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -314,6 +314,7 @@ typedef struct CustomColumnInfo
 } CustomColumnInfo;
 
 extern CustomObjectDef *chfdw_check_for_custom_function(Oid funcid);
+extern FuncExpr * ch_get_params_function(TargetEntry *tle);
 extern CustomObjectDef *chfdw_check_for_custom_type(Oid typeoid);
 extern void chfdw_apply_custom_table_options(CHFdwRelationInfo *fpinfo, Oid relid);
 extern CustomColumnInfo *chfdw_get_custom_column_info(Oid relid, uint16 varattno);

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -14,7 +14,6 @@ SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
  
 (1 row)
 
--- argMax, argMin
 SELECT clickhouse_raw_query($$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
@@ -187,7 +186,7 @@ SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
 ---+-----
 (0 rows)
 
--- check argMin, argMax, uniqExact
+-- check aggregates.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -456,6 +455,66 @@ SELECT uniqTheta(a, c) FROM t1;
  uniqtheta 
 -----------
          3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(params(0.25), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(params(0.25), a) FROM t1;
+ quantile 
+----------
+     1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(a) FROM t1;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(a) FROM t1;
+ quantile 
+----------
+        2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(params(0.75), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(params(0.75), a) FROM t1;
+ quantileexact 
+---------------
+             2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(a) FROM t1;
+ quantileexact 
+---------------
+             2
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -14,7 +14,6 @@ SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
  
 (1 row)
 
--- argMax, argMin
 SELECT clickhouse_raw_query($$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
@@ -187,7 +186,7 @@ SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
 ---+-----
 (0 rows)
 
--- check argMin, argMax, uniqExact
+-- check aggregates.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -456,6 +455,66 @@ SELECT uniqTheta(a, c) FROM t1;
  uniqtheta 
 -----------
          3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(params(0.25), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(params(0.25), a) FROM t1;
+ quantile 
+----------
+     1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(a) FROM t1;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(a) FROM t1;
+ quantile 
+----------
+        2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(params(0.75), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(params(0.75), a) FROM t1;
+ quantileexact 
+---------------
+             2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(a) FROM t1;
+ quantileexact 
+---------------
+             2
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -14,7 +14,6 @@ SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
  
 (1 row)
 
--- argMax, argMin
 SELECT clickhouse_raw_query($$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
@@ -187,7 +186,7 @@ SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
 ---+-----
 (0 rows)
 
--- check argMin, argMax, uniqExact
+-- check aggregates.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
                         QUERY PLAN                        
 ----------------------------------------------------------
@@ -456,6 +455,66 @@ SELECT uniqTheta(a, c) FROM t1;
  uniqtheta 
 -----------
          3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(params(0.25), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(params(0.25), a) FROM t1;
+ quantile 
+----------
+     1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(a) FROM t1;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan
+   Output: (quantile(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantile(a) FROM t1;
+ quantile 
+----------
+        2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(params(0.75), a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(params(0.75), a) FROM t1;
+ quantileexact 
+---------------
+             2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Foreign Scan
+   Output: (quantileexact(a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExact(a) FROM functions_test.t1
+(4 rows)
+
+SELECT quantileExact(a) FROM t1;
+ quantileexact 
+---------------
+             2
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -6,7 +6,6 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
 SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
 
--- argMax, argMin
 SELECT clickhouse_raw_query($$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
@@ -90,7 +89,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
 SELECT a, sum(b) FROM t1 WHERE a NOT IN (1,2,3) GROUP BY a;
 
--- check argMin, argMax, uniqExact
+-- check aggregates.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT argMin(a, b) FROM t1;
 SELECT argMin(a, b) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT argMax(a, b) FROM t1;
@@ -132,6 +131,16 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqTheta(a, b) FROM t1;
 SELECT uniqTheta(a, b) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqTheta(a, c) FROM t1;
 SELECT uniqTheta(a, c) FROM t1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
+SELECT quantile(params(0.25), a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(a) FROM t1;
+SELECT quantile(a) FROM t1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
+SELECT quantileExact(params(0.75), a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
+SELECT quantileExact(a) FROM t1;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;


### PR DESCRIPTION
ClickHouse provides a number of "parametric aggregates" which take one or more parameters in a first set of parentheses and then normal arguments in a second. An example is `quantile`, which can be called like so:

    SELECT quantile(0.25)(val) FROM t;

To mimic this feature, implement a `params` data type and function that takes a list of values of any type. Detect when it's the first argument to any aggregates and pass it as ClickHouse parameters before any other arguments. The equivalent of the above query in PostgreSQL is:

    SELECT quantile(params(0.25), val) FROM t;

The pattern is general and can be used for any aggregate functions, but used here only for the new `quantile` and `quantileExact` aggregate functions. Others can be added in the future; all they have to do is use the `clickhouse_func_push_fail` function for their `SFUNC`, with one variant that takes `params` as the first argument and the remaining arguments specified as usual (likely as `"any"` to allow data type enforcement to be pushed down to ClickHouse).

Done by using the new `ch_get_params_function() function to detect `params()` as the first argument to an aggregate function in `deparseAggref()` and emitting it before appending the arguments opening parenthesis.

Document the new functions and explain how to use them.

While at it, simplify the handling of `F_REGEXP_LIKE_TEXT_TEXT` in Postgres 14 and earlier by simply setting it on those versions, rather than using `#define` to omit any code that uses it. This aligns with how the type mapper handles other such data type constants.

Also:

*   Fix an `Assert` for a variadic array to apply to the array, rather than the parent node. *   Also, remove the unused `func_arg` field from the `deparse_expr_cxt` struct and add a comment explaining the `array_as_tuple` field.