### PR TITLE
Add clickhouse_push_fail() for params, dictGet

### DIFF
--- a/sql/clickhouse_fdw.sql
+++ b/sql/clickhouse_fdw.sql
@@ -24,31 +24,25 @@ CREATE FOREIGN DATA WRAPPER clickhouse_fdw
 -- Function used for parametric aggregate parameters.
 CREATE TYPE params AS ();
 CREATE FUNCTION params(VARIADIC "any") RETURNS params
-AS 'MODULE_PATHNAME', 'clickhouse_func_push_fail'
+AS 'MODULE_PATHNAME', 'clickhouse_push_fail'
 LANGUAGE C STRICT;
 
 -- Function used by variadic aggregate functions when pushdown fails. The
 -- first argument should describe the operation that should have been pushed
 -- down.
 CREATE FUNCTION ch_push_agg_text(TEXT, VARIADIC "any") RETURNS TEXT
-AS 'MODULE_PATHNAME', 'clickhouse_func_push_fail'
-LANGUAGE C STRICT;
-
--- Function used by TEXT-returning functions when pushdown fails. The
--- argument should describe the operation that should have been pushed down.
-CREATE FUNCTION ch_push_func_text(TEXT) RETURNS TEXT
-AS 'MODULE_PATHNAME', 'clickhouse_func_push_fail'
+AS 'MODULE_PATHNAME', 'clickhouse_op_push_fail'
 LANGUAGE C STRICT;
 
 -- Function used by parametric aggregates that take an array for the
 -- parameters plus an item of any type.
 CREATE FUNCTION ch_param_any_text(TEXT, params, "any") RETURNS TEXT
-AS 'MODULE_PATHNAME', 'clickhouse_func_push_fail'
+AS 'MODULE_PATHNAME', 'clickhouse_op_push_fail'
 LANGUAGE C STRICT;
 
 -- Function used by aggregates that take a single value of any type.
 CREATE FUNCTION ch_any_text(TEXT, "any") RETURNS TEXT
-AS 'MODULE_PATHNAME', 'clickhouse_func_push_fail'
+AS 'MODULE_PATHNAME', 'clickhouse_op_push_fail'
 LANGUAGE C STRICT;
 
 -- No-op functions used for aggregate final functions that specific types.
@@ -190,6 +184,6 @@ CREATE AGGREGATE uniqTheta(VARIADIC "any")
 */
 
 -- Create error-raising functions that should be pushed down to ClickHouse.
-CREATE FUNCTION dictGet(TEXT, TEXT, ANYELEMENT)
-RETURNS TEXT AS $$ SELECT ch_push_func_text('dictGet()') $$
-LANGUAGE 'sql' IMMUTABLE;
+CREATE FUNCTION dictGet(TEXT, TEXT, ANYELEMENT) RETURNS TEXT
+AS 'MODULE_PATHNAME', 'clickhouse_push_fail'
+LANGUAGE C STRICT;

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -180,7 +180,8 @@ typedef struct
  */
 PG_FUNCTION_INFO_V1(clickhouse_fdw_handler);
 PG_FUNCTION_INFO_V1(clickhouse_raw_query);
-PG_FUNCTION_INFO_V1(clickhouse_func_push_fail);
+PG_FUNCTION_INFO_V1(clickhouse_op_push_fail);
+PG_FUNCTION_INFO_V1(clickhouse_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_noop);
 extern PGDLLEXPORT void _PG_init(void);
 static double time_used = 0;
@@ -2875,15 +2876,29 @@ clickhouse_noop(PG_FUNCTION_ARGS)
 }
 
 /*
- * Function that simply raises an exception reporting that the first argument
- * should have been pushed down.
+ * Function that simply raises an exception reporting that the operation
+ * described by the first argument should have been pushed down.
 */
 Datum
-clickhouse_func_push_fail(PG_FUNCTION_ARGS)
+clickhouse_op_push_fail(PG_FUNCTION_ARGS)
 {
 	text* name = PG_GETARG_TEXT_PP(0);
 	ereport(ERROR,
 		errcode(ERRCODE_FDW_ERROR),
 		errmsg("clickhouse_fdw: failed to push down %s", text_to_cstring(name))
+	);
+}
+
+/*
+ * Function that simply raises an exception reporting that the function should
+ * have been pushed down.
+*/
+Datum
+clickhouse_push_fail(PG_FUNCTION_ARGS)
+{
+	char *name = get_func_name(fcinfo->flinfo->fn_oid);
+	ereport(ERROR,
+		errcode(ERRCODE_FDW_ERROR),
+		errmsg("clickhouse_fdw: failed to push down %s()", name)
 	);
 }

