### PR TITLE
Propagate aggregate detection to outer node

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         # Test latest version and all LTS releases.
         # .github/ubuntu/ch-versions --lts --latest-stable --earliest 22  --prefix '          - ' | pbcopy

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         pg: [18, 17, 16, 15, 14, 13]
         os:

--- a/test/expected/engines.out
+++ b/test/expected/engines.out
@@ -84,7 +84,8 @@ SELECT clickhouse_raw_query('
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
 		d SimpleAggregateFunction(sum, Int64),
-		e AggregateFunction(count))
+		e AggregateFunction(count),
+		f AggregateFunction(quantile, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
  clickhouse_raw_query 
@@ -164,12 +165,14 @@ FDW options: (database 'engines_test', table_name 't3_aggr', engine 'Materialize
  c      | integer |           | not null |         | (aggregatefunction '1')         | plain   |              | 
  d      | bigint  |           | not null |         | (simpleaggregatefunction 'sum') | plain   |              | 
  e      | bigint  |           | not null |         |                                 | plain   |              | 
+ f      | integer |           | not null |         | (aggregatefunction 'quantile')  | plain   |              | 
 Not-null constraints:
     "t4_a_not_null" NOT NULL "a"
     "t4_b_not_null" NOT NULL "b"
     "t4_c_not_null" NOT NULL "c"
     "t4_d_not_null" NOT NULL "d"
     "t4_e_not_null" NOT NULL "e"
+    "t4_f_not_null" NOT NULL "f"
 Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't4', engine 'AggregatingMergeTree')
 
@@ -244,6 +247,34 @@ SELECT a, sum(b) FROM t2 GROUP BY a ORDER BY a;
  8 | 530
  9 | 540
 (10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (percentile_cont('0.75'::double precision) WITHIN GROUP (ORDER BY ((f)::double precision)))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, quantileMerge(0.75)(f) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+ a | percentile_cont 
+---+-----------------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, ((percentile_cont('0.75'::double precision) WITHIN GROUP (ORDER BY ((f)::double precision)) / (sum(d))::double precision))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, (quantileMerge(0.75)(f) / sum(d)) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+ a | ?column? 
+---+----------
+(0 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');

--- a/test/expected/engines_1.out
+++ b/test/expected/engines_1.out
@@ -84,7 +84,8 @@ SELECT clickhouse_raw_query('
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
 		d SimpleAggregateFunction(sum, Int64),
-		e AggregateFunction(count))
+		e AggregateFunction(count),
+		f AggregateFunction(quantile, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
  clickhouse_raw_query 
@@ -148,6 +149,7 @@ FDW options: (database 'engines_test', table_name 't3_aggr', engine 'Materialize
  c      | integer |           | not null |         | (aggregatefunction '1')         | plain   |              | 
  d      | bigint  |           | not null |         | (simpleaggregatefunction 'sum') | plain   |              | 
  e      | bigint  |           | not null |         |                                 | plain   |              | 
+ f      | integer |           | not null |         | (aggregatefunction 'quantile')  | plain   |              | 
 Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't4', engine 'AggregatingMergeTree')
 
@@ -222,6 +224,34 @@ SELECT a, sum(b) FROM t2 GROUP BY a ORDER BY a;
  8 | 530
  9 | 540
 (10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (percentile_cont('0.75'::double precision) WITHIN GROUP (ORDER BY ((f)::double precision)))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, quantileMerge(0.75)(f) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+ a | percentile_cont 
+---+-----------------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, ((percentile_cont('0.75'::double precision) WITHIN GROUP (ORDER BY ((f)::double precision)) / (sum(d))::double precision))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, (quantileMerge(0.75)(f) / sum(d)) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+ a | ?column? 
+---+----------
+(0 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');

--- a/test/sql/engines.sql
+++ b/test/sql/engines.sql
@@ -43,7 +43,8 @@ SELECT clickhouse_raw_query('
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
 		d SimpleAggregateFunction(sum, Int64),
-		e AggregateFunction(count))
+		e AggregateFunction(count),
+		f AggregateFunction(quantile, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
 
@@ -63,6 +64,12 @@ SELECT a, sum(b) FROM t1_aggr GROUP BY a ORDER BY a;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT a, sum(b) FROM t2 GROUP BY a;
 SELECT a, sum(b) FROM t2 GROUP BY a ORDER BY a;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');


### PR DESCRIPTION
The `foreign_expr_walker` function recursively walks the nodes in an SQL query. To detect whether a table column was configured as an `AggregateFunction`, the `T_Aggref` node checks to see if the next node sets `found_AggregateFunction`. For most aggregate functions, the `T_Var` node is next, so `T_Aggref` sees it and sets it properly.

However, sometimes the `T_Var` node is *not* the next node after a `T_Aggref` node. For ordered set aggregates such as `percentile_cont`, there can be a `T_FuncExpr` node, a `T_List`, and *then* a `T_Var` node. But the setting of `found_AggregateFunction` was not propagated from the recursive call, so it would be lost. This resulted in `percentile_cont`, which maps to ClickHouse's `quantile` function, not getting the `Merge` suffix for a `AggregateFunction(quantile)` column.

So set the outer (previous) context's `found_AggregateFunction` to true if the current inner context has set it to true. This allows its value to propagate back to `T_Aggref` and be detected (and then unset). As a result, it properly appends `Merge` to `quantile`, thus properly executing against an `AggregateFunction(quantile)` column.

Add a test case to `test/sql/engines.sql` demonstrating this functionality, including the remote SQL converting `percentile_cont` to `quantileMerge` to query a `AggregateFunction(quantile)` column. Add another test that includes following nodes, including another aggregate function, to ensure that a true `found_AggregateFunction` value only propagates to the previous `T_Aggref`, not any subsequent `T_Aggref` nodes.

While at it, tell the ClickHouse and Postgres workflows not to fail all jobs in a matrix if one fails. This will make it easier to identify which versions fail and which do not.