### PR TITLE
Add support for ClickHouse Bool

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -914,7 +914,9 @@ nested_col:
         }
         break;
 		default:
-			throw std::runtime_error("unsupported type in binary protocol");
+			throw std::runtime_error(
+				"unsupported type "+std::string(Type::TypeName(type_code)) +" in binary protocol"
+			);
 	}
 
 	return ret;

--- a/test/expected/binary.out
+++ b/test/expected/binary.out
@@ -18,7 +18,7 @@ SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
-    c9 Float32, c10 Float64
+    c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
  clickhouse_raw_query 
@@ -28,7 +28,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
 
 SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
-    number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
+    number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
+    FROM numbers(10);');
  clickhouse_raw_query 
 ----------------------
  
@@ -110,7 +111,8 @@ CREATE FOREIGN TABLE fints (
 	c7 int8,
 	c8 int8,
     c9 float4,
-    c10 float8
+    c10 float8,
+    c11 bool
 ) SERVER binary_loopback OPTIONS (table_name 'ints');
 CREATE FOREIGN TABLE ftypes (
 	c1 date,
@@ -137,18 +139,18 @@ CREATE FOREIGN TABLE ftuples (
 ) SERVER binary_loopback OPTIONS (table_name 'tuples');
 -- integers
 SELECT * FROM fints ORDER BY c1;
- c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |  c9  | c10  
-----+----+----+----+----+----+----+----+------+------
-  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8.1 |  9.2
-  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9.1 | 10.2
-  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10.1 | 11.2
-  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11.1 | 12.2
-  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12.1 | 13.2
-  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13.1 | 14.2
-  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14.1 | 15.2
-  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15.1 | 16.2
-  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16.1 | 17.2
-  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17.1 | 18.2
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |  c9  | c10  | c11 
+----+----+----+----+----+----+----+----+------+------+-----
+  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8.1 |  9.2 | f
+  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9.1 | 10.2 | t
+  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10.1 | 11.2 | f
+  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11.1 | 12.2 | t
+  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12.1 | 13.2 | f
+  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13.1 | 14.2 | t
+  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14.1 | 15.2 | f
+  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15.1 | 16.2 | t
+  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16.1 | 17.2 | f
+  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17.1 | 18.2 | t
 (10 rows)
 
 SELECT c2, c1, c8, c3, c4, c7, c6, c5 FROM fints ORDER BY c1;

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -23,7 +23,7 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
 (1 row)
 
 SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
-    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
  clickhouse_raw_query 
@@ -68,7 +68,6 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
 (1 row)
 
 IMPORT FOREIGN SCHEMA "binary_inserts_test" FROM SERVER binary_inserts_loopback INTO public;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c1", change it to BOOLEAN if needed
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -113,13 +112,13 @@ SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
 
 /* check other number types */
 INSERT INTO uints
-	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
 SELECT * FROM uints ORDER BY c1;
- c1 | c2 | c3 | c4 
-----+----+----+----
-  1 |  2 |  3 |  4
-  2 |  3 |  4 |  5
-  3 |  4 |  5 |  6
+ c1 | c2 | c3 | c4 | c5 
+----+----+----+----+----
+  1 |  2 |  3 |  4 | t
+  2 |  3 |  4 |  5 | f
+  3 |  4 |  5 |  6 | t
 (3 rows)
 
 INSERT INTO floats

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -23,7 +23,7 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
 (1 row)
 
 SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
-    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
  clickhouse_raw_query 
@@ -68,7 +68,6 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
 (1 row)
 
 IMPORT FOREIGN SCHEMA "binary_inserts_test" FROM SERVER binary_inserts_loopback INTO public;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c1", change it to BOOLEAN if needed
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -113,13 +112,13 @@ SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
 
 /* check other number types */
 INSERT INTO uints
-	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
 SELECT * FROM uints ORDER BY c1;
- c1 | c2 | c3 | c4 
-----+----+----+----
-  1 |  2 |  3 |  4
-  2 |  3 |  4 |  5
-  3 |  4 |  5 |  6
+ c1 | c2 | c3 | c4 | c5 
+----+----+----+----+----
+  1 |  2 |  3 |  4 | t
+  2 |  3 |  4 |  5 | f
+  3 |  4 |  5 |  6 | t
 (3 rows)
 
 INSERT INTO floats

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -38,7 +38,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
  
 (1 row)
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
  clickhouse_raw_query 
 ----------------------
@@ -80,17 +80,20 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 CREATE FOREIGN TABLE ftcopy (
 	c1 int,
@@ -132,8 +135,19 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
+ c1 | c2 |   c3   | c4 
+----+----+--------+----
+  1 |  2 | AAA001 | t
+  2 |  3 | AAA002 | f
+  3 |  4 | AAA003 | t
+  4 |  5 | AAA004 | f
+  5 |  6 | AAA005 | t
+(5 rows)
+
 COPY ftcopy FROM stdin;
 INSERT INTO ftcopy VALUES
 	(3, 4, '1990-03-03', '1990-03-03 12:02:02', '12:02:02', 'val3'),

--- a/test/expected/import_schema.out
+++ b/test/expected/import_schema.out
@@ -199,7 +199,6 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
 (1 row)
 
 IMPORT FOREIGN SCHEMA "import_test" FROM SERVER import_loopback INTO clickhouse;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 NOTICE:  pg_clickhouse: ClickHouse <Tuple> type was translated to <TEXT> type for column "c2", please create composite type and alter the column if needed
 \d+ clickhouse.ints;
                                          Foreign table "clickhouse.ints"
@@ -372,7 +371,6 @@ SELECT * FROM clickhouse.ip ORDER BY c1;
 (3 rows)
 
 IMPORT FOREIGN SCHEMA "import_test" FROM SERVER import_loopback_bin INTO clickhouse_bin;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 NOTICE:  pg_clickhouse: ClickHouse <Tuple> type was translated to <TEXT> type for column "c2", please create composite type and alter the column if needed
 \d+ clickhouse_bin.ints;
                                        Foreign table "clickhouse_bin.ints"
@@ -545,7 +543,6 @@ SELECT * FROM clickhouse.ip ORDER BY c1;
 (3 rows)
 
 IMPORT FOREIGN SCHEMA "import_test" LIMIT TO (ints, types) FROM SERVER import_loopback INTO clickhouse_limit;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 \d+ clickhouse_limit.ints;
                                       Foreign table "clickhouse_limit.ints"
  Column |       Type       | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 

--- a/test/expected/import_schema_1.out
+++ b/test/expected/import_schema_1.out
@@ -199,7 +199,6 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
 (1 row)
 
 IMPORT FOREIGN SCHEMA "import_test" FROM SERVER import_loopback INTO clickhouse;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 NOTICE:  pg_clickhouse: ClickHouse <Tuple> type was translated to <TEXT> type for column "c2", please create composite type and alter the column if needed
 \d+ clickhouse.ints;
                                          Foreign table "clickhouse.ints"
@@ -336,7 +335,6 @@ SELECT * FROM clickhouse.ip ORDER BY c1;
 (3 rows)
 
 IMPORT FOREIGN SCHEMA "import_test" FROM SERVER import_loopback_bin INTO clickhouse_bin;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 NOTICE:  pg_clickhouse: ClickHouse <Tuple> type was translated to <TEXT> type for column "c2", please create composite type and alter the column if needed
 \d+ clickhouse_bin.ints;
                                        Foreign table "clickhouse_bin.ints"
@@ -473,7 +471,6 @@ SELECT * FROM clickhouse.ip ORDER BY c1;
 (3 rows)
 
 IMPORT FOREIGN SCHEMA "import_test" LIMIT TO (ints, types) FROM SERVER import_loopback INTO clickhouse_limit;
-NOTICE:  pg_clickhouse: ClickHouse <UInt8> type was translated to <INT2> type for column "c5", change it to BOOLEAN if needed
 \d+ clickhouse_limit.ints;
                                       Foreign table "clickhouse_limit.ints"
  Column |       Type       | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 

--- a/test/sql/binary.sql
+++ b/test/sql/binary.sql
@@ -10,12 +10,13 @@ SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
-    c9 Float32, c10 Float64
+    c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
-    number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
+    number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
+    FROM numbers(10);');
 
 -- date and string types
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
@@ -66,7 +67,8 @@ CREATE FOREIGN TABLE fints (
 	c7 int8,
 	c8 int8,
     c9 float4,
-    c10 float8
+    c10 float8,
+    c11 bool
 ) SERVER binary_loopback OPTIONS (table_name 'ints');
 
 CREATE FOREIGN TABLE ftypes (

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -10,7 +10,7 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
 ');
 
 SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
-    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
@@ -53,7 +53,7 @@ SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
 
 /* check other number types */
 INSERT INTO uints
-	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
 SELECT * FROM uints ORDER BY c1;
 INSERT INTO floats
 	SELECT i * 1.1, i + 2.1 FROM generate_series(1, 3) i;

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -15,7 +15,7 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
 SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String)
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
 SELECT clickhouse_raw_query('
 	CREATE TABLE http_test.tcopy
@@ -52,19 +52,22 @@ CREATE FOREIGN TABLE ft3 (
 CREATE FOREIGN TABLE ft4 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 
 CREATE FOREIGN TABLE ft5 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback OPTIONS (table_name 't4');
 
 CREATE FOREIGN TABLE ft6 (
 	c1 int NOT NULL,
 	c2 int NOT NULL,
-	c3 text
+	c3 text,
+	c4 bool
 ) SERVER http_loopback2 OPTIONS (table_name 't4');
 
 CREATE FOREIGN TABLE ftcopy (
@@ -100,8 +103,11 @@ SELECT c3, (c3 = 'lf\ntab\t\b\f\r') AS true FROM ft3 WHERE c1 = 2;
 INSERT INTO ft4
 	SELECT id,
 	       id + 1,
-	       'AAA' || to_char(id, 'FM000')
+	       'AAA' || to_char(id, 'FM000'),
+		   (id % 2)::bool
 	FROM generate_series(1, 100) id;
+
+SELECT * FROM ft5 ORDER BY c1 LIMIT 5;
 
 COPY ftcopy FROM stdin;
 1	2	1990-01-01	1990-01-01 10:01:02	10:01:02	val1


### PR DESCRIPTION
Map the ClickHouse `Bool` data type to the PostgreSQL `BOOLEAN` type. Internally, the `clickhouse-cpp` library treats booleans as `UInt2`, so add a custom function, `convert_bool_to_int16`, to cast PostgreSQL `BOOLEAN` to `INT16` to support inserting into ClickHouse, and tweak `init_output_convert_state` to use it in this case.

Add tests for boolean inserts and selects to both the binary and HTTP tests.

With the introduction of proper `Bool` support, remove the `ClickHouse <UInt8> type was translated to <INT2>` notice.

While at it:

*   Improve the exception raised by `make_datum() to include the name of the unsupported data type. Done to help track down the fact that `Bool` wasn't supported.
*   Add the `table_name` parameter to `parse_type()` and update the exception it throws to include the table and column for a data type that cannot be mapped from a PostgreSQL type to a ClickHouse type. Update all the callers to this function as appropriate.