### PR TITLE
Add query and status code to error messages

### DIFF
--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` does not exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` doesn't exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` doesn't exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect, or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -165,12 +165,13 @@ SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
 
 ALTER SERVER http_loopback OPTIONS (SET dbname 'no such database');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 81. DB::Exception: Database `no such database` doesn't exist. (UNKNOWN_DATABASE)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 81. DB::Exception: Database `no such database` doesn't exist. (UNKNOWN_DATABASE)
+DETAIL:  Remote Query: SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+CONTEXT:  HTTP status code: 404
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (ADD user 'no such user');
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1;  -- should fail
-ERROR:  clickhouse_fdw:Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect or there is no user with such name. (AUTHENTICATION_FAILED)
-QUERY:SELECT c1, c3, c4 FROM "no such database".t1 ORDER BY c3 ASC, c1 ASC
+ERROR:  clickhouse_fdw: Code: 516. DB::Exception: no such user: Authentication failed: password is incorrect or there is no user with such name. (AUTHENTICATION_FAILED)
+CONTEXT:  HTTP status code: 403
 ALTER SERVER http_loopback OPTIONS (SET dbname 'http_test');
 ALTER USER MAPPING FOR CURRENT_USER SERVER http_loopback OPTIONS (DROP user);
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work again


### PR DESCRIPTION
When queries fail, include error detail with the remote query that was executed. For HTTP queries, limit the query detail to response codes greater than or equal to 404 and also always include the status code in error context. Always include the remote SQL for binary queries and change the error code to `ERRCODE_SQL_ROUTINE_EXCEPTION`.