### PR TITLE
Set `join_use_nulls`

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -147,9 +147,12 @@ ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char 
 
 	assert(conn && conn->curl);
 
-	/* construct url */
-	url = malloc(conn->base_url_len + 37 + 12 /* query_id + ?query_id= */);
-	sprintf(url, "%s?query_id=%s", conn->base_url, resp->query_id);
+	/* Enable SQL compatibility. */
+	const char *params = "join_use_nulls=1";
+
+	/* construct url: query_id + ?query_id= + params */
+	url = malloc(conn->base_url_len + 37 + 12 + strlen(params));
+	sprintf(url, "%s?query_id=%s&%s", conn->base_url, resp->query_id, params);
 
 	/* constant */
 	errbuffer[0] = '\0';


### PR DESCRIPTION
To increase SQL compatibility, set `join_use_nulls=1` before executing `SELECT` queries. Discovered via the recommendations for the [TPC-H queries].

Enabled for the http engine by passing the setting as a URL query parameter. Enabled for the binary engine by setting it for each query. It'd be nice to set it for every request via the binary client, but it does not currently offer an API for that purpose.

These solutions are generalized enough that adding additional settings in the future will be quite straightforward.

  [TPC-H queries]: https://clickhouse.com/docs/getting-started/example-datasets/tpch#queries