### PR TITLE
Pass filter expressions for ordered aggregates

### DIFF
--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -547,6 +547,21 @@ SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone(
       1546426260
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+               1
+(1 row)
+
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
  percentile_cont 
 -----------------

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -547,6 +547,21 @@ SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone(
       1546426260
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+               1
+(1 row)
+
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
  percentile_cont 
 -----------------

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -547,6 +547,21 @@ SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone(
       1546426260
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('0.25'::double precision) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+               1
+(1 row)
+
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
  percentile_cont 
 -----------------

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -146,6 +146,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
 SELECT percentile_cont(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;


### PR DESCRIPTION
Follow up to 087cfdc, restore emitting aggregate filter expressions as "-If" conditions after ordered aggregate output. This allows a query such as:

```sql
SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
```

To be sent to ClickHouse as:

```sql
SELECT quantileIf(0.25)(a, (((b = 1)) > 0)) FROM t1;
```

Done by moving the `-If` conditional out of the `if/then` for ordered vs normal aggregates, as well as "AVG stuff". This requires suppressing wrapping the ordered list expression in parentheses, done by setting the new `context.no_sort_parens` boolean.