### PR TITLE
Pushdown `percentile_cont()` as `quantile()`

### DIFF
--- a/doc/clickhouse_fdw.md
+++ b/doc/clickhouse_fdw.md
@@ -110,6 +110,34 @@ cannot be pushed down they will raise an exception.
 
 ### Pushdown Aggregates
 
+These PostgreSQL aggregate functions pushdown to ClickHouse.
+
+*   [count](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count)
+
+### Pushdown Ordered Set Aggregates
+
+These PostgreSQL [ordered-set aggregate functions] map to ClickHouse
+[Parametric aggregate functions] by passing their *direct argument* as a
+parameter and their `ORDER BY` expressions as arguments. For example, this
+PostgreSQL query:
+
+```sql
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+```
+
+Maps to this ClickHouse query:
+
+```sql
+SELECT quantile(0.25)(a) FROM t1;
+```
+
+Note that the non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST`
+are not supported and will raise an error.
+
+*   `percentile_cont(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+
+### Custom Aggregates
+
 These custom aggregate functions created by `clickhouse_fdw` provide pushdown
 for select ClickHouse aggregate functions with no PostgreSQL equivalents. If
 any of these functions cannot be pushed down they will raise an exception.
@@ -159,4 +187,5 @@ Omit `params()` to get the default value, where relevant.
   [foreign data wrapper]: https://www.postgresql.org/docs/current/fdwhandler.html
     "PostgreSQL Docs: Writing a Foreign Data Wrapper"
   [ClickHouse]: https://clickhouse.com/clickhouse
+  [ordered-set aggregate functions]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
   [Parametric aggregate functions]: https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -313,6 +313,7 @@ typedef struct CustomColumnInfo
 	char	signfield[NAMEDATALEN];
 } CustomColumnInfo;
 
+extern bool chfdw_check_for_builtin_ordered_aggregate(Oid funcid);
 extern CustomObjectDef *chfdw_check_for_custom_function(Oid funcid);
 extern FuncExpr * ch_get_params_function(TargetEntry *tle);
 extern CustomObjectDef *chfdw_check_for_custom_type(Oid typeoid);

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -517,6 +517,48 @@ SELECT quantileExact(a) FROM t1;
              2
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_cont 
+-----------------
+      1546426260
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -517,6 +517,48 @@ SELECT quantileExact(a) FROM t1;
              2
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_cont 
+-----------------
+      1546426260
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -517,6 +517,48 @@ SELECT quantileExact(a) FROM t1;
              2
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantile(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_cont 
+-----------------
+      1546426260
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+            1.75
+(1 row)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  clickhouse_fdw: ClickHouse does not support "DESC" in aggregate expressions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                   QUERY PLAN                                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -142,6 +142,15 @@ SELECT quantileExact(params(0.75), a) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
 SELECT quantileExact(a) FROM t1;
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 


### PR DESCRIPTION
Detect use of `percentile_cont()`, an ordered set aggregate, and push it down to ClickHouse as `quantile()`. Like `quantile()`'s parameters, the argument to `percentile_cont()` is evaluates only once, but the arguments to `WITHIN GROUP (ORDER BY)` are evaluated for each row.

In examples seen in the wild, including [HouseClick] and [this blog post], this appears to be a valid mapping, as long as there is no `DESC`, `USING >`, or `NULLS FIRST`.

In the future we should be able to map `percentile_cont(float[])` to `quantiles()`, though it will require converting the array argument to a parameter list. It might also make sense to map `percentile_disc` to `quantileExactHigh()`.

To implement this syntax conversion, `deparseAggref()` borrows from `postgres_fdw` to output the arguments to the aggregate as a parameter list and then the `WITHIN GROUP (ORDER)` as the normal parameter arguments. Thus this PostgreSQL query:

```sql
SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
```

Maps to this ClickHouse query:

```sql
SELECT quantile(0.25)(a) FROM t1;
```

The non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST` are not supported and will raise an error.

For normal aggregates it keeps the previous behavior.

  [HouseClick]: https://github.com/ClickHouse/HouseClick/blob/fa449b2/app/lib/analytics_queries.ts
  [this blog post]: https://clickhouse.com/blog/redshift-vs-clickhouse-comparison#ethereum-gas-used-by-week
    "Optimizing Analytical Workloads: Comparing Redshift vs ClickHouse"