### PR TITLE
Remove `params` function and type

### DIFF
--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -115,28 +115,6 @@ These PostgreSQL aggregate functions pushdown to ClickHouse.
 
 *   [count](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count)
 
-### Pushdown Ordered Set Aggregates
-
-These PostgreSQL [ordered-set aggregate functions] map to ClickHouse
-[Parametric aggregate functions] by passing their *direct argument* as a
-parameter and their `ORDER BY` expressions as arguments. For example, this
-PostgreSQL query:
-
-```sql
-SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
-```
-
-Maps to this ClickHouse query:
-
-```sql
-SELECT quantile(0.25)(a) FROM t1;
-```
-
-Note that the non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST`
-are not supported and will raise an error.
-
-*   `percentile_cont(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
-
 ### Custom Aggregates
 
 These custom aggregate functions created by `pg_clickhouse` provide foreign
@@ -155,23 +133,28 @@ an exception.
 *   [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
 *   [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
 
-#### Parametric Aggregates
+### Pushdown Ordered Set Aggregates
 
-To pass parameters to ClickHouse [Parametric aggregate functions], pass a call
-to the special `params()` function as the first argument. For example, a
-ClickHouse query such as
-
-```sql
-SELECT quantile(0.25)(val) FROM t;
-```
-
-Should be written in PostgreSQL as:
+These [ordered-set aggregate functions] map to ClickHouse [Parametric
+aggregate functions] by passing their *direct argument* as a parameter and
+their `ORDER BY` expressions as arguments. For example, this PostgreSQL query:
 
 ```sql
-SELECT quantile(params(0.25), val) FROM t;
+SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
 ```
 
-Omit `params()` to get the default value, where relevant.
+Maps to this ClickHouse query:
+
+```sql
+SELECT quantile(0.25)(a) FROM t1;
+```
+
+Note that the non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST`
+are not supported and will raise an error.
+
+*   `percentile_cont(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   `quantile(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   `quantileExact(double)` => [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
 
 ## Authors
 

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -631,7 +631,7 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 		/*
 		 * We leave fdw_recheck_quals empty in this case, since we never need
 		 * to apply EPQ recheck clauses.  In the case of a joinrel, EPQ
-		 * recheck is handled elsewhere --- see postgresGetForeignJoinPaths().
+		 * recheck is handled elsewhere --- see clickhouseGetForeignJoinPaths().
 		 * If we're planning an upperrel (ie, remote grouping or aggregation)
 		 * then there's no EPQ to do because SELECT FOR UPDATE wouldn't be
 		 * allowed, and indeed we *can't* put the remote clauses into

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -313,9 +313,8 @@ typedef struct CustomColumnInfo
 	char	signfield[NAMEDATALEN];
 } CustomColumnInfo;
 
-extern bool chfdw_check_for_builtin_ordered_aggregate(Oid funcid);
+extern bool chfdw_check_for_ordered_aggregate(Aggref *agg);
 extern CustomObjectDef *chfdw_check_for_custom_function(Oid funcid);
-extern FuncExpr * ch_get_params_function(TargetEntry *tle);
 extern CustomObjectDef *chfdw_check_for_custom_type(Oid typeoid);
 extern void chfdw_apply_custom_table_options(CHFdwRelationInfo *fpinfo, Oid relid);
 extern CustomColumnInfo *chfdw_get_custom_column_info(Oid relid, uint16 varattno);

--- a/test/expected/function_pushdown.out
+++ b/test/expected/function_pushdown.out
@@ -46,8 +46,6 @@ NOTICE:   SELECT ch_argmin(3, 3, true) : HV000 - pg_clickhouse: failed to push d
 NOTICE:   SELECT ch_argmin(true, false, now()) : HV000 - pg_clickhouse: failed to push down aggregate argMin()
 NOTICE:   SELECT dictGet('', '', '{"x": true}'::json) : HV000 - pg_clickhouse: failed to push down dictget()
 NOTICE:   SELECT dictGet('a', 'b', ARRAY[1]) : HV000 - pg_clickhouse: failed to push down dictget()
-NOTICE:   SELECT params(1) : HV000 - pg_clickhouse: failed to push down params()
-NOTICE:   SELECT params(1, 98.6, 'foo', false) : HV000 - pg_clickhouse: failed to push down params()
 NOTICE:   SELECT quantile(1) : HV000 - pg_clickhouse: failed to push down aggregate quantile()
 NOTICE:   SELECT quantile('x') : HV000 - pg_clickhouse: failed to push down aggregate quantile()
 NOTICE:   SELECT quantileExact(42) : HV000 - pg_clickhouse: failed to push down aggregate quantileExact()

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -457,16 +457,16 @@ SELECT uniqTheta(a, c) FROM t1;
          3
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
-                          QUERY PLAN                           
----------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantile(params(0.25), a))
+   Output: (quantile('0.25'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantile(params(0.25), a) FROM t1;
+SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
  quantile 
 ----------
      1.75
@@ -487,16 +487,16 @@ SELECT quantile(a) FROM t1;
         2
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
-                             QUERY PLAN                             
---------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantileexact(params(0.75), a))
+   Output: (quantileexact('0.75'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantileExact(params(0.75), a) FROM t1;
+SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
  quantileexact 
 ---------------
              2

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -457,16 +457,16 @@ SELECT uniqTheta(a, c) FROM t1;
          3
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
-                          QUERY PLAN                           
----------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantile(params(0.25), a))
+   Output: (quantile('0.25'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantile(params(0.25), a) FROM t1;
+SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
  quantile 
 ----------
      1.75
@@ -487,16 +487,16 @@ SELECT quantile(a) FROM t1;
         2
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
-                             QUERY PLAN                             
---------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantileexact(params(0.75), a))
+   Output: (quantileexact('0.75'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantileExact(params(0.75), a) FROM t1;
+SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
  quantileexact 
 ---------------
              2

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -457,16 +457,16 @@ SELECT uniqTheta(a, c) FROM t1;
          3
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
-                          QUERY PLAN                           
----------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantile(params(0.25), a))
+   Output: (quantile('0.25'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantile(0.25)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantile(params(0.25), a) FROM t1;
+SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
  quantile 
 ----------
      1.75
@@ -487,16 +487,16 @@ SELECT quantile(a) FROM t1;
         2
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
-                             QUERY PLAN                             
---------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Foreign Scan
-   Output: (quantileexact(params(0.75), a))
+   Output: (quantileexact('0.75'::double precision) WITHIN GROUP (ORDER BY a))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT quantileExact(0.75)(a) FROM functions_test.t1
 (4 rows)
 
-SELECT quantileExact(params(0.75), a) FROM t1;
+SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
  quantileexact 
 ---------------
              2

--- a/test/sql/function_pushdown.sql
+++ b/test/sql/function_pushdown.sql
@@ -69,9 +69,6 @@ BEGIN
         $$ SELECT dictGet('', '', '{"x": true}'::json) $$,
         $$ SELECT dictGet('a', 'b', ARRAY[1]) $$,
 
-        $$ SELECT params(1) $$,
-        $$ SELECT params(1, 98.6, 'foo', false) $$,
-
         $$ SELECT quantile(1) $$,
         $$ SELECT quantile('x') $$,
         $$ SELECT quantileExact(42) $$,

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -132,13 +132,13 @@ SELECT uniqTheta(a, b) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT uniqTheta(a, c) FROM t1;
 SELECT uniqTheta(a, c) FROM t1;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(params(0.25), a) FROM t1;
-SELECT quantile(params(0.25), a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT quantile(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT quantile(a) FROM t1;
 SELECT quantile(a) FROM t1;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(params(0.75), a) FROM t1;
-SELECT quantileExact(params(0.75), a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT quantileExact(0.75) WITHIN GROUP (ORDER BY a) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT quantileExact(a) FROM t1;
 SELECT quantileExact(a) FROM t1;
 


### PR DESCRIPTION
Remove the `params` function that was used to emulate ClickHouse parametric aggregate arguments. Instead, change `quantile()` and `quantileExact` to use the PostgreSQL `WITHIN GROUP (ORDER BY x)` syntax, and deparse them into their ClickHouse parametric equivalents exactly as `percentile_cont` is translated. This removes a special casing and funky workaround in favor of translating the differing syntaxes.

This presumes that Postgres ordered set aggregates are the equivalent of ClickHouse parametric aggregates, which in the case of `percentile_cont` and `quantile`, at least, appears correct.