--- a/test/expected/function_pushdown.out
+++ b/test/expected/function_pushdown.out
@@ -44,7 +44,11 @@ NOTICE:   SELECT ch_argmax(true, false, now()) : HV000 - clickhouse_fdw: failed 
 NOTICE:   SELECT ch_argmin('x'::text, 'x'::text, 3) : HV000 - clickhouse_fdw: failed to push down aggregate argMin()
 NOTICE:   SELECT ch_argmin(3, 3, true) : HV000 - clickhouse_fdw: failed to push down aggregate argMin()
 NOTICE:   SELECT ch_argmin(true, false, now()) : HV000 - clickhouse_fdw: failed to push down aggregate argMin()
-NOTICE:   SELECT ch_push_func_text('hello') : HV000 - clickhouse_fdw: failed to push down hello
-NOTICE:   SELECT ch_push_func_text('goodbye') : HV000 - clickhouse_fdw: failed to push down goodbye
-NOTICE:   SELECT dictGet('', '', '{"x": true}'::json) : HV000 - clickhouse_fdw: failed to push down dictGet()
-NOTICE:   SELECT dictGet('a', 'b', ARRAY[1]) : HV000 - clickhouse_fdw: failed to push down dictGet()
+NOTICE:   SELECT dictGet('', '', '{"x": true}'::json) : HV000 - clickhouse_fdw: failed to push down dictget()
+NOTICE:   SELECT dictGet('a', 'b', ARRAY[1]) : HV000 - clickhouse_fdw: failed to push down dictget()
+NOTICE:   SELECT params(1) : HV000 - clickhouse_fdw: failed to push down params()
+NOTICE:   SELECT params(1, 98.6, 'foo', false) : HV000 - clickhouse_fdw: failed to push down params()
+NOTICE:   SELECT quantile(1) : HV000 - clickhouse_fdw: failed to push down aggregate quantile()
+NOTICE:   SELECT quantile('x') : HV000 - clickhouse_fdw: failed to push down aggregate quantile()
+NOTICE:   SELECT quantileExact(42) : HV000 - clickhouse_fdw: failed to push down aggregate quantileExact()
+NOTICE:   SELECT quantileExact(98.6) : HV000 - clickhouse_fdw: failed to push down aggregate quantileExact()

--- a/test/sql/function_pushdown.sql
+++ b/test/sql/function_pushdown.sql
@@ -66,12 +66,17 @@ BEGIN
         $$ SELECT ch_argmin(3, 3, true) $$,
         $$ SELECT ch_argmin(true, false, now()) $$,
 
-        $$ SELECT ch_push_func_text('hello') $$,
-        $$ SELECT ch_push_func_text('goodbye') $$,
-
         $$ SELECT dictGet('', '', '{"x": true}'::json) $$,
-        $$ SELECT dictGet('a', 'b', ARRAY[1]) $$
-    ] LOOP
+        $$ SELECT dictGet('a', 'b', ARRAY[1]) $$,
+
+        $$ SELECT params(1) $$,
+        $$ SELECT params(1, 98.6, 'foo', false) $$,
+
+        $$ SELECT quantile(1) $$,
+        $$ SELECT quantile('x') $$,
+        $$ SELECT quantileExact(42) $$,
+        $$ SELECT quantileExact(98.6) $$
+   ] LOOP
         BEGIN
             EXECUTE q;
             RAISE NOTICE '`%`: did not fail', q;


### PR DESCRIPTION
Add a new function `clickhouse_push_fail()`, that just looks up the nam of the SQL function and raises an exception reporting that it failed to be pushed down. Use it for `params()`, which previously would crash the server because it wasn't passing its function name to `clickhouse_func_push_fail()`.

Also use `clickhouse_push_fail()` for `dictGet()`, and remove the now unused function `ch_push_func_text()`. The only side effect is that `clickhouse_push_fail()` reports PostgreSQL canonical function names, which is to say all lowercase, e.g., `dictget()` instead of `dictGet()`.

To better represent that it reports pushdown failures for any operation passed as the first argument, rename `clickhouse_func_push_fail()` to `clickhouse_op_push_fail()`.

While at it, test the pushdown failure of `params()` in `test/sql/function_pushdown.sql`; this call previously would crash the server. Also test the pushdown failure of `quantile()` and `quantileExact()`.