### PR TITLE
Add Docker image workflow

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -1,0 +1,44 @@
+name: 🍪 Bake Docker Image
+
+on:
+  push:
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+jobs:
+  bake:
+    name: 🍪 Bake with Postgres ${{ matrix.pgv }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pgv: [18, 17, 16, 15, 14, 13]
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+        with: { submodules: true }
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Vendor Build
+        uses: actions/cache@v4
+        with:
+          path: vendor/_build
+          key: ${{ runner.os }}-vendor-build
+      - name: Set Bake Variables
+        run: make bake-vars REGISTRY=ghcr.io/clickhouse PG_VERSIONS=${{ matrix.pgv }} >> $GITHUB_ENV
+      - name: Build${{ startsWith(github.ref, 'refs/tags') && ' and Push' || '' }}
+        uses: depot/bake-action@v1
+        with:
+          project: vrpfjb99c5
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: ${{ startsWith(github.ref, 'refs/tags') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+ARG PG_MAJOR=18
+
+FROM postgres:$PG_MAJOR-trixie AS build
+
+WORKDIR /work
+COPY . .
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-server-dev-$PG_MAJOR \
+    libcurl4-openssl-dev \
+    uuid-dev \
+    make \
+    cmake \
+    libssl-dev \
+    g++
+
+RUN make && make install DESTDIR=/dest
+
+FROM postgres:$PG_MAJOR-trixie
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends libcurl4t64 uuid \
+    && apt-get clean \
+    && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+# Install extension files.
+COPY --chmod=644 --from=build \
+    /dest/usr/share/postgresql/$PG_MAJOR/extension/*.* \
+    /usr/share/postgresql/$PG_MAJOR/extension/
+
+# Install shared libraries.
+COPY --chmod=755 --from=build \
+    /dest/usr/lib/postgresql/$PG_MAJOR/lib/*.so* \
+    /usr/lib/postgresql/$PG_MAJOR/lib/
+
+# Install bitcode files.
+COPY --chmod=644 --from=build \
+    /dest/usr/lib/postgresql/$PG_MAJOR/lib/bitcode/*.bc \
+    /usr/lib/postgresql/$PG_MAJOR/lib/bitcode/
+COPY --chmod=644 --from=build \
+    /dest/usr/lib/postgresql/$PG_MAJOR/lib/bitcode/clickhouse_fdw/src/*.bc \
+    /usr/lib/postgresql/$PG_MAJOR/lib/bitcode/clickhouse_fdw/src/

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "clickhouse_fdw",
    "abstract": "A Foreign Data Wrapper for ClickHouse",
    "description": "Provides a Foreign Data Wrapper for easy and efficient access to ClickHouse databases, including pushdown of WHERE and JOIN conditions as well as comprehensive EXPLAIN and ANALYZE support.",
-   "version": "2.0.0",
+   "version": "2.0.0-b1",
    "maintainer": "David E. Wheeler <david@justatheory.com>",
    "license": "apache_2_0",
    "provides": {

--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,21 @@ results:
 
 # Run make print-VARIABLE_NAME to print VARIABLE_NAME's flavor and value.
 print-%	: ; $(info $* is $(flavor $*) variable set to "$($*)") @true
+
+# OCI images.
+REGISTRY ?= localhost:5001
+REVISION := $(shell git rev-parse --short HEAD)
+PLATFORMS ?= linux/amd64,linux/arm64
+PG_VERSIONS ?= 18,17,16,15,14,13
+.PHONY: image # Build the linux/amd64 OCI image.
+image:
+	registry=$(REGISTRY) version=$(DISTVERSION) revision=$(REVISION) pg_versions=$(PG_VERSIONS) \
+	docker buildx bake --set "*.platform=$(PLATFORMS)" \
+	$(if $(filter true,$(PUSH)),--push,) \
+	$(if $(filter true,$(LOAD)),--load,) \
+
+bake-vars:
+	@echo "registry=$(REGISTRY)"
+	@echo "version=$(DISTVERSION)"
+	@echo "revision=$(REVISION)"
+	@echo "pg_versions=$(PG_VERSIONS)"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 clickhouse_fdw Postgres Extension
 =================================
 
-[![PGXN version](https://badge.fury.io/pg/clickhouse_fdw.svg)](https://badge.fury.io/pg/clickhouse_fdw)
-[![Build Status](https://github.com/clickhouse/clickhouse_fdw/actions/workflows/ci.yml/badge.svg)](https://github.com/clickhouse/clickhouse_fdw/actions/workflows/ci.yml)
+[![PGXN]][⚙️] [![Postgres]][🐘] [![ClickHouse]][🏠] [![Docker]][🐳]
 
 This library contains the PostgreSQL extension `clickhouse_fdw` a foreign data
 wrapper for ClickHouse databases. It supports ClickHouse v22 and later.
@@ -29,6 +28,7 @@ sudo apt install \
   uuid-dev \
   make \
   cmake \
+  libssl-dev \
   g++
 ```
 
@@ -172,6 +172,15 @@ and [libuuid]. Building the extension requires a compiler, GNU `make`, and
 *   Portions Copyright (c) 2019-2023, Adjust GmbH
 *   Portions Copyright (c) 2019 Percona
 *   Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
+
+  [PGXN]: https://badge.fury.io/pg/clickhouse_fdw.svg
+  [⚙️]: https://pgxn.org/dist/clickhouse_fdw "Latest version on PGXN"
+  [Postgres]:  https://github.com/clickhouse/clickhouse_fdw/actions/workflows/postgres.yml/badge.svg
+  [🐘]:        https://github.com/clickhouse/clickhouse_fdw/actions/workflows/postgres.yml "Tested with PostgreSQL 13-18"
+  [ClickHouse]: https://github.com/clickhouse/clickhouse_fdw/actions/workflows/clickhouse.yml/badge.svg
+  [🏠]:          https://github.com/clickhouse/clickhouse_fdw/actions/workflows/clickhouse.yml "Tested with ClickHouse v22–25"
+  [Docker]:    https://ghcr-badge.egpl.dev/clickhouse/clickhouse_fdw/latest_tag?color=%2344cc11&ignore=latest&label=version
+  [🐳]:        https://github.com/ClickHouse/clickhouse_fdw/pkgs/container/postgres-clickhouse_fdw "Latest version on Docker Hub"
 
   [`postgresql.conf` parameters]: https://www.postgresql.org/docs/devel/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-OTHER
   [libcurl]: https://curl.se/libcurl/ "libcurl — your network transfer library"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,70 @@
+# Variables to be specified externally.
+variable "registry" {
+  default = "ghcr.io/clickhouse"
+  description = "The image registry."
+}
+
+variable "version" {
+  default = ""
+  description = "The release version."
+}
+
+variable "revision" {
+  default = ""
+  description = "The current Git commit SHA."
+}
+
+# Postgres versions to build. Pass comma-delimited list: pg_versions=18,16.
+variable "pg_versions" {
+    type    = list(number)
+    default = [18, 17, 16, 15, 14, 13]
+}
+
+# Values to use in the targets.
+now = timestamp()
+authors = "David E. Wheeler"
+url = "https://github.com/ClickHouse/clickhouse_fdw"
+
+target "default" {
+  platforms = ["linux/amd64", "linux/arm64"]
+  matrix = {
+    pgv = pg_versions
+  }
+  name = "clickhouse_fdw-${pgv}"
+  context = "."
+  args = {
+    PG_MAJOR = "${pgv}"
+  }
+  tags = [
+    "${registry}/postgres-clickhouse_fdw:${pgv}",
+    "${registry}/postgres-clickhouse_fdw:${pgv}-${version}",
+  ]
+  annotations = [
+    "index,manifest:org.opencontainers.image.created=${now}",
+    "index,manifest:org.opencontainers.image.url=${url}",
+    "index,manifest:org.opencontainers.image.source=${url}",
+    "index,manifest:org.opencontainers.image.version=${pgv}-${version}",
+    "index,manifest:org.opencontainers.image.revision=${revision}",
+    "index,manifest:org.opencontainers.image.vendor=${authors}",
+    "index,manifest:org.opencontainers.image.title=PostgreSQL with clickhouse_fdw",
+    "index,manifest:org.opencontainers.image.description=PostgreSQL ${pgv} with clickhouse_fdw ${version}",
+    "index,manifest:org.opencontainers.image.documentation=${url}",
+    "index,manifest:org.opencontainers.image.authors=${authors}",
+    "index,manifest:org.opencontainers.image.licenses=PostgreSQL AND Apache-2.0",
+    "index,manifest:org.opencontainers.image.base.name=postgres",
+  ]
+  labels = {
+    "org.opencontainers.image.created" = "${now}",
+    "org.opencontainers.image.url" = "${url}",
+    "org.opencontainers.image.source" = "${url}",
+    "org.opencontainers.image.version" = "${pgv}-${version}",
+    "org.opencontainers.image.revision" = "${revision}",
+    "org.opencontainers.image.vendor" = "${authors}",
+    "org.opencontainers.image.title" = "PostgreSQL with clickhouse_fdw",
+    "org.opencontainers.image.description" = "PostgreSQL ${pgv} with clickhouse_fdw ${version}",
+    "org.opencontainers.image.documentation" = "${url}",
+    "org.opencontainers.image.authors" = "${authors}",
+    "org.opencontainers.image.licenses" = "PostgreSQL AND Apache-2.0"
+    "org.opencontainers.image.base.name" = "scratch",
+  }
+}


### PR DESCRIPTION
Add a `Dockerfile` that builds the current branch into a Docker image for a specific version of Postgres. Then add a `docker-bake.hcl` file that bakes docker images for each supported Postgres version and for multiple platforms. Add the `image` target to the `Makefile` to simplify build the image(s) and optionally pushing to a registry. Finally, add the `bake.yml` workflow that actually bakes and, when executing for a tag, pushes the results.

Update `README.md` with up-to-date status badges for the Postgres and ClickHouse workflows and add one for the Docker image, as well.