### PR TITLE
Run `pg_bsd_indent` on all C and C++ files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,3 +173,9 @@ bake-vars:
 	@echo "version=$(DISTVERSION)"
 	@echo "revision=$(REVISION)"
 	@echo "pg_versions=$(PG_VERSIONS)"
+
+# Format the .c and .h files according to the PostgreSQL indentation standard.
+# Requires `pg_bsd_indent` to be in the path.
+indent:
+	@for fn in $(wildcard src/*.c.in src/*.c src/*/*.hh src/*/*.cpp); do printf "%s\n" "$$fn"; pg_bsd_indent -bad -bap -bbb -bc -bl -cli1 -cp33 -cdb -nce -d0 -di12 -nfc1 -i4 -l79 -lp -lpl -nip -npro -sac -tpg -ts4 "$$fn"; done
+	@rm *.BAK

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -13,8 +13,8 @@
 #include <clickhouse/types/types.h>
 
 #if __cplusplus > 199711L
-#define register // Deprecated in C++11.
-#endif // #if __cplusplus > 199711L
+#define register /* Deprecated in C++11. */
+#endif /* #if __cplusplus > 199711L */
 
 extern "C" {
 
@@ -39,7 +39,7 @@ extern "C" {
 
 using namespace clickhouse;
 
-#if defined(__APPLE__) // Byte ordering on macOS
+#if defined(__APPLE__) /* Byte ordering on macOS */
 #include <machine/endian.h>
 #include <libkern/OSByteOrder.h>
 #define HOST_TO_BIG_ENDIAN_64(x) OSSwapHostToBigInt64(x)
@@ -137,7 +137,7 @@ ch_binary_connection_t * ch_binary_connect(
 		if (options->port == CLICKHOUSE_SECURE_PORT)
 			options->SetSSLOptions(ClientOptions::SSLOptions());
 
-		//options->SetRethrowException(false);
+		/* options->SetRethrowException(false); */
 		conn = new ch_binary_connection_t();
 
 		Client * client = new Client(*options);
@@ -318,7 +318,7 @@ void ch_binary_insert_state_free(void * c)
 
 void ch_binary_prepare_insert(void * conn, char * query, ch_binary_insert_state * state)
 {
-	// Start the INSERT.
+	/* Start the INSERT. */
 	Block * block;
 	Client * client = (Client *)((ch_binary_connection_t *)conn)->client;
 	try
@@ -331,7 +331,7 @@ void ch_binary_prepare_insert(void * conn, char * query, ch_binary_insert_state 
 		elog(ERROR, "pg_clickhouse: could not prepare insert - %s", e.what());
 	}
 
-	// Setup the column config (or return if no columns).
+	/* Setup the column config (or return if no columns). */
 	state->len = block->GetColumnCount();
 	if (state->len == 0)
 	{
@@ -340,11 +340,11 @@ void ch_binary_prepare_insert(void * conn, char * query, ch_binary_insert_state 
 	}
 	state->outdesc = CreateTemplateTupleDesc(state->len);
 
-	// Iterate over the list of columns returned by ClickHouse.
+	/* Iterate over the list of columns returned by ClickHouse. */
 	AttrNumber i = 0;
 	for (Block::Iterator bi(*block); bi.IsValid(); bi.Next())
 	{
-		// Determine the Postgres column type.
+		/* Determine the Postgres column type. */
 		Oid pg_type = get_corr_postgres_type(bi.Type());
 		const char * colname = bi.Name().c_str();
 
@@ -354,7 +354,7 @@ void ch_binary_prepare_insert(void * conn, char * query, ch_binary_insert_state 
 		}
 		PG_CATCH();
 		{
-			// Clean up and re-throw.
+			/* Clean up and re-throw. */
 			client->ResetConnection();
 			delete block;
 			PG_RE_THROW();
@@ -455,7 +455,7 @@ static void column_append(clickhouse::ColumnRef col, Datum val, Oid valtype, boo
 			break;
 		}
 		case NUMERICOID: {
-			// Convert numeric to string and let ColumnDecimal parse it.
+			/* Convert numeric to string and let ColumnDecimal parse it. */
 			char *s = DatumGetCString(DirectFunctionCall1(numeric_out, val));
 			switch (col->Type()->GetCode())
 			{
@@ -749,16 +749,16 @@ nested_col:
 			auto decCol = col->As<ColumnDecimal>();
 			auto val = decCol->At(row);
 
-			// Convert the Int128 to a string.
+			/* Convert the Int128 to a string. */
 			std::stringstream ss;
 			ss << val;
 			std::string str = ss.str();
 
-			// Start a destination string.
+			/* Start a destination string. */
 			std::stringstream res;
 			auto scale = decCol->GetScale();
 
-			// Output a dash for negative values
+			/* Output a dash for negative values */
 			if (val < 0)
 			{
 				res << '-';
@@ -767,16 +767,16 @@ nested_col:
 
 			if (str.length() <= scale)
 			{
-				// Append the entire value prepended with zeros after the decimal.
+				/* Append the entire value prepended with zeros after the decimal. */
 				res << "0." << std::string(scale-1, '0') << str;
 			}
 			else
 			{
-				// There are digits before the decimal.
+				/* There are digits before the decimal. */
 				auto decAt = str.length() - scale;
 				res << str.substr(0, decAt);
 
-				// Append any digits after the decimal.
+				/* Append any digits after the decimal. */
 				if (decAt < str.length())
 				{
 					res << '.' << str.substr(decAt);

--- a/src/connection.c
+++ b/src/connection.c
@@ -34,23 +34,23 @@
 /*
  * Connection cache (initialized on first use)
  */
-static HTAB *ConnectionHash = NULL;
+static HTAB * ConnectionHash = NULL;
 static void chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue);
 static int32 strtoint32(const char *s);
 
 
 static ch_connection
-clickhouse_connect(ForeignServer *server, UserMapping *user)
+clickhouse_connect(ForeignServer * server, UserMapping * user)
 {
 	char	   *driver = "http";
 
 	/* default settings */
-	ch_connection_details	details = {"127.0.0.1", 0, NULL, NULL, "default"};
+	ch_connection_details details = {"127.0.0.1", 0, NULL, NULL, "default"};
 
 	chfdw_extract_options(server->options, &driver, &details.host,
-		&details.port, &details.dbname, &details.username, &details.password);
+						  &details.port, &details.dbname, &details.username, &details.password);
 	chfdw_extract_options(user->options, &driver, &details.host,
-		&details.port, &details.dbname, &details.username, &details.password);
+						  &details.port, &details.dbname, &details.username, &details.password);
 
 	if (strcmp(driver, "http") == 0)
 	{
@@ -65,7 +65,7 @@ clickhouse_connect(ForeignServer *server, UserMapping *user)
 }
 
 ch_connection
-chfdw_get_connection(UserMapping *user)
+chfdw_get_connection(UserMapping * user)
 {
 	bool		found;
 	ConnCacheEntry *entry;
@@ -95,7 +95,7 @@ chfdw_get_connection(UserMapping *user)
 									  chfdw_inval_callback, (Datum) 0);
 	}
 
-	/* Create hash key for the entry.  Assume no pad bytes in key struct */
+	/* Create hash key for the entry. Assume no pad bytes in key struct */
 	key.userid = user->umid;
 
 	/*
@@ -124,13 +124,13 @@ chfdw_get_connection(UserMapping *user)
 
 	/*
 	 * We don't check the health of cached connection here, because it would
-	 * require some overhead.  Broken connection will be detected when the
+	 * require some overhead. Broken connection will be detected when the
 	 * connection is actually used.
 	 */
 
 	/*
 	 * If cache entry doesn't have a connection, we have to establish a new
-	 * connection.  (If clickhouse_connect throws an error, the cache entry
+	 * connection. (If clickhouse_connect throws an error, the cache entry
 	 * will remain in a valid empty state, ie conn == NULL.)
 	 */
 	if (entry->gate.conn == NULL)
@@ -190,10 +190,10 @@ chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue)
 
 		/* hashvalue == 0 means a cache reset, must clear all state */
 		if (hashvalue == 0 ||
-				(cacheid == FOREIGNSERVEROID &&
-				 entry->server_hashvalue == hashvalue) ||
-				(cacheid == USERMAPPINGOID &&
-				 entry->mapping_hashvalue == hashvalue))
+			(cacheid == FOREIGNSERVEROID &&
+			 entry->server_hashvalue == hashvalue) ||
+			(cacheid == USERMAPPINGOID &&
+			 entry->mapping_hashvalue == hashvalue))
 		{
 			entry->invalidated = true;
 		}
@@ -209,7 +209,7 @@ connstring_parse(const char *connstring)
 	char	   *buf;
 	char	   *cp;
 	char	   *cp2;
-    ch_connection_details *details = palloc0(sizeof(ch_connection_details));
+	ch_connection_details *details = palloc0(sizeof(ch_connection_details));
 
 	/* Need a modifiable copy of the input string */
 	if ((buf = pstrdup(connstring)) == NULL)
@@ -310,19 +310,26 @@ connstring_parse(const char *connstring)
 			}
 		}
 
-		if (strcmp(pname, "host") == 0) {
+		if (strcmp(pname, "host") == 0)
+		{
 			details->host = pstrdup(pval);
-		} else if (strcmp(pname, "port") == 0) {
+		}
+		else if (strcmp(pname, "port") == 0)
+		{
 			details->port = strtoint32(pval);
-		} else if (strcmp(pname, "username") == 0) {
+		}
+		else if (strcmp(pname, "username") == 0)
+		{
 			details->username = pstrdup(pval);
-		} else if (strcmp(pname, "password") == 0) {
+		}
+		else if (strcmp(pname, "password") == 0)
+		{
 			details->password = pstrdup(pval);
 		}
 	}
 
-    pfree(buf);
-    return details;
+	pfree(buf);
+	return details;
 }
 
 /*

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -62,12 +62,13 @@ typedef struct foreign_glob_cxt
 	RelOptInfo *foreignrel;		/* the foreign relation we are planning for */
 	Relids		relids;			/* relids of base relations in the underlying
 								 * scan */
-} foreign_glob_cxt;
+}			foreign_glob_cxt;
 
 typedef struct foreign_loc_cxt
 {
-	bool	found_AggregateFunction;	/* indicator or CH AggregateFunction fields */
-} foreign_loc_cxt;
+	bool		found_AggregateFunction;	/* indicator or CH
+											 * AggregateFunction fields */
+}			foreign_loc_cxt;
 
 /*
  * Context for deparseExpr
@@ -81,12 +82,12 @@ typedef struct deparse_expr_cxt
 								 * a base relation. */
 	StringInfo	buf;			/* output buffer to append to */
 	List	  **params_list;	/* exprs that will become remote Params */
-	CustomObjectDef	*func;		/* custom function deparse */
+	CustomObjectDef *func;		/* custom function deparse */
 	CHFdwRelationInfo *fpinfo;	/* fdw relation info */
 	bool		interval_op;
 	bool		array_as_tuple; /* determines array output format */
-	bool        no_sort_parens; /* determines sort group clause format */
-} deparse_expr_cxt;
+	bool		no_sort_parens; /* determines sort group clause format */
+}			deparse_expr_cxt;
 
 #define REL_ALIAS_PREFIX	"r"
 /* Handy macro to add relation name qualification */
@@ -106,77 +107,77 @@ do { \
  * Functions to determine whether an expression can be evaluated safely on
  * remote server.
  */
-static bool foreign_expr_walker(Node *node,
-					foreign_glob_cxt *glob_cxt,
-					foreign_loc_cxt *outer_cxt);
+static bool foreign_expr_walker(Node * node,
+								foreign_glob_cxt * glob_cxt,
+								foreign_loc_cxt * outer_cxt);
 static char *deparse_type_name(Oid type_oid, int32 typemod);
 
 /*
  * Functions to construct string representation of a node tree.
  */
 static void deparseTargetList(StringInfo buf,
-				  RangeTblEntry *rte,
-				  Index rtindex,
-				  Relation rel,
-				  Bitmapset *attrs_used,
-				  bool qualify_col,
-				  List **retrieved_attrs);
-static void deparseExplicitTargetList(List *tlist,
-						  List **retrieved_attrs,
-						  deparse_expr_cxt *context);
-static void deparseSubqueryTargetList(deparse_expr_cxt *context);
-static void deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
-	int varno, int varattno, RangeTblEntry *rte, bool qualify_col);
+							  RangeTblEntry * rte,
+							  Index rtindex,
+							  Relation rel,
+							  Bitmapset * attrs_used,
+							  bool qualify_col,
+							  List * *retrieved_attrs);
+static void deparseExplicitTargetList(List * tlist,
+									  List * *retrieved_attrs,
+									  deparse_expr_cxt * context);
+static void deparseSubqueryTargetList(deparse_expr_cxt * context);
+static void deparseColumnRef(StringInfo buf, CustomObjectDef * cdef,
+							 int varno, int varattno, RangeTblEntry * rte, bool qualify_col);
 static void deparseRelation(StringInfo buf, Relation rel);
-static void deparseExpr(Expr *expr, deparse_expr_cxt *context);
-static void deparseVar(Var *node, deparse_expr_cxt *context);
-static void deparseConst(Const *node, deparse_expr_cxt *context, int showtype);
-static void deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context);
-static void deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context);
-static void deparseOpExpr(OpExpr *node, deparse_expr_cxt *context);
+static void deparseExpr(Expr * expr, deparse_expr_cxt * context);
+static void deparseVar(Var * node, deparse_expr_cxt * context);
+static void deparseConst(Const * node, deparse_expr_cxt * context, int showtype);
+static void deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context);
+static void deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context);
+static void deparseOpExpr(OpExpr * node, deparse_expr_cxt * context);
 static void deparseOperatorName(StringInfo buf, Form_pg_operator opform);
-static void deparseDistinctExpr(DistinctExpr *node, deparse_expr_cxt *context);
-static void deparseScalarArrayOpExpr(ScalarArrayOpExpr *node,
-                                     deparse_expr_cxt *context);
-static void deparseCaseExpr(CaseExpr *node, deparse_expr_cxt *context);
-static void deparseCaseWhen(CaseWhen *node, deparse_expr_cxt *context);
-static void deparseRelabelType(RelabelType *node, deparse_expr_cxt *context);
-static void deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context);
-static void deparseNullTest(NullTest *node, deparse_expr_cxt *context);
-static void deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context);
-static void deparseArrayList(ArrayExpr *node, deparse_expr_cxt *context);
-static void deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
-				 deparse_expr_cxt *context);
-static void appendOrderByClause(List *pathkeys, bool has_final_sort,
-					deparse_expr_cxt *context);
-static void appendLimitClause(deparse_expr_cxt *context);
-static void appendConditions(List *exprs, deparse_expr_cxt *context);
-static void deparseFromExprForRel(StringInfo buf, PlannerInfo *root,
-					  RelOptInfo *foreignrel, bool use_alias,
-					  Index ignore_rel, List **ignore_conds,
-					  List **params_list);
-static void deparseFromExpr(List *quals, deparse_expr_cxt *context);
-static void deparseRangeTblRef(StringInfo buf, PlannerInfo *root,
-				   RelOptInfo *foreignrel, bool make_subquery,
-				   Index ignore_rel, List **ignore_conds, List **params_list);
-static void deparseAggref(Aggref *node, deparse_expr_cxt *context);
-static void appendGroupByClause(List *tlist, deparse_expr_cxt *context);
-static CustomObjectDef *appendFunctionName(Oid funcid, deparse_expr_cxt *context);
-static Node *deparseSortGroupClause(Index ref, List *tlist, bool force_colno,
-					   deparse_expr_cxt *context);
-static void deparseCoerceViaIO(CoerceViaIO *node, deparse_expr_cxt *context);
-static void deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context);
-static void deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context);
-static void deparseRowExpr(RowExpr *node, deparse_expr_cxt *context);
-static void deparseNullIfExpr(NullIfExpr *node, deparse_expr_cxt *context);
+static void deparseDistinctExpr(DistinctExpr * node, deparse_expr_cxt * context);
+static void deparseScalarArrayOpExpr(ScalarArrayOpExpr * node,
+									 deparse_expr_cxt * context);
+static void deparseCaseExpr(CaseExpr * node, deparse_expr_cxt * context);
+static void deparseCaseWhen(CaseWhen * node, deparse_expr_cxt * context);
+static void deparseRelabelType(RelabelType * node, deparse_expr_cxt * context);
+static void deparseBoolExpr(BoolExpr * node, deparse_expr_cxt * context);
+static void deparseNullTest(NullTest * node, deparse_expr_cxt * context);
+static void deparseArrayExpr(ArrayExpr * node, deparse_expr_cxt * context);
+static void deparseArrayList(ArrayExpr * node, deparse_expr_cxt * context);
+static void deparseSelectSql(List * tlist, bool is_subquery, List * *retrieved_attrs,
+							 deparse_expr_cxt * context);
+static void appendOrderByClause(List * pathkeys, bool has_final_sort,
+								deparse_expr_cxt * context);
+static void appendLimitClause(deparse_expr_cxt * context);
+static void appendConditions(List * exprs, deparse_expr_cxt * context);
+static void deparseFromExprForRel(StringInfo buf, PlannerInfo * root,
+								  RelOptInfo * foreignrel, bool use_alias,
+								  Index ignore_rel, List * *ignore_conds,
+								  List * *params_list);
+static void deparseFromExpr(List * quals, deparse_expr_cxt * context);
+static void deparseRangeTblRef(StringInfo buf, PlannerInfo * root,
+							   RelOptInfo * foreignrel, bool make_subquery,
+							   Index ignore_rel, List * *ignore_conds, List * *params_list);
+static void deparseAggref(Aggref * node, deparse_expr_cxt * context);
+static void appendGroupByClause(List * tlist, deparse_expr_cxt * context);
+static CustomObjectDef * appendFunctionName(Oid funcid, deparse_expr_cxt * context);
+static Node * deparseSortGroupClause(Index ref, List * tlist, bool force_colno,
+									 deparse_expr_cxt * context);
+static void deparseCoerceViaIO(CoerceViaIO * node, deparse_expr_cxt * context);
+static void deparseCoalesceExpr(CoalesceExpr * node, deparse_expr_cxt * context);
+static void deparseMinMaxExpr(MinMaxExpr * node, deparse_expr_cxt * context);
+static void deparseRowExpr(RowExpr * node, deparse_expr_cxt * context);
+static void deparseNullIfExpr(NullIfExpr * node, deparse_expr_cxt * context);
 
 /*
  * Helper functions
  */
-static bool is_subquery_var(Var *node, RelOptInfo *foreignrel,
-				int *relno, int *colno);
-static void get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel,
-							  int *relno, int *colno);
+static bool is_subquery_var(Var * node, RelOptInfo * foreignrel,
+							int *relno, int *colno);
+static void get_relation_column_alias_ids(Var * node, RelOptInfo * foreignrel,
+										  int *relno, int *colno);
 
 static char *
 get_alias_name()
@@ -192,11 +193,11 @@ get_alias_name()
  *	- local_conds contains expressions that can't be evaluated remotely
  */
 void
-chfdw_classify_conditions(PlannerInfo *root,
-				   RelOptInfo *baserel,
-				   List *input_conds,
-				   List **remote_conds,
-				   List **local_conds)
+chfdw_classify_conditions(PlannerInfo * root,
+						  RelOptInfo * baserel,
+						  List * input_conds,
+						  List * *remote_conds,
+						  List * *local_conds)
 {
 	ListCell   *lc;
 
@@ -218,13 +219,13 @@ chfdw_classify_conditions(PlannerInfo *root,
  * Returns true if given expr is safe to evaluate on the foreign server.
  */
 bool
-chfdw_is_foreign_expr(PlannerInfo *root,
-				RelOptInfo *baserel,
-				Expr *expr)
+chfdw_is_foreign_expr(PlannerInfo * root,
+					  RelOptInfo * baserel,
+					  Expr * expr)
 {
 	foreign_glob_cxt glob_cxt;
 	foreign_loc_cxt loc_cxt = {false};
-	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *)(baserel->fdw_private);
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) (baserel->fdw_private);
 
 	/*
 	 * Check that the expression consists of nodes that are safe to execute
@@ -236,7 +237,7 @@ chfdw_is_foreign_expr(PlannerInfo *root,
 	/*
 	 * For an upper relation, use relids from its underneath scan relation,
 	 * because the upperrel's own relids currently aren't set to anything
-	 * meaningful by the core code.  For other relation, use their own relids.
+	 * meaningful by the core code. For other relation, use their own relids.
 	 */
 	if (IS_UPPER_REL(baserel))
 		glob_cxt.relids = fpinfo->outerrel->relids;
@@ -254,9 +255,9 @@ chfdw_is_foreign_expr(PlannerInfo *root,
 int
 chfdw_is_equal_op(Oid opno)
 {
-	Form_pg_operator	operform;
-	HeapTuple			opertup;
-	int					res = 0;
+	Form_pg_operator operform;
+	HeapTuple	opertup;
+	int			res = 0;
 
 	opertup = SearchSysCache1(OPEROID, ObjectIdGetDatum(opno));
 	if (!HeapTupleIsValid(opertup))
@@ -281,15 +282,15 @@ chfdw_is_equal_op(Oid opno)
  * We must check that the expression contains only node types we can deparse,
  * that all types/functions/operators are safe to send (they are "shippable"),
  * and that all collations used in the expression derive from Vars of the
- * foreign table.  Because of the latter, the logic is pretty close to
+ * foreign table. Because of the latter, the logic is pretty close to
  * assign_collations_walker() in parse_collate.c, though we can assume here
- * that the given expression is valid.  Note function mutability is not
+ * that the given expression is valid. Note function mutability is not
  * currently considered here.
  */
 static bool
-foreign_expr_walker(Node *node,
-                    foreign_glob_cxt *glob_cxt,
-                    foreign_loc_cxt *outer_cxt)
+foreign_expr_walker(Node * node,
+					foreign_glob_cxt * glob_cxt,
+					foreign_loc_cxt * outer_cxt)
 {
 	bool		check_type = true;
 	CHFdwRelationInfo *fpinfo;
@@ -300,351 +301,354 @@ foreign_expr_walker(Node *node,
 		return true;
 
 	/* May need server info from baserel's fdw_private struct */
-	fpinfo = (CHFdwRelationInfo *)(glob_cxt->foreignrel->fdw_private);
+	fpinfo = (CHFdwRelationInfo *) (glob_cxt->foreignrel->fdw_private);
 
 	switch (nodeTag(node))
 	{
-	case T_Var:
-	{
-		Var		   *var = (Var *) node;
-
-		/*
-		 * If the Var is from the foreign table, we consider its
-		 * collation (if any) safe to use.  If it is from another
-		 * table, we treat its collation the same way as we would a
-		 * Param's collation, ie it's not safe for it to have a
-		 * non-default collation.
-		 */
-		if (bms_is_member(var->varno, glob_cxt->relids) &&
-				var->varlevelsup == 0)
-		{
-			RangeTblEntry		*rte;
-			CustomColumnInfo	*cinfo;
-
-			/* Var belongs to foreign table */
-
-			/*
-			 * System columns other than ctid and oid should not be
-			 * sent to the remote, since we don't make any effort to
-			 * ensure that local and remote values match (tableoid, in
-			 * particular, almost certainly doesn't match).
-			 */
-			if (var->varattno < 0)
-				return false;
-
-			rte = planner_rt_fetch(var->varno, glob_cxt->root);
-			cinfo = chfdw_get_custom_column_info(rte->relid, var->varattno);
-
-			/*
-			 * If this T_Var column is an aggregate function column, tell the
-			 * outer context as much, so that it propagates to its parent
-			 * `T_Aggref`, if any.
-			 */
-			if (cinfo && cinfo->is_AggregateFunction == CF_AGGR_FUNC)
-				outer_cxt->found_AggregateFunction = true;
-		}
-	}
-	break;
-	case T_Const:
-	break;
-	case T_Param:
-	{
-		/* We are not supporting param push down*/
-		return false;
-	}
-	break;
-	case T_SubscriptingRef:
-	{
-		SubscriptingRef   *ar = (SubscriptingRef *) node;
-
-		/* Assignment should not be in restrictions. */
-		if (ar->refassgnexpr != NULL)
-			return false;
-
-		/*
-		 * Recurse to remaining subexpressions.  Since the array
-		 * subscripts must yield (noncollatable) integers, they won't
-		 * affect the inner_cxt state.
-		 */
-		if (!foreign_expr_walker((Node *) ar->refupperindexpr,
-								 glob_cxt, &inner_cxt))
-			return false;
-
-		if (!foreign_expr_walker((Node *) ar->reflowerindexpr,
-								 glob_cxt, &inner_cxt))
-			return false;
-
-		if (!foreign_expr_walker((Node *) ar->refexpr,
-								 glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_FuncExpr:
-	{
-		CustomObjectDef	*cdef = NULL;
-		FuncExpr   *fe = (FuncExpr *) node;
-
-		/* not in ClickHouse */
-		if (fe->funcvariadic)
-			return false;
-
-		/*
-		 * If function used by the expression is not shippable, it
-		 * can't be sent to remote because it might have incompatible
-		 * semantics on remote side.
-		 */
-		if (!chfdw_is_shippable(fe->funcid, ProcedureRelationId, fpinfo, &cdef))
-			return false;
-
-		/* only simple Var as first argument for accumulate */
-		if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE && (!IsA(linitial(fe->args), Var)))
-			return false;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) fe->args,
-								 glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_OpExpr:
-	case T_NullIfExpr:
-	case T_DistinctExpr:	/* struct-equivalent to OpExpr */
-	{
-		OpExpr	   *oe = (OpExpr *) node;
-
-		/*
-		 * Similarly, only shippable operators can be sent to remote.
-		 * (If the operator is shippable, we assume its underlying
-		 * function is too.)
-		 */
-		if (!chfdw_is_shippable(oe->opno, OperatorRelationId, fpinfo, NULL))
-			return false;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) oe->args,
-								 glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_ScalarArrayOpExpr:
-	{
-		ScalarArrayOpExpr *oe = (ScalarArrayOpExpr *) node;
-
-		if (!chfdw_is_equal_op(oe->opno))
-			return false;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) oe->args,
-								 glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_RelabelType:
-	{
-		RelabelType *r = (RelabelType *) node;
-
-		/*
-		 * Recurse to input subexpression.
-		 */
-		if (!foreign_expr_walker((Node *) r->arg,
-								 glob_cxt, &inner_cxt))
-		{
-			return false;
-		}
-	}
-	break;
-	case T_BoolExpr:
-	{
-		BoolExpr   *b = (BoolExpr *) node;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) b->args,
-								 glob_cxt, &inner_cxt))
-		{
-			return false;
-		}
-	}
-	break;
-	case T_NullTest:
-	{
-		NullTest   *nt = (NullTest *) node;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) nt->arg,
-								 glob_cxt, &inner_cxt))
-		{
-			return false;
-		}
-	}
-	break;
-	case T_ArrayExpr:
-	{
-		ArrayExpr  *a = (ArrayExpr *) node;
-
-		/*
-		 * Recurse to input subexpressions.
-		 */
-		if (!foreign_expr_walker((Node *) a->elements,
-								 glob_cxt, &inner_cxt))
-		{
-			return false;
-		}
-	}
-	break;
-	case T_List:
-	{
-		List	   *l = (List *) node;
-		ListCell   *lc;
-
-		/*
-		 * Recurse to component subexpressions.
-		 */
-		foreach (lc, l)
-		{
-			if (!foreign_expr_walker((Node *) lfirst(lc),
-									 glob_cxt, &inner_cxt))
+		case T_Var:
 			{
+				Var		   *var = (Var *) node;
+
+				/*
+				 * If the Var is from the foreign table, we consider its
+				 * collation (if any) safe to use. If it is from another
+				 * table, we treat its collation the same way as we would a
+				 * Param's collation, ie it's not safe for it to have a
+				 * non-default collation.
+				 */
+				if (bms_is_member(var->varno, glob_cxt->relids) &&
+					var->varlevelsup == 0)
+				{
+					RangeTblEntry *rte;
+					CustomColumnInfo *cinfo;
+
+					/* Var belongs to foreign table */
+
+					/*
+					 * System columns other than ctid and oid should not be
+					 * sent to the remote, since we don't make any effort to
+					 * ensure that local and remote values match (tableoid, in
+					 * particular, almost certainly doesn't match).
+					 */
+					if (var->varattno < 0)
+						return false;
+
+					rte = planner_rt_fetch(var->varno, glob_cxt->root);
+					cinfo = chfdw_get_custom_column_info(rte->relid, var->varattno);
+
+					/*
+					 * If this T_Var column is an aggregate function column,
+					 * tell the outer context as much, so that it propagates
+					 * to its parent `T_Aggref`, if any.
+					 */
+					if (cinfo && cinfo->is_AggregateFunction == CF_AGGR_FUNC)
+						outer_cxt->found_AggregateFunction = true;
+				}
+			}
+			break;
+		case T_Const:
+			break;
+		case T_Param:
+			{
+				/* We are not supporting param push down */
 				return false;
 			}
-		}
-
-		/* Don't apply exprType() to the list. */
-		check_type = false;
-	}
-	break;
-	case T_Aggref:
-	{
-		Aggref	   *agg = (Aggref *) node;
-		ListCell   *lc;
-
-		/* Not safe to pushdown when not in grouping context */
-		if (!IS_UPPER_REL(glob_cxt->foreignrel))
-			return false;
-
-		/* Only non-split aggregates are pushable. */
-		if (agg->aggsplit != AGGSPLIT_SIMPLE)
-			return false;
-
-		/* As usual, it must be shippable. */
-		if (!chfdw_is_shippable(agg->aggfnoid, ProcedureRelationId, fpinfo, NULL))
-			return false;
-
-			/* Features that ClickHouse doesn't support */
-		if (AGGKIND_IS_ORDERED_SET(agg->aggkind)
-			&& !chfdw_check_for_ordered_aggregate(agg))
-			return false;
-
-		if (agg->aggdistinct && agg->aggfilter)
-			return false;
-
-		/*
-		 * Recurse to input args. aggdirectargs, aggorder and
-		 * aggdistinct are all present in args, so no need to check
-		 * their shippability explicitly.
-		 */
-		foreach (lc, agg->args)
-		{
-			Node	   *n = (Node *) lfirst(lc);
-
-			/* If TargetEntry, extract the expression from it */
-			if (IsA(n, TargetEntry))
+			break;
+		case T_SubscriptingRef:
 			{
-				TargetEntry *tle = (TargetEntry *) n;
+				SubscriptingRef *ar = (SubscriptingRef *) node;
 
-				n = (Node *) tle->expr;
+				/* Assignment should not be in restrictions. */
+				if (ar->refassgnexpr != NULL)
+					return false;
+
+				/*
+				 * Recurse to remaining subexpressions. Since the array
+				 * subscripts must yield (noncollatable) integers, they won't
+				 * affect the inner_cxt state.
+				 */
+				if (!foreign_expr_walker((Node *) ar->refupperindexpr,
+										 glob_cxt, &inner_cxt))
+					return false;
+
+				if (!foreign_expr_walker((Node *) ar->reflowerindexpr,
+										 glob_cxt, &inner_cxt))
+					return false;
+
+				if (!foreign_expr_walker((Node *) ar->refexpr,
+										 glob_cxt, &inner_cxt))
+					return false;
 			}
+			break;
+		case T_FuncExpr:
+			{
+				CustomObjectDef *cdef = NULL;
+				FuncExpr   *fe = (FuncExpr *) node;
+
+				/* not in ClickHouse */
+				if (fe->funcvariadic)
+					return false;
+
+				/*
+				 * If function used by the expression is not shippable, it
+				 * can't be sent to remote because it might have incompatible
+				 * semantics on remote side.
+				 */
+				if (!chfdw_is_shippable(fe->funcid, ProcedureRelationId, fpinfo, &cdef))
+					return false;
+
+				/* only simple Var as first argument for accumulate */
+				if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE && (!IsA(linitial(fe->args), Var)))
+					return false;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) fe->args,
+										 glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_OpExpr:
+		case T_NullIfExpr:
+		case T_DistinctExpr:	/* struct-equivalent to OpExpr */
+			{
+				OpExpr	   *oe = (OpExpr *) node;
+
+				/*
+				 * Similarly, only shippable operators can be sent to remote.
+				 * (If the operator is shippable, we assume its underlying
+				 * function is too.)
+				 */
+				if (!chfdw_is_shippable(oe->opno, OperatorRelationId, fpinfo, NULL))
+					return false;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) oe->args,
+										 glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_ScalarArrayOpExpr:
+			{
+				ScalarArrayOpExpr *oe = (ScalarArrayOpExpr *) node;
+
+				if (!chfdw_is_equal_op(oe->opno))
+					return false;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) oe->args,
+										 glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_RelabelType:
+			{
+				RelabelType *r = (RelabelType *) node;
+
+				/*
+				 * Recurse to input subexpression.
+				 */
+				if (!foreign_expr_walker((Node *) r->arg,
+										 glob_cxt, &inner_cxt))
+				{
+					return false;
+				}
+			}
+			break;
+		case T_BoolExpr:
+			{
+				BoolExpr   *b = (BoolExpr *) node;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) b->args,
+										 glob_cxt, &inner_cxt))
+				{
+					return false;
+				}
+			}
+			break;
+		case T_NullTest:
+			{
+				NullTest   *nt = (NullTest *) node;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) nt->arg,
+										 glob_cxt, &inner_cxt))
+				{
+					return false;
+				}
+			}
+			break;
+		case T_ArrayExpr:
+			{
+				ArrayExpr  *a = (ArrayExpr *) node;
+
+				/*
+				 * Recurse to input subexpressions.
+				 */
+				if (!foreign_expr_walker((Node *) a->elements,
+										 glob_cxt, &inner_cxt))
+				{
+					return false;
+				}
+			}
+			break;
+		case T_List:
+			{
+				List	   *l = (List *) node;
+				ListCell   *lc;
+
+				/*
+				 * Recurse to component subexpressions.
+				 */
+				foreach(lc, l)
+				{
+					if (!foreign_expr_walker((Node *) lfirst(lc),
+											 glob_cxt, &inner_cxt))
+					{
+						return false;
+					}
+				}
+
+				/* Don't apply exprType() to the list. */
+				check_type = false;
+			}
+			break;
+		case T_Aggref:
+			{
+				Aggref	   *agg = (Aggref *) node;
+				ListCell   *lc;
+
+				/* Not safe to pushdown when not in grouping context */
+				if (!IS_UPPER_REL(glob_cxt->foreignrel))
+					return false;
+
+				/* Only non-split aggregates are pushable. */
+				if (agg->aggsplit != AGGSPLIT_SIMPLE)
+					return false;
+
+				/* As usual, it must be shippable. */
+				if (!chfdw_is_shippable(agg->aggfnoid, ProcedureRelationId, fpinfo, NULL))
+					return false;
+
+				/* Features that ClickHouse doesn't support */
+				if (AGGKIND_IS_ORDERED_SET(agg->aggkind)
+					&& !chfdw_check_for_ordered_aggregate(agg))
+					return false;
+
+				if (agg->aggdistinct && agg->aggfilter)
+					return false;
+
+				/*
+				 * Recurse to input args. aggdirectargs, aggorder and
+				 * aggdistinct are all present in args, so no need to check
+				 * their shippability explicitly.
+				 */
+				foreach(lc, agg->args)
+				{
+					Node	   *n = (Node *) lfirst(lc);
+
+					/* If TargetEntry, extract the expression from it */
+					if (IsA(n, TargetEntry))
+					{
+						TargetEntry *tle = (TargetEntry *) n;
+
+						n = (Node *) tle->expr;
+					}
+
+					/*
+					 * Walk the inner node and determine if the inner T_Var is
+					 * an AggregateFunction. If so, we'll append "Merge" to
+					 * the function call in deparseAggref.
+					 */
+					inner_cxt.found_AggregateFunction = false;
+					if (!foreign_expr_walker(n, glob_cxt, &inner_cxt))
+						return false;
+
+					if (inner_cxt.found_AggregateFunction)
+						agg->location = -2;
+
+					/* Prevent propagating to earlier nodes. */
+					inner_cxt.found_AggregateFunction = false;
+				}
+
+				/* Check aggregate filter */
+				if (!foreign_expr_walker((Node *) agg->aggfilter,
+										 glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_CaseExpr:
+			{
+				CaseExpr   *caseexpr = (CaseExpr *) node;
+				ListCell   *lc;
+
+				if (!foreign_expr_walker((Node *) caseexpr->arg, glob_cxt, &inner_cxt))
+					return true;
+
+				foreach(lc, caseexpr->args)
+				{
+					CaseWhen   *when = lfirst_node(CaseWhen, lc);
+
+					if (!foreign_expr_walker((Node *) when->expr, glob_cxt, &inner_cxt))
+						return false;
+					if (!foreign_expr_walker((Node *) when->result, glob_cxt, &inner_cxt))
+						return false;
+				}
+				if (!foreign_expr_walker((Node *) caseexpr->defresult, glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_CoalesceExpr:
+			{
+				CoalesceExpr *ce = (CoalesceExpr *) node;
+
+				if (!foreign_expr_walker((Node *) ce->args, glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_MinMaxExpr:
+			{
+				MinMaxExpr *me = (MinMaxExpr *) node;
+
+				if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_CoerceViaIO:
+			{
+				CoerceViaIO *me = (CoerceViaIO *) node;
+
+				if (!foreign_expr_walker((Node *) me->arg, glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_RowExpr:
+			{
+				RowExpr    *me = (RowExpr *) node;
+
+				if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
+					return false;
+			}
+			break;
+		case T_CaseTestExpr:
+			break;
+		default:
 
 			/*
-			 * Walk the inner node and determine if the inner T_Var is an
-			 * AggregateFunction. If so, we'll append "Merge" to the function
-			 * call in deparseAggref.
-			*/
-			inner_cxt.found_AggregateFunction = false;
-			if (!foreign_expr_walker(n, glob_cxt, &inner_cxt))
-				return false;
-
-			if (inner_cxt.found_AggregateFunction)
-				agg->location = -2;
-
-			/* Prevent propagating to earlier nodes. */
-			inner_cxt.found_AggregateFunction = false;
-		}
-
-		/* Check aggregate filter */
-		if (!foreign_expr_walker((Node *) agg->aggfilter,
-								 glob_cxt, &inner_cxt))
+			 * If it's anything else, assume it's unsafe. This list can be
+			 * expanded later, but don't forget to add deparse support below.
+			 */
 			return false;
-	}
-	break;
-	case T_CaseExpr:
-	{
-		CaseExpr   *caseexpr = (CaseExpr *) node;
-		ListCell   *lc;
-
-		if (!foreign_expr_walker((Node *) caseexpr->arg, glob_cxt, &inner_cxt))
-			return true;
-
-		foreach(lc, caseexpr->args)
-		{
-			CaseWhen   *when = lfirst_node(CaseWhen, lc);
-
-			if (!foreign_expr_walker((Node *) when->expr, glob_cxt, &inner_cxt))
-				return false;
-			if (!foreign_expr_walker((Node *) when->result, glob_cxt, &inner_cxt))
-				return false;
-		}
-		if (!foreign_expr_walker((Node *) caseexpr->defresult, glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_CoalesceExpr:
-	{
-		CoalesceExpr   *ce = (CoalesceExpr *) node;
-
-		if (!foreign_expr_walker((Node *) ce->args, glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_MinMaxExpr:
-	{
-		MinMaxExpr	*me = (MinMaxExpr *) node;
-		if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_CoerceViaIO:
-	{
-		CoerceViaIO	*me = (CoerceViaIO *) node;
-		if (!foreign_expr_walker((Node *) me->arg, glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_RowExpr:
-	{
-		RowExpr	*me = (RowExpr *) node;
-		if (!foreign_expr_walker((Node *) me->args, glob_cxt, &inner_cxt))
-			return false;
-	}
-	break;
-	case T_CaseTestExpr:
-	break;
-	default:
-
-		/*
-		 * If it's anything else, assume it's unsafe.  This list can be
-		 * expanded later, but don't forget to add deparse support below.
-		 */
-		return false;
 	}
 
 	/*
@@ -708,8 +712,8 @@ ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
 	typeform = (Form_pg_type) GETSTRUCT(tuple);
 
 	/*
-	 * Check if it's a regular (variable length) array type.  Fixed-length
-	 * array types such as "name" shouldn't get deconstructed.  As of Postgres
+	 * Check if it's a regular (variable length) array type. Fixed-length
+	 * array types such as "name" shouldn't get deconstructed. As of Postgres
 	 * 8.1, rather than checking typlen we check the toast property, and don't
 	 * deconstruct "plain storage" array types --- this is because we don't
 	 * want to show oidvector as oid[].
@@ -741,7 +745,7 @@ ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
 	 *
 	 * If we do not provide a special-case output here, the type name will be
 	 * handled the same way as a user type name --- in particular, it will be
-	 * double-quoted if it matches any lexer keyword.  This behavior is
+	 * double-quoted if it matches any lexer keyword. This behavior is
 	 * essential for some cases, such as types "bit" and "char".
 	 */
 	buf = NULL;					/* flag for no special case */
@@ -759,7 +763,7 @@ ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
 			{
 				/*
 				 * bpchar with typmod -1 is not the same as CHARACTER, which
-				 * means CHARACTER(1) per SQL spec.  Report it as bpchar so
+				 * means CHARACTER(1) per SQL spec. Report it as bpchar so
 				 * that parser will not assign a bogus typmod.
 				 */
 			}
@@ -822,7 +826,7 @@ ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
 
 	if (buf == NULL)
 	{
-		CustomObjectDef	*cdef;
+		CustomObjectDef *cdef;
 		char	   *typname;
 
 		cdef = chfdw_check_for_custom_type(type_oid);
@@ -848,13 +852,13 @@ ch_format_type_extended(Oid type_oid, int32 typemod, bits16 flags)
 
 /*
  * Convert type OID + typmod info into a type name we can ship to the remote
- * server.  Someplace else had better have verified that this type name is
+ * server. Someplace else had better have verified that this type name is
  * expected to be known on the remote end.
  *
  * This is almost just format_type_with_typemod(), except that if left to its
  * own devices, that function will make schema-qualification decisions based
- * on the local search_path, which is wrong.  We must schema-qualify all
- * type names that are not in pg_catalog.  We assume here that built-in types
+ * on the local search_path, which is wrong. We must schema-qualify all
+ * type names that are not in pg_catalog. We assume here that built-in types
  * are all in pg_catalog and need not be qualified; otherwise, qualify.
  */
 static char *
@@ -872,12 +876,12 @@ deparse_type_name(Oid type_oid, int32 typemod)
  * Build the targetlist for given relation to be deparsed as SELECT clause.
  *
  * The output targetlist contains the columns that need to be fetched from the
- * foreign server for the given relation.  If foreignrel is an upper relation,
+ * foreign server for the given relation. If foreignrel is an upper relation,
  * then the output targetlist can also contain expressions to be evaluated on
  * foreign server.
  */
-List *
-chfdw_build_tlist_to_deparse(RelOptInfo *foreignrel)
+List	   *
+chfdw_build_tlist_to_deparse(RelOptInfo * foreignrel)
 {
 	List	   *tlist = NIL;
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
@@ -934,16 +938,17 @@ chfdw_build_tlist_to_deparse(RelOptInfo *foreignrel)
  * List of columns selected is returned in retrieved_attrs.
  */
 void
-chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
-						List *tlist, List *remote_conds, List *pathkeys,
-						bool has_final_sort, bool has_limit, bool is_subquery,
-						List **retrieved_attrs, List **params_list)
+chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo * root, RelOptInfo * rel,
+								  List * tlist, List * remote_conds, List * pathkeys,
+								  bool has_final_sort, bool has_limit, bool is_subquery,
+								  List * *retrieved_attrs, List * *params_list)
 {
 	deparse_expr_cxt context;
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) rel->fdw_private;
 	List	   *quals;
 
 	elog(DEBUG2, "> %s:%d", __FUNCTION__, __LINE__);
+
 	/*
 	 * We handle relations for foreign tables, joins between those and upper
 	 * relations.
@@ -1006,20 +1011,20 @@ chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo *root, RelOptInfo 
 
 /*
  * Construct a simple SELECT statement that retrieves desired columns
- * of the specified foreign table, and append it to "buf".  The output
+ * of the specified foreign table, and append it to "buf". The output
  * contains just "SELECT ... ".
  *
  * We also create an integer List of the columns being retrieved, which is
  * returned to *retrieved_attrs, unless we deparse the specified relation
  * as a subquery.
  *
- * tlist is the list of desired columns.  is_subquery is the flag to
+ * tlist is the list of desired columns. is_subquery is the flag to
  * indicate whether to deparse the specified relation as a subquery.
  * Read prologue of chfdw_deparse_select_stmt_for_rel() for details.
  */
 static void
-deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
-				 deparse_expr_cxt *context)
+deparseSelectSql(List * tlist, bool is_subquery, List * *retrieved_attrs,
+				 deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	RelOptInfo *foreignrel = context->foreignrel;
@@ -1029,6 +1034,7 @@ deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
 	/* reset var counter */
 	var_counter = 0;
 	elog(DEBUG2, "> %s:%d", __FUNCTION__, __LINE__);
+
 	/*
 	 * Construct SELECT list
 	 */
@@ -1038,7 +1044,7 @@ deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
 	{
 		/*
 		 * For a relation that is deparsed as a subquery, emit expressions
-		 * specified in the relation's reltarget.  Note that since this is for
+		 * specified in the relation's reltarget. Note that since this is for
 		 * the subquery, no need to care about *retrieved_attrs.
 		 */
 		deparseSubqueryTargetList(context);
@@ -1080,7 +1086,7 @@ deparseSelectSql(List *tlist, bool is_subquery, List **retrieved_attrs,
  * (These may or may not include RestrictInfo decoration.)
  */
 static void
-deparseFromExpr(List *quals, deparse_expr_cxt *context)
+deparseFromExpr(List * quals, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	RelOptInfo *scanrel = context->scanrel;
@@ -1115,12 +1121,12 @@ deparseFromExpr(List *quals, deparse_expr_cxt *context)
  */
 static void
 deparseTargetList(StringInfo buf,
-				  RangeTblEntry *rte,
+				  RangeTblEntry * rte,
 				  Index rtindex,
 				  Relation rel,
-				  Bitmapset *attrs_used,
+				  Bitmapset * attrs_used,
 				  bool qualify_col,
-				  List **retrieved_attrs)
+				  List * *retrieved_attrs)
 {
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	bool		have_wholerow;
@@ -1136,7 +1142,7 @@ deparseTargetList(StringInfo buf,
 	first = true;
 	for (i = 1; i <= tupdesc->natts; i++)
 	{
-		CustomObjectDef	*cdef;
+		CustomObjectDef *cdef;
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, i - 1);
 
 		/* Ignore dropped attributes. */
@@ -1184,13 +1190,13 @@ deparseTargetList(StringInfo buf,
  * or bare clauses.
  */
 static void
-appendConditions(List *exprs, deparse_expr_cxt *context)
+appendConditions(List * exprs, deparse_expr_cxt * context)
 {
 	ListCell   *lc;
 	bool		is_first = true;
 	StringInfo	buf = context->buf;
 
-	foreach (lc, exprs)
+	foreach(lc, exprs)
 	{
 		Expr	   *expr = (Expr *) lfirst(lc);
 
@@ -1220,21 +1226,21 @@ chfdw_get_jointype_name(JoinType jointype)
 {
 	switch (jointype)
 	{
-	case JOIN_INNER:
-		return "INNER";
+		case JOIN_INNER:
+			return "INNER";
 
-	case JOIN_LEFT:
-		return "LEFT";
+		case JOIN_LEFT:
+			return "LEFT";
 
-	case JOIN_RIGHT:
-		return "RIGHT";
+		case JOIN_RIGHT:
+			return "RIGHT";
 
-	case JOIN_FULL:
-		return "FULL";
+		case JOIN_FULL:
+			return "FULL";
 
-	default:
-		/* Shouldn't come here, but protect from buggy code. */
-		elog(ERROR, "unsupported join type %d", jointype);
+		default:
+			/* Shouldn't come here, but protect from buggy code. */
+			elog(ERROR, "unsupported join type %d", jointype);
 	}
 
 	/* Keep compiler happy */
@@ -1250,9 +1256,9 @@ chfdw_get_jointype_name(JoinType jointype)
  * from 1. It has same number of entries as tlist.
  */
 static void
-deparseExplicitTargetList(List *tlist,
-                          List **retrieved_attrs,
-                          deparse_expr_cxt *context)
+deparseExplicitTargetList(List * tlist,
+						  List * *retrieved_attrs,
+						  deparse_expr_cxt * context)
 {
 	ListCell   *lc;
 	StringInfo	buf = context->buf;
@@ -1260,7 +1266,7 @@ deparseExplicitTargetList(List *tlist,
 
 	*retrieved_attrs = NIL;
 
-	foreach (lc, tlist)
+	foreach(lc, tlist)
 	{
 		TargetEntry *tle = lfirst_node(TargetEntry, lc);
 
@@ -1283,7 +1289,7 @@ deparseExplicitTargetList(List *tlist,
  * This is used for deparsing the given relation as a subquery.
  */
 static void
-deparseSubqueryTargetList(deparse_expr_cxt *context)
+deparseSubqueryTargetList(deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	RelOptInfo *foreignrel = context->foreignrel;
@@ -1318,16 +1324,16 @@ deparseSubqueryTargetList(deparse_expr_cxt *context)
  * relation it just returns schema-qualified tablename, with the appropriate
  * alias if so requested.
  *
- * 'ignore_rel' is either zero or the RT index of a target relation.  In the
+ * 'ignore_rel' is either zero or the RT index of a target relation. In the
  * latter case the function constructs FROM clause of UPDATE or USING clause
  * of DELETE; it deparses the join relation as if the relation never contained
  * the target relation, and creates a List of conditions to be deparsed into
  * the top-level WHERE clause, which is returned to *ignore_conds.
  */
 static void
-deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
-                      bool use_alias, Index ignore_rel, List **ignore_conds,
-                      List **params_list)
+deparseFromExprForRel(StringInfo buf, PlannerInfo * root, RelOptInfo * foreignrel,
+					  bool use_alias, Index ignore_rel, List * *ignore_conds,
+					  List * *params_list)
 {
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
 
@@ -1345,13 +1351,13 @@ deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 			/*
 			 * If this is an inner join, add joinclauses to *ignore_conds and
 			 * set it to empty so that those can be deparsed into the WHERE
-			 * clause.  Note that since the target relation can never be
-			 * within the nullable side of an outer join, those could safely
-			 * be pulled up into the WHERE clause (see foreign_join_ok()).
-			 * Note also that since the target relation is only inner-joined
-			 * to any other relation in the query, all conditions in the join
-			 * tree mentioning the target relation could be deparsed into the
-			 * WHERE clause by doing this recursively.
+			 * clause. Note that since the target relation can never be within
+			 * the nullable side of an outer join, those could safely be
+			 * pulled up into the WHERE clause (see foreign_join_ok()). Note
+			 * also that since the target relation is only inner-joined to any
+			 * other relation in the query, all conditions in the join tree
+			 * mentioning the target relation could be deparsed into the WHERE
+			 * clause by doing this recursively.
 			 */
 			if (fpinfo->jointype == JOIN_INNER)
 			{
@@ -1485,9 +1491,9 @@ deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
  * Append FROM clause entry for the given relation into buf.
  */
 static void
-deparseRangeTblRef(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
-                   bool make_subquery, Index ignore_rel, List **ignore_conds,
-                   List **params_list)
+deparseRangeTblRef(StringInfo buf, PlannerInfo * root, RelOptInfo * foreignrel,
+				   bool make_subquery, Index ignore_rel, List * *ignore_conds,
+				   List * *params_list)
 {
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
 
@@ -1513,9 +1519,9 @@ deparseRangeTblRef(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 		/* Deparse the subquery representing the relation. */
 		appendStringInfoChar(buf, '(');
 		chfdw_deparse_select_stmt_for_rel(buf, root, foreignrel, NIL,
-								fpinfo->remote_conds, NIL,
-                                false, false, true,
-								&retrieved_attrs, params_list);
+										  fpinfo->remote_conds, NIL,
+										  false, false, true,
+										  &retrieved_attrs, params_list);
 		appendStringInfoChar(buf, ')');
 
 		/* Append the relation alias. */
@@ -1523,7 +1529,7 @@ deparseRangeTblRef(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 						 fpinfo->relation_index);
 
 		/*
-		 * Append the column aliases if needed.  Note that the subquery emits
+		 * Append the column aliases if needed. Note that the subquery emits
 		 * expressions specified in the relation's reltarget (see
 		 * deparseSubqueryTargetList).
 		 */
@@ -1553,14 +1559,14 @@ deparseRangeTblRef(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 /*
  * deparse remote INSERT statement
  */
-char *
-chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry *rte,
-                 Index rtindex, Relation rel,
-                 List *targetAttrs)
+char	   *
+chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry * rte,
+						 Index rtindex, Relation rel,
+						 List * targetAttrs)
 {
-	bool    first;
+	bool		first;
 	ListCell   *lc;
-	StringInfoData	table_name;
+	StringInfoData table_name;
 
 	initStringInfo(&table_name);
 	appendStringInfoString(buf, "INSERT INTO ");
@@ -1572,7 +1578,7 @@ chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry *rte,
 		appendStringInfoChar(buf, '(');
 
 		first = true;
-		foreach (lc, targetAttrs)
+		foreach(lc, targetAttrs)
 		{
 			int			attnum = lfirst_int(lc);
 
@@ -1596,12 +1602,12 @@ chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry *rte,
  * If qualify_col is true, qualify column name with the alias of relation.
  */
 static void
-deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
-				 int varno, int varattno, RangeTblEntry *rte,
-                 bool qualify_col)
+deparseColumnRef(StringInfo buf, CustomObjectDef * cdef,
+				 int varno, int varattno, RangeTblEntry * rte,
+				 bool qualify_col)
 {
 	char	   *colname = NULL;
-	CustomColumnInfo	*cinfo;
+	CustomColumnInfo *cinfo;
 
 	/* varno must not be any of OUTER_VAR, INNER_VAR and INDEX_VAR. */
 	Assert(!IS_SPECIAL_VARNO(varno));
@@ -1615,16 +1621,16 @@ deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
 		colname = cinfo->colname;
 
 	/*
-	 * If it's a column of a regular table or it doesn't have column_name
-	 * FDW option, use attribute name.
+	 * If it's a column of a regular table or it doesn't have column_name FDW
+	 * option, use attribute name.
 	 */
 	if (colname == NULL)
 		colname = get_attname(rte->relid, varattno, false);
 
 	if (cinfo && cinfo->coltype == CF_ISTORE_ARR)
 	{
-		char *colkey = psprintf("%s_keys", colname);
-		char *colval = psprintf("%s_values", colname);
+		char	   *colkey = psprintf("%s_keys", colname);
+		char	   *colval = psprintf("%s_values", colname);
 
 		if (cdef && cdef->cf_type == CF_ISTORE_SUM)
 		{
@@ -1695,12 +1701,14 @@ deparseColumnRef(StringInfo buf, CustomObjectDef *cdef,
 	}
 	else if (cinfo && cinfo->coltype == CF_ISTORE_COL)
 	{
-		char *alias_name = get_alias_name();
+		char	   *alias_name = get_alias_name();
 
 		if (cdef && cdef->cf_type == CF_ISTORE_FETCHVAL)
 		{
-			/* ((finalizeAggregation(colname) as _tmp).2)[indexOf(_tmp.1, - we fill this part
-			 * <key>)] - should be filled later */
+			/*
+			 * ((finalizeAggregation(colname) as _tmp).2)[indexOf(_tmp.1, - we
+			 * fill this part <key>)] - should be filled later
+			 */
 
 			appendStringInfoString(buf, "((");
 
@@ -1759,9 +1767,9 @@ deparseRelation(StringInfo buf, Relation rel)
 {
 	ForeignTable *table;
 	const char *relname = NULL;
-	char       *dbname = "default";
+	char	   *dbname = "default";
 	ForeignServer *server = chfdw_get_foreign_server(rel);
-	ListCell    *lc;
+	ListCell   *lc;
 
 	chfdw_extract_options(server->options, NULL, NULL, NULL, &dbname, NULL, NULL);
 
@@ -1771,7 +1779,7 @@ deparseRelation(StringInfo buf, Relation rel)
 	/*
 	 * Use value of FDW options if any, instead of the name of object itself.
 	 */
-	foreach (lc, table->options)
+	foreach(lc, table->options)
 	{
 		DefElem    *def = (DefElem *) lfirst(lc);
 
@@ -1780,9 +1788,9 @@ deparseRelation(StringInfo buf, Relation rel)
 			relname = defGetString(def);
 		}
 		else if (strcmp(def->defname, "database") == 0)
-        {
+		{
 			dbname = defGetString(def);
-        }
+		}
 	}
 	if (relname == NULL)
 	{
@@ -1828,7 +1836,7 @@ deparseStringLiteral(StringInfo buf, const char *val, bool quote)
  * should be self-parenthesized.
  */
 static void
-deparseExpr(Expr *node, deparse_expr_cxt *context)
+deparseExpr(Expr * node, deparse_expr_cxt * context)
 {
 	if (node == NULL)
 	{
@@ -1837,67 +1845,67 @@ deparseExpr(Expr *node, deparse_expr_cxt *context)
 
 	switch (nodeTag(node))
 	{
-	case T_Var:
-		deparseVar((Var *) node, context);
-		break;
-	case T_Const:
-		deparseConst((Const *) node, context, 0);
-		break;
-	case T_SubscriptingRef:
-		deparseSubscriptingRef((SubscriptingRef *) node, context);
-		break;
-	case T_FuncExpr:
-		deparseFuncExpr((FuncExpr *) node, context);
-		break;
-	case T_OpExpr:
-		deparseOpExpr((OpExpr *) node, context);
-		break;
-	case T_DistinctExpr:
-		deparseDistinctExpr((DistinctExpr *) node, context);
-		break;
-	case T_NullIfExpr:
-		deparseNullIfExpr((NullIfExpr *) node, context);
-		break;
-	case T_ScalarArrayOpExpr:
-		deparseScalarArrayOpExpr((ScalarArrayOpExpr *) node, context);
-		break;
-	case T_RelabelType:
-		deparseRelabelType((RelabelType *) node, context);
-		break;
-	case T_BoolExpr:
-		deparseBoolExpr((BoolExpr *) node, context);
-		break;
-	case T_NullTest:
-		deparseNullTest((NullTest *) node, context);
-		break;
-	case T_ArrayExpr:
-		deparseArrayExpr((ArrayExpr *) node, context);
-		break;
-	case T_Aggref:
-		deparseAggref((Aggref *) node, context);
-		break;
-	case T_CaseExpr:
-		deparseCaseExpr((CaseExpr *) node, context);
-		break;
-	case T_CaseWhen:
-		deparseCaseWhen((CaseWhen *) node, context);
-		break;
-	case T_CoalesceExpr:
-		deparseCoalesceExpr((CoalesceExpr *) node, context);
-		break;
-	case T_MinMaxExpr:
-		deparseMinMaxExpr((MinMaxExpr *) node, context);
-		break;
-	case T_CoerceViaIO:
-		deparseCoerceViaIO((CoerceViaIO *) node, context);
-		break;
-	case T_RowExpr:
-		deparseRowExpr((RowExpr *) node, context);
-		break;
-	default:
-		elog(ERROR, "unsupported expression type for deparse: %d",
-			 (int) nodeTag(node));
-		break;
+		case T_Var:
+			deparseVar((Var *) node, context);
+			break;
+		case T_Const:
+			deparseConst((Const *) node, context, 0);
+			break;
+		case T_SubscriptingRef:
+			deparseSubscriptingRef((SubscriptingRef *) node, context);
+			break;
+		case T_FuncExpr:
+			deparseFuncExpr((FuncExpr *) node, context);
+			break;
+		case T_OpExpr:
+			deparseOpExpr((OpExpr *) node, context);
+			break;
+		case T_DistinctExpr:
+			deparseDistinctExpr((DistinctExpr *) node, context);
+			break;
+		case T_NullIfExpr:
+			deparseNullIfExpr((NullIfExpr *) node, context);
+			break;
+		case T_ScalarArrayOpExpr:
+			deparseScalarArrayOpExpr((ScalarArrayOpExpr *) node, context);
+			break;
+		case T_RelabelType:
+			deparseRelabelType((RelabelType *) node, context);
+			break;
+		case T_BoolExpr:
+			deparseBoolExpr((BoolExpr *) node, context);
+			break;
+		case T_NullTest:
+			deparseNullTest((NullTest *) node, context);
+			break;
+		case T_ArrayExpr:
+			deparseArrayExpr((ArrayExpr *) node, context);
+			break;
+		case T_Aggref:
+			deparseAggref((Aggref *) node, context);
+			break;
+		case T_CaseExpr:
+			deparseCaseExpr((CaseExpr *) node, context);
+			break;
+		case T_CaseWhen:
+			deparseCaseWhen((CaseWhen *) node, context);
+			break;
+		case T_CoalesceExpr:
+			deparseCoalesceExpr((CoalesceExpr *) node, context);
+			break;
+		case T_MinMaxExpr:
+			deparseMinMaxExpr((MinMaxExpr *) node, context);
+			break;
+		case T_CoerceViaIO:
+			deparseCoerceViaIO((CoerceViaIO *) node, context);
+			break;
+		case T_RowExpr:
+			deparseRowExpr((RowExpr *) node, context);
+			break;
+		default:
+			elog(ERROR, "unsupported expression type for deparse: %d",
+				 (int) nodeTag(node));
+			break;
 	}
 }
 
@@ -1906,12 +1914,12 @@ deparseExpr(Expr *node, deparse_expr_cxt *context)
  *
  * If the Var belongs to the foreign relation, just print its remote name.
  * Otherwise, it's effectively a Param (and will in fact be a Param at
- * run time).  Handle it the same way we handle plain Params.
+ * run time). Handle it the same way we handle plain Params.
  */
 static void
-deparseVar(Var *node, deparse_expr_cxt *context)
+deparseVar(Var * node, deparse_expr_cxt * context)
 {
-	CustomObjectDef	*cdef;
+	CustomObjectDef *cdef;
 	Relids		relids = context->scanrel->relids;
 	int			relno;
 	int			colno;
@@ -2002,7 +2010,7 @@ ch_timestamp_out(PG_FUNCTION_ARGS)
 	if (TIMESTAMP_NOT_FINITE(timestamp))
 		EncodeSpecialTimestamp(timestamp, buf);
 	else if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) == 0)
-		/* we ignore ftractional seconds */
+		/* we ignore fractional seconds */
 		EncodeDateTime(tm, 0, false, 0, NULL, USE_ISO_DATES, buf);
 	else
 		ereport(ERROR,
@@ -2014,7 +2022,7 @@ ch_timestamp_out(PG_FUNCTION_ARGS)
 }
 
 static void
-deparseArray(Datum arr, deparse_expr_cxt *context)
+deparseArray(Datum arr, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	AnyArrayType *array = DatumGetAnyArrayP(arr);
@@ -2069,41 +2077,42 @@ deparseArray(Datum arr, deparse_expr_cxt *context)
 		}
 		else
 		{
-			char *extval = OidOutputFunctionCall(typiofunc, elt);
+			char	   *extval = OidOutputFunctionCall(typiofunc, elt);
+
 			switch (element_type)
 			{
-			case INT2OID:
-			case INT4OID:
-			case INT8OID:
-			case OIDOID:
-			case FLOAT4OID:
-			case FLOAT8OID:
-			case NUMERICOID:
-			{
-				/*
-				 * No need to quote unless it's a special value such as 'NaN'.
-				 * See comments in get_const_expr().
-				 */
-				if (strspn(extval, "0123456789+-eE.") == strlen(extval))
-				{
-					if (extval[0] == '+' || extval[0] == '-')
-						appendStringInfo(buf, "(%s)", extval);
+				case INT2OID:
+				case INT4OID:
+				case INT8OID:
+				case OIDOID:
+				case FLOAT4OID:
+				case FLOAT8OID:
+				case NUMERICOID:
+					{
+						/*
+						 * No need to quote unless it's a special value such
+						 * as 'NaN'. See comments in get_const_expr().
+						 */
+						if (strspn(extval, "0123456789+-eE.") == strlen(extval))
+						{
+							if (extval[0] == '+' || extval[0] == '-')
+								appendStringInfo(buf, "(%s)", extval);
+							else
+								appendStringInfoString(buf, extval);
+						}
+						else
+							appendStringInfo(buf, "'%s'", extval);
+					}
+					break;
+				case BOOLOID:
+					if (strcmp(extval, "t") == 0)
+						appendStringInfoString(buf, "true");
 					else
-						appendStringInfoString(buf, extval);
-				}
-				else
-					appendStringInfo(buf, "'%s'", extval);
-			}
-			break;
-			case BOOLOID:
-				if (strcmp(extval, "t") == 0)
-					appendStringInfoString(buf, "true");
-				else
-					appendStringInfoString(buf, "false");
-				break;
-			default:
-				deparseStringLiteral(buf, extval, true);
-				break;
+						appendStringInfoString(buf, "false");
+					break;
+				default:
+					deparseStringLiteral(buf, extval, true);
+					break;
 			}
 			pfree(extval);
 		}
@@ -2123,7 +2132,7 @@ deparseArray(Datum arr, deparse_expr_cxt *context)
  * to be the right type by default.
  */
 static void
-deparseConst(Const *node, deparse_expr_cxt *context, int showtype)
+deparseConst(Const * node, deparse_expr_cxt * context, int showtype)
 {
 	StringInfo	buf = context->buf;
 	Oid			typoutput;
@@ -2148,16 +2157,17 @@ deparseConst(Const *node, deparse_expr_cxt *context, int showtype)
 		/*
 		 * We use our own function here, that removes fractional seconds since
 		 * there are not supported in clickhouse
-		 * */
+		 */
 		extval = DatumGetCString(DirectFunctionCall1(ch_timestamp_out, node->constvalue));
 	}
 	else if (typoutput == F_INTERVAL_OUT)
 	{
-		/* basicly we can't convert month part since we should know about
+		/*
+		 * basicly we can't convert month part since we should know about
 		 * related timestamp first.
 		 *
 		 * for other types we just convert to seconds.
-		 * */
+		 */
 		uint64		sec;
 		Interval   *ival = DatumGetIntervalP(node->constvalue);
 		char		bufint8[MAXINT8LEN + 1];
@@ -2182,11 +2192,9 @@ deparseConst(Const *node, deparse_expr_cxt *context, int showtype)
 		extval = OidOutputFunctionCall(typoutput, node->constvalue);
 		if (cdef && cdef->cf_type == CF_AJBOOL_OUT)
 		{
-			/* ajbool:
-				'f' => 0
-				't' => 1
-				'u' => -1
-			*/
+			/*
+			 * ajbool: 'f' => 0 't' => 1 'u' => -1
+			 */
 			if (extval[0] == 'f')
 				appendStringInfoChar(buf, '0');
 			else if (extval[0] == 't')
@@ -2207,42 +2215,42 @@ deparseConst(Const *node, deparse_expr_cxt *context, int showtype)
 
 	switch (node->consttype)
 	{
-	case INT2OID:
-	case INT4OID:
-	case INT8OID:
-	case OIDOID:
-	case FLOAT4OID:
-	case FLOAT8OID:
-	case NUMERICOID:
-	{
-		/*
-		 * No need to quote unless it's a special value such as 'NaN'.
-		 * See comments in get_const_expr().
-		 */
-		if (strspn(extval, "0123456789+-eE.") == strlen(extval))
-		{
-			if (extval[0] == '+' || extval[0] == '-')
-				appendStringInfo(buf, "(%s)", extval);
+		case INT2OID:
+		case INT4OID:
+		case INT8OID:
+		case OIDOID:
+		case FLOAT4OID:
+		case FLOAT8OID:
+		case NUMERICOID:
+			{
+				/*
+				 * No need to quote unless it's a special value such as 'NaN'.
+				 * See comments in get_const_expr().
+				 */
+				if (strspn(extval, "0123456789+-eE.") == strlen(extval))
+				{
+					if (extval[0] == '+' || extval[0] == '-')
+						appendStringInfo(buf, "(%s)", extval);
+					else
+						appendStringInfoString(buf, extval);
+				}
+				else
+					appendStringInfo(buf, "'%s'", extval);
+			}
+			break;
+		case BITOID:
+		case VARBITOID:
+			appendStringInfo(buf, "B'%s'", extval);
+			break;
+		case BOOLOID:
+			if (strcmp(extval, "t") == 0)
+				appendStringInfoString(buf, "1");
 			else
-				appendStringInfoString(buf, extval);
-		}
-		else
-			appendStringInfo(buf, "'%s'", extval);
-	}
-	break;
-	case BITOID:
-	case VARBITOID:
-		appendStringInfo(buf, "B'%s'", extval);
-		break;
-	case BOOLOID:
-		if (strcmp(extval, "t") == 0)
-			appendStringInfoString(buf, "1");
-		else
-			appendStringInfoString(buf, "0");
-		break;
-	default:
-		deparseStringLiteral(buf, extval, true);
-		break;
+				appendStringInfoString(buf, "0");
+			break;
+		default:
+			deparseStringLiteral(buf, extval, true);
+			break;
 	}
 
 	if (closebr)
@@ -2262,7 +2270,7 @@ cleanup:
  * Deparse an array subscript expression.
  */
 static void
-deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
+deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	ListCell   *lowlist_item;
@@ -2272,9 +2280,9 @@ deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
 	appendStringInfoChar(buf, '(');
 
 	/*
-	 * Deparse referenced array expression first.  If that expression includes
+	 * Deparse referenced array expression first. If that expression includes
 	 * a cast, we have to parenthesize to prevent the array subscript from
-	 * being taken as typename decoration.  We can avoid that in the typical
+	 * being taken as typename decoration. We can avoid that in the typical
 	 * case of subscripting a Var, but otherwise do it.
 	 */
 	if (IsA(node->refexpr, Var))
@@ -2290,7 +2298,7 @@ deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
 
 	/* Deparse subscript expressions. */
 	lowlist_item = list_head(node->reflowerindexpr);	/* could be NULL */
-	foreach (uplist_item, node->refupperindexpr)
+	foreach(uplist_item, node->refupperindexpr)
 	{
 		appendStringInfoChar(buf, '[');
 		if (lowlist_item)
@@ -2310,14 +2318,14 @@ deparseSubscriptingRef(SubscriptingRef *node, deparse_expr_cxt *context)
  * Deparse a function call.
  */
 static void
-deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
+deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	bool		first;
 	ListCell   *arg;
-	CustomObjectDef	*cdef,
-					*old_cdef;
-	CustomObjectDef	 funcdef;
+	CustomObjectDef *cdef,
+			   *old_cdef;
+	CustomObjectDef funcdef;
 	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
 
 	/*
@@ -2355,10 +2363,11 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	cdef = appendFunctionName(node->funcid, context);
 	if (cdef && cdef->cf_type == CF_DATE_TRUNC)
 	{
-		Const *arg = (Const *) linitial(node->args);
-		char *trunctype = TextDatumGetCString(arg->constvalue);
+		Const	   *arg = (Const *) linitial(node->args);
+		char	   *trunctype = TextDatumGetCString(arg->constvalue);
+
 		CSTRING_TOLOWER(trunctype);
-		int cast_to_datetime64 = 0;
+		int			cast_to_datetime64 = 0;
 
 		if (strcmp(trunctype, "week") == 0)
 		{
@@ -2415,8 +2424,9 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	}
 	else if (cdef && cdef->cf_type == CF_DATE_PART)
 	{
-		Const *arg = (Const *) linitial(node->args);
-		char *parttype = TextDatumGetCString(arg->constvalue);
+		Const	   *arg = (Const *) linitial(node->args);
+		char	   *parttype = TextDatumGetCString(arg->constvalue);
+
 		CSTRING_TOLOWER(parttype);
 
 		if (strcmp(parttype, "day") == 0)
@@ -2510,16 +2520,17 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		colname = cinfo->colname;
 		if (cinfo->coltype == CF_ISTORE_ARR)
 		{
-			char *max_key_alias = get_alias_name();
-			char *colkey = psprintf("%s_keys", colname);
-			char *colval = psprintf("%s_values", colname);
+			char	   *max_key_alias = get_alias_name();
+			char	   *colkey = psprintf("%s_keys", colname);
+			char	   *colval = psprintf("%s_values", colname);
 
 			if (list_length(node->args) == 1)
 				elog(ERROR, "pg_clickhouse supports accumulate only with max_key parameter");
 
-			/* first block
-			 *	if(a_keys[1] <= max_key, arrayMap(x -> a_keys[1] + x - 1,
-			 *		arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key) - a_keys[1] + 1))), []),
+			/*
+			 * first block if(a_keys[1] <= max_key, arrayMap(x -> a_keys[1] +
+			 * x - 1, arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key)
+			 * - a_keys[1] + 1))), []),
 			 */
 			appendStringInfoString(buf, "if(");
 			if (qualify_col)
@@ -2539,9 +2550,11 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 			appendStringInfoString(buf, colkey);
 			appendStringInfoString(buf, "[1] + 1))), []),");
 
-			/* second block:
-			 *	if(a_keys[1] <= max_key, arrayCumSum(arrayMap(x -> sign * (a_values[indexOf(a_keys, a_keys[1] + x - 1)]),
-			 *		arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key) -a_keys[1] + 1)))), [])
+			/*
+			 * second block: if(a_keys[1] <= max_key, arrayCumSum(arrayMap(x
+			 * -> sign * (a_values[indexOf(a_keys, a_keys[1] + x - 1)]),
+			 * arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key)
+			 * -a_keys[1] + 1)))), [])
 			 */
 			appendStringInfoString(buf, "if(");
 			if (qualify_col)
@@ -2580,15 +2593,16 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		}
 		else if (cinfo->coltype == CF_ISTORE_COL)
 		{
-			/* (mapFill((finalizeAggregation(col) as t1).1, t1.2, <max_key>) as t2).1,
-			 * arrayCumSum(t2.2)
+			/*
+			 * (mapFill((finalizeAggregation(col) as t1).1, t1.2, <max_key>)
+			 * as t2).1, arrayCumSum(t2.2)
 			 *
-			 * simple:
-			 * (mapFill((col as t1).1, t1.2, <max_key>) as t2).1,
-			 * arrayCumSum(t2.2) */
+			 * simple: (mapFill((col as t1).1, t1.2, <max_key>) as t2).1,
+			 * arrayCumSum(t2.2)
+			 */
 
-			char *alias1 = get_alias_name();
-			char *alias2 = get_alias_name();
+			char	   *alias1 = get_alias_name();
+			char	   *alias2 = get_alias_name();
 
 			appendStringInfoString(buf, "(mapFill((");
 			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
@@ -2644,27 +2658,22 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	/* sup_up requires only values part of array */
 	if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
 	{
-		/* sum_up(daily_time_spent_cohort, 12)
-			=>
-			arraySum(arrayFilter((v, k) -> k <= 12,
-			daily_time_spent_cohort_values,
-			daily_time_spent_cohort_keys))
-
-			sum_up(daily_time_spent_cohort)
-			=>
-			arraySum(daily_time_spent_cohort_values)
-
-			!!!! or in case of AggregateFunction:
-			sum_up(daily_time_spent_cohort, 12)
-			=>
-			arraySum(arrayFilter((v, k) -> k <= 12,
-			(finalizeAggregation(daily_time_spent_cohort) as _tmp).2,
-			_tmp.1))
-
-			sum_up(daily_time_spent_cohort)
-			=>
-			arraySum(finalizeAggregation(daily_time_spent_cohort).2)
-		*/
+		/*
+		 * sum_up(daily_time_spent_cohort, 12) => arraySum(arrayFilter((v, k)
+		 * -> k <= 12, daily_time_spent_cohort_values,
+		 * daily_time_spent_cohort_keys))
+		 *
+		 * sum_up(daily_time_spent_cohort) =>
+		 * arraySum(daily_time_spent_cohort_values)
+		 *
+		 * !!!! or in case of AggregateFunction:
+		 * sum_up(daily_time_spent_cohort, 12) => arraySum(arrayFilter((v, k)
+		 * -> k <= 12, (finalizeAggregation(daily_time_spent_cohort) as
+		 * _tmp).2, _tmp.1))
+		 *
+		 * sum_up(daily_time_spent_cohort) =>
+		 * arraySum(finalizeAggregation(daily_time_spent_cohort).2)
+		 */
 		funcdef = *cdef;
 		funcdef.cf_context = node->args;
 		context->func = &funcdef;
@@ -2687,7 +2696,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 
 	/* ... and all the arguments */
 	first = true;
-	foreach (arg, node->args)
+	foreach(arg, node->args)
 	{
 		if (!first)
 			appendStringInfoString(buf, ", ");
@@ -2702,7 +2711,7 @@ end:
 }
 
 static void
-deparseIntervalOp(Node *first, Node *second, deparse_expr_cxt *context, bool plus)
+deparseIntervalOp(Node * first, Node * second, deparse_expr_cxt * context, bool plus)
 {
 	StringInfo	buf = context->buf;
 	Const	   *constval;
@@ -2711,7 +2720,8 @@ deparseIntervalOp(Node *first, Node *second, deparse_expr_cxt *context, bool plu
 
 	if (!IsA(second, Const))
 	{
-		bool old_op = context->interval_op;
+		bool		old_op = context->interval_op;
+
 		/* first argument */
 		deparseExpr((Expr *) first, context);
 
@@ -2778,7 +2788,7 @@ deparseIntervalOp(Node *first, Node *second, deparse_expr_cxt *context, bool plu
 
 	/* addSeconds arg */
 	appendStringInfoChar(buf, ',');
-	pg_lltoa((int64)(span->time / 1000000), ibuf);
+	pg_lltoa((int64) (span->time / 1000000), ibuf);
 	if (!plus)
 	{
 		appendStringInfoString(buf, "-(");
@@ -2798,8 +2808,9 @@ findFunction(Oid typoid, char *name)
 	HeapTuple	proctup;
 	Form_pg_proc procform;
 	CatCList   *catlist;
+
 	catlist = SearchSysCacheList1(PROCNAMEARGSNSP,
-			CStringGetDatum(name));
+								  CStringGetDatum(name));
 
 	if (catlist->n_members == 0)
 		elog(ERROR, "pg_clickhouse requires istore extension to parse istore values");
@@ -2822,18 +2833,18 @@ findFunction(Oid typoid, char *name)
 }
 
 /*
- * Deparse given operator expression.   To avoid problems around
- * priority of operations, we always parenthesize the arguments.
+ * Deparse given operator expression. To avoid problems around priority of
+ * operations, we always parenthesize the arguments.
  */
 static void
-deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
+deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	HeapTuple	tuple;
 	Form_pg_operator form;
 	char		oprkind;
 	ListCell   *arg;
-	CustomObjectDef	*cdef;
+	CustomObjectDef *cdef;
 
 	/* Retrieve information about the operator from system catalog. */
 	tuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(node->opno));
@@ -2854,97 +2865,100 @@ deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
 		switch (cdef->cf_type)
 		{
 			case CF_AJTIME_OPERATOR:
-			{
-				/* intervals with ajtime */
-				CustomObjectDef	*fdef = chfdw_check_for_custom_function(form->oprcode);
-				if (fdef && fdef->cf_type == CF_AJTIME_PL_INTERVAL)
 				{
-					deparseIntervalOp(linitial(node->args),
-						list_nth(node->args, 1), context, true);
-					goto cleanup;
+					/* intervals with ajtime */
+					CustomObjectDef *fdef = chfdw_check_for_custom_function(form->oprcode);
+
+					if (fdef && fdef->cf_type == CF_AJTIME_PL_INTERVAL)
+					{
+						deparseIntervalOp(linitial(node->args),
+										  list_nth(node->args, 1), context, true);
+						goto cleanup;
+					}
+					else if (fdef && fdef->cf_type == CF_AJTIME_MI_INTERVAL)
+					{
+						deparseIntervalOp(linitial(node->args),
+										  list_nth(node->args, 1), context, false);
+						goto cleanup;
+					}
 				}
-				else if (fdef && fdef->cf_type == CF_AJTIME_MI_INTERVAL)
-				{
-					deparseIntervalOp(linitial(node->args),
-						list_nth(node->args, 1), context, false);
-					goto cleanup;
-				}
-			}
-			break;
+				break;
 			case CF_TIMESTAMPTZ_PL_INTERVAL:
-			{
-				deparseIntervalOp(linitial(node->args),
-					list_nth(node->args, 1), context, true);
-				goto cleanup;
-			}
-			break;
+				{
+					deparseIntervalOp(linitial(node->args),
+									  list_nth(node->args, 1), context, true);
+					goto cleanup;
+				}
+				break;
 			case CF_HSTORE_FETCHVAL:
-			{
-				Expr *arg1 = linitial(node->args);
-				Expr *arg2 = list_nth(node->args, 1);
-
-				if (IsA(arg1, Const))
 				{
-					Const	   *constval = (Const *) arg1;
-					Oid			akeys = findFunction(constval->consttype, "akeys");
-					Oid			avalues = findFunction(constval->consttype, "avals");
+					Expr	   *arg1 = linitial(node->args);
+					Expr	   *arg2 = list_nth(node->args, 1);
 
-					/* vals[nullif(indexOf(keys,toString(arg1)), 0)] */
-					appendStringInfoChar(buf, '(');
-					deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
-					appendStringInfoString(buf, "[nullif(indexOf(");
-					deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
-					appendStringInfoChar(buf, ',');
-					deparseExpr(arg2, context);
-					appendStringInfoString(buf, "), 0)])");
+					if (IsA(arg1, Const))
+					{
+						Const	   *constval = (Const *) arg1;
+						Oid			akeys = findFunction(constval->consttype, "akeys");
+						Oid			avalues = findFunction(constval->consttype, "avals");
+
+						/* vals[nullif(indexOf(keys,toString(arg1)), 0)] */
+						appendStringInfoChar(buf, '(');
+						deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
+						appendStringInfoString(buf, "[nullif(indexOf(");
+						deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
+						appendStringInfoChar(buf, ',');
+						deparseExpr(arg2, context);
+						appendStringInfoString(buf, "), 0)])");
+					}
+					else
+						elog(ERROR, "pg_clickhouse supports hstore fetchval "
+							 "only for scalars");
+
+					goto cleanup;
 				}
-				else
-					elog(ERROR, "pg_clickhouse supports hstore fetchval "
-							"only for scalars");
-
-				goto cleanup;
-			}
-			break;
+				break;
 			case CF_ISTORE_FETCHVAL:
-			{
-				Node *arg = linitial(node->args);
-
-				if (IsA(arg, Var))
 				{
-					CustomObjectDef	*temp;
+					Node	   *arg = linitial(node->args);
 
-					temp = context->func;
-					context->func = cdef;
+					if (IsA(arg, Var))
+					{
+						CustomObjectDef *temp;
 
-					/* values[nullif(indexOf(ids, ...  in deparseColumnRef */
-					deparseExpr((Expr *) arg, context);
-					deparseExpr((Expr *) list_nth(node->args, 1), context);
-					/* ... 0)] */
-					appendStringInfoString(buf, "), 0)]");
+						temp = context->func;
+						context->func = cdef;
 
-					context->func = temp;
+						/* values[nullif(indexOf(ids, ... in deparseColumnRef */
+						deparseExpr((Expr *) arg, context);
+						deparseExpr((Expr *) list_nth(node->args, 1), context);
+						/* ... 0)] */
+						appendStringInfoString(buf, "), 0)]");
+
+						context->func = temp;
+					}
+					else if (IsA(arg, Const))
+					{
+						Const	   *constval = (Const *) arg;
+						Oid			akeys = findFunction(constval->consttype, "akeys");
+						Oid			avalues = findFunction(constval->consttype, "avals");
+
+						/*
+						 * ([val1, val2][nullif(indexOf([k1, k2], arg), 0])
+						 */
+						appendStringInfoChar(buf, '(');
+						deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
+						appendStringInfoString(buf, "[nullif(indexOf(");
+						deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
+						appendStringInfoString(buf, ", ");
+						deparseExpr((Expr *) list_nth(node->args, 1), context);
+						appendStringInfoString(buf, "), 0)])");
+					}
+					else
+						elog(ERROR, "pg_clickhouse supports fetchval only for columns and consts");
+
+					goto cleanup;
 				}
-				else if (IsA(arg, Const))
-				{
-					Const	   *constval = (Const *) arg;
-					Oid			akeys = findFunction(constval->consttype, "akeys");
-					Oid			avalues = findFunction(constval->consttype, "avals");
-
-					/* ([val1, val2][nullif(indexOf([key1, key2], arg), 0]) */
-					appendStringInfoChar(buf, '(');
-					deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
-					appendStringInfoString(buf, "[nullif(indexOf(");
-					deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
-					appendStringInfoString(buf, ", ");
-					deparseExpr((Expr *) list_nth(node->args, 1), context);
-					appendStringInfoString(buf, "), 0)])");
-				}
-				else
-					elog(ERROR, "pg_clickhouse supports fetchval only for columns and consts");
-
-				goto cleanup;
-			}
-			break;
+				break;
 			default: /* keep compiler quiet */ ;
 		}
 	}
@@ -2952,9 +2966,10 @@ deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
 	if ((node->opresulttype == INT2OID ||
 		 node->opresulttype == INT4OID ||
 		 node->opresulttype == INT8OID) &&
-			strcmp(NameStr(form->oprname), "/") == 0)
+		strcmp(NameStr(form->oprname), "/") == 0)
 	{
-		char *s = ch_format_type_extended(node->opresulttype, 0, 0);
+		char	   *s = ch_format_type_extended(node->opresulttype, 0, 0);
+
 		appendStringInfo(buf, "to%s", s);
 	}
 
@@ -2968,8 +2983,8 @@ deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
 
 		/*
 		 * Check for TestCaseExpr, in statements like CASE expr WHEN <val>.
-		 * Basically they would look like, OpExpr->(TestCaseExpr, Const).
-		 * We should just skip first arg and deparse second.
+		 * Basically they would look like, OpExpr->(TestCaseExpr, Const). We
+		 * should just skip first arg and deparse second.
 		 */
 		if (IsA(lfirst(arg), CaseTestExpr))
 		{
@@ -2989,10 +3004,12 @@ deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
 	 */
 	if (context->interval_op && strcmp(NameStr(form->oprname), "||") == 0)
 	{
-		Const *right = lfirst(list_tail(node->args));
+		Const	   *right = lfirst(list_tail(node->args));
+
 		if (IsA(right, Const) && right->consttype == TEXTOID)
 		{
-			char *s = TextDatumGetCString(right->constvalue);
+			char	   *s = TextDatumGetCString(right->constvalue);
+
 			if (strstr(s, "day") != NULL)
 				appendStringInfoString(buf, ") day");
 			else if (strstr(s, "year") != NULL)
@@ -3050,7 +3067,7 @@ deparseOperatorName(StringInfo buf, Form_pg_operator opform)
  * Deparse IS DISTINCT FROM.
  */
 static void
-deparseDistinctExpr(DistinctExpr *node, deparse_expr_cxt *context)
+deparseDistinctExpr(DistinctExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 
@@ -3064,7 +3081,7 @@ deparseDistinctExpr(DistinctExpr *node, deparse_expr_cxt *context)
 }
 
 static void
-deparseNullIfExpr(NullIfExpr *node, deparse_expr_cxt *context)
+deparseNullIfExpr(NullIfExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 
@@ -3077,11 +3094,12 @@ deparseNullIfExpr(NullIfExpr *node, deparse_expr_cxt *context)
 	appendStringInfoChar(buf, ')');
 }
 
-static void deparseAsIn(ScalarArrayOpExpr *node, deparse_expr_cxt *context, int optype)
+static void
+deparseAsIn(ScalarArrayOpExpr * node, deparse_expr_cxt * context, int optype)
 {
 	StringInfo	buf = context->buf;
-	Expr *arg1 = linitial(node->args);
-	Expr *arg2 = lsecond(node->args);
+	Expr	   *arg1 = linitial(node->args);
+	Expr	   *arg2 = lsecond(node->args);
 
 	deparseExpr(arg1, context);
 	if (optype == 1)
@@ -3096,11 +3114,11 @@ static void deparseAsIn(ScalarArrayOpExpr *node, deparse_expr_cxt *context, int 
 }
 
 /*
- * Deparse given ScalarArrayOpExpr expression.  To avoid problems
- * around priority of operations, we always parenthesize the arguments.
+ * Deparse given ScalarArrayOpExpr expression. To avoid problems around
+ * priority of operations, we always parenthesize the arguments.
  */
 static void
-deparseScalarArrayOpExpr(ScalarArrayOpExpr *node, deparse_expr_cxt *context)
+deparseScalarArrayOpExpr(ScalarArrayOpExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	Expr	   *arg1;
@@ -3170,7 +3188,9 @@ deparseScalarArrayOpExpr(ScalarArrayOpExpr *node, deparse_expr_cxt *context)
 				/* Deparse right operand again */
 				deparseExpr(arg2, context);
 				appendStringInfoChar(buf, ')');
-			} else {
+			}
+			else
+			{
 				appendStringInfoString(buf, ") = 0");
 			}
 		}
@@ -3183,7 +3203,7 @@ deparseScalarArrayOpExpr(ScalarArrayOpExpr *node, deparse_expr_cxt *context)
  * Deparse a RelabelType (binary-compatible cast) node.
  */
 static void
-deparseRelabelType(RelabelType *node, deparse_expr_cxt *context)
+deparseRelabelType(RelabelType * node, deparse_expr_cxt * context)
 {
 	deparseExpr(node->arg, context);
 }
@@ -3192,7 +3212,7 @@ deparseRelabelType(RelabelType *node, deparse_expr_cxt *context)
  * Deparse a BoolExpr node.
  */
 static void
-deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context)
+deparseBoolExpr(BoolExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	const char *op = NULL;		/* keep compiler quiet */
@@ -3201,22 +3221,22 @@ deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context)
 
 	switch (node->boolop)
 	{
-	case AND_EXPR:
-		op = "AND";
-		break;
-	case OR_EXPR:
-		op = "OR";
-		break;
-	case NOT_EXPR:
-		appendStringInfoString(buf, "(NOT ");
-		deparseExpr(linitial(node->args), context);
-		appendStringInfoChar(buf, ')');
-		return;
+		case AND_EXPR:
+			op = "AND";
+			break;
+		case OR_EXPR:
+			op = "OR";
+			break;
+		case NOT_EXPR:
+			appendStringInfoString(buf, "(NOT ");
+			deparseExpr(linitial(node->args), context);
+			appendStringInfoChar(buf, ')');
+			return;
 	}
 
 	appendStringInfoChar(buf, '(');
 	first = true;
-	foreach (lc, node->args)
+	foreach(lc, node->args)
 	{
 		if (!first)
 		{
@@ -3232,7 +3252,7 @@ deparseBoolExpr(BoolExpr *node, deparse_expr_cxt *context)
  * Deparse IS [NOT] NULL expression.
  */
 static void
-deparseNullTest(NullTest *node, deparse_expr_cxt *context)
+deparseNullTest(NullTest * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 
@@ -3241,7 +3261,7 @@ deparseNullTest(NullTest *node, deparse_expr_cxt *context)
 
 	/*
 	 * For scalar inputs, we prefer to print as IS [NOT] NULL, which is
-	 * shorter and traditional.  If it's a rowtype input but we're applying a
+	 * shorter and traditional. If it's a rowtype input but we're applying a
 	 * scalar test, must print IS [NOT] DISTINCT FROM NULL to be semantically
 	 * correct.
 	 */
@@ -3265,7 +3285,7 @@ deparseNullTest(NullTest *node, deparse_expr_cxt *context)
  * Deparse ARRAY[...] construct.
  */
 static void
-deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context)
+deparseArrayExpr(ArrayExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 
@@ -3279,7 +3299,7 @@ deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context)
 	/* If the array is empty, we need an explicit cast to the array type. */
 	if (node->elements == NIL)
 		appendStringInfo(buf, ", '%s')",
-			deparse_type_name(node->array_typeid, -1));
+						 deparse_type_name(node->array_typeid, -1));
 }
 
 /*
@@ -3287,7 +3307,7 @@ deparseArrayExpr(ArrayExpr *node, deparse_expr_cxt *context)
  * array to the list of individual values.
 */
 static void
-deparseArrayList(ArrayExpr *node, deparse_expr_cxt *context)
+deparseArrayList(ArrayExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	bool		first = true;
@@ -3309,9 +3329,9 @@ deparseArrayList(ArrayExpr *node, deparse_expr_cxt *context)
  */
 static void
 appendAggOrderBySuffix(Oid sortop, Oid sortcoltype, bool nulls_first,
-						deparse_expr_cxt *context)
+					   deparse_expr_cxt * context)
 {
-	// StringInfo	buf = context->buf;
+	/* StringInfo buf = context->buf; */
 	TypeCacheEntry *typentry;
 
 	/* See whether operator is default < or > for sort expr's datatype. */
@@ -3319,19 +3339,35 @@ appendAggOrderBySuffix(Oid sortop, Oid sortcoltype, bool nulls_first,
 								 TYPECACHE_LT_OPR | TYPECACHE_GT_OPR);
 
 	if (sortop == typentry->lt_opr)
-		// appendStringInfoString(buf, " ASC");
-		; // Okay.
+	{
+		/*
+		 * Okay.
+		 *
+		 * appendStringInfoString(buf, " ASC");
+		 */
+		;
+	}
 	else if (sortop == typentry->gt_opr)
-		// appendStringInfoString(buf, " DESC");
+	{
+		/* appendStringInfoString(buf, " DESC"); */
 		elog(ERROR, "pg_clickhouse: ClickHouse does not support \"DESC\" in aggregate expressions");
+	}
 	else
 		elog(ERROR, "pg_clickhouse: ClickHouse does not support \"USING\" in aggregate expressions");
 
 	if (nulls_first)
-		// appendStringInfoString(buf, " NULLS FIRST");
+	{
+		/* appendStringInfoString(buf, " NULLS FIRST"); */
 		elog(ERROR, "pg_clickhouse: ClickHouse does not support \"NULLS FIRST\" in aggregate expressions");
-	// else // Okay unless DESC support added.
-		// appendStringInfoString(buf, " NULLS LAST");
+	}
+	else
+	{
+		/*
+		 * Okay unless DESC support added.
+		 *
+		 * appendStringInfoString(buf, " NULLS LAST");
+		 */
+	}
 }
 
 
@@ -3339,7 +3375,7 @@ appendAggOrderBySuffix(Oid sortop, Oid sortcoltype, bool nulls_first,
  * Append ORDER BY arguments to aggregate function arguments.
  */
 static void
-appendAggOrderBy(List *orderList, List *targetList, deparse_expr_cxt *context)
+appendAggOrderBy(List * orderList, List * targetList, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	ListCell   *lc;
@@ -3359,7 +3395,7 @@ appendAggOrderBy(List *orderList, List *targetList, deparse_expr_cxt *context)
 										  false, context);
 		/* Add decoration as needed. */
 		appendAggOrderBySuffix(srt->sortop, exprType(sortexpr), srt->nulls_first,
-								context);
+							   context);
 	}
 }
 
@@ -3367,16 +3403,16 @@ appendAggOrderBy(List *orderList, List *targetList, deparse_expr_cxt *context)
  * Deparse an Aggref node.
  */
 static void
-deparseAggref(Aggref *node, deparse_expr_cxt *context)
+deparseAggref(Aggref * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
-	CustomObjectDef	*cdef;
+	CustomObjectDef *cdef;
 	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
-	bool	aggfilter = false;
-	bool	sign_count_filter = false;
-	uint8	brcount = 1;
-	bool	use_variadic;
-	char    *name = get_func_name(node->aggfnoid);
+	bool		aggfilter = false;
+	bool		sign_count_filter = false;
+	uint8		brcount = 1;
+	bool		use_variadic;
+	char	   *name = get_func_name(node->aggfnoid);
 
 	/* Only basic, non-split aggregation accepted. */
 	Assert(node->aggsplit == AGGSPLIT_SIMPLE);
@@ -3405,7 +3441,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 	appendStringInfoChar(buf, '(');
 
 	/* Explained below. */
-	bool omit_star = false;
+	bool		omit_star = false;
 
 	if (AGGKIND_IS_ORDERED_SET(node->aggkind))
 	{
@@ -3435,47 +3471,55 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 	else
 	{
 		/* Add DISTINCT */
-		if (node->aggdistinct != NIL)  appendStringInfoString(buf, "DISTINCT ");
+		if (node->aggdistinct != NIL)
+			appendStringInfoString(buf, "DISTINCT ");
 
 		/* aggstar can be set only in zero-argument aggregates */
 		if (node->aggstar)
 		{
-			/* Omit * for COUNT(*) but not COUNT(DISTINCT *)
-			* https://github.com/ClickHouse/pg_clickhouse/issues/25
-			* To be fixed in ClickHouse 25.11, so can be omitted once relased.
-			* https://github.com/ClickHouse/ClickHouse/pull/89373
-			*
-			* XXX Once ClickHouse has made a release fixing this issue, consider
-			* adding the Client::ServerInfo struct returned from
-			* Client::GetServerInfo() to deparse_expr_cxt so we can allow * to be
-			* passed through for the fixed version.
-			*/
+			/*
+			 * Omit * for COUNT(*) but not COUNT(DISTINCT *)
+			 * https://github.com/ClickHouse/pg_clickhouse/issues/25 To be
+			 * fixed in ClickHouse 25.11, so can be omitted once relased.
+			 * https://github.com/ClickHouse/ClickHouse/pull/89373
+			 *
+			 * XXX Once ClickHouse has made a release fixing this issue,
+			 * consider adding the Client::ServerInfo struct returned from
+			 * Client::GetServerInfo() to deparse_expr_cxt so we can allow *
+			 * to be passed through for the fixed version.
+			 */
 			omit_star = node->aggfilter && node->aggdistinct == NIL && !strcmp(name, "count");
 			if (context->func && context->func->cf_type == CF_SIGN_COUNT)
 			{
 				Assert(fpinfo && fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE);
 				appendStringInfoString(buf, fpinfo->ch_table_sign_field);
 			}
-			// Omit * for COUNT(*) but not COUNT(DISTINCT *).
+			/* Omit * for COUNT (*) but not COUNT(DISTINCT *). */
 			else if (!omit_star)
+			{
 				appendStringInfoChar(buf, '*');
+			}
 		}
 		else
 		{
 			ListCell   *arg;
 			bool		first = true;
 			bool		signMultiply = (context->func &&
-							(context->func->cf_type == CF_SIGN_AVG ||
-								context->func->cf_type == CF_SIGN_SUM));
+										(context->func->cf_type == CF_SIGN_AVG ||
+										 context->func->cf_type == CF_SIGN_SUM));
 
 			/* Add all the arguments */
 			if (sign_count_filter)
-				/* in case if COUNT(col) we should get countIf(sign, col is not null) */
+
+				/*
+				 * in case if COUNT(col) we should get countIf(sign, col is
+				 * not null)
+				 */
 				appendStringInfoString(buf, fpinfo->ch_table_sign_field);
 			else
 			{
 				/* default arguments output */
-				foreach (arg, node->args)
+				foreach(arg, node->args)
 				{
 					TargetEntry *tle = (TargetEntry *) lfirst(arg);
 					Node	   *n = (Node *) tle->expr;
@@ -3490,7 +3534,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 
 					if (use_variadic && lnext(node->args, arg) == NULL)
 					{
-						// Convert variadic array to list of arguments.
+						/* Convert variadic array to list of arguments. */
 						Assert(nodeTag(n) == T_ArrayExpr);
 						deparseArrayList((ArrayExpr *) n, context);
 					}
@@ -3513,7 +3557,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 	/* Add 'If' part condition */
 	if (aggfilter)
 	{
-		// No argument output for COUNT(*).
+		/* No argument output for COUNT (*). */
 		if (!omit_star)
 			appendStringInfoChar(buf, ',');
 
@@ -3559,7 +3603,7 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 }
 
 static void
-deparseCaseExpr(CaseExpr *node, deparse_expr_cxt *context)
+deparseCaseExpr(CaseExpr * node, deparse_expr_cxt * context)
 {
 #define DEPARSE_WRAPPED(node) \
 do { \
@@ -3592,14 +3636,16 @@ do { \
 
 	foreach(lc, node->args)
 	{
-		CaseWhen	*arg = lfirst(lc);
+		CaseWhen   *arg = lfirst(lc);
 
 		Assert(IsA(arg, CaseWhen));
 		appendStringInfoString(buf, " WHEN ");
 		deparseExpr(arg->expr, context);
 
-		/* in simple cases like WHEN val THEN we should extend the condition
-		 * for WHEN val = 1 since there is no bool type in ClickHouse */
+		/*
+		 * in simple cases like WHEN val THEN we should extend the condition
+		 * for WHEN val = 1 since there is no bool type in ClickHouse
+		 */
 		if (IsA(arg->expr, Var))
 			appendStringInfoString(buf, " = 1");
 
@@ -3619,15 +3665,19 @@ do { \
 }
 
 static void
-deparseCaseWhen(CaseWhen *node, deparse_expr_cxt *context)
+deparseCaseWhen(CaseWhen * node, deparse_expr_cxt * context)
 {
-	// XXX Needs implementation.
-	// StringInfo	buf = context->buf;
-	// ListCell   *lc;
+	/*
+	 * XXX Needs implementation.
+	 *
+	 * StringInfo buf = context->buf;
+	 *
+	 * ListCell * lc;
+	 */
 }
 
 static void
-deparseRowExpr(RowExpr *node, deparse_expr_cxt *context)
+deparseRowExpr(RowExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	ListCell   *lc;
@@ -3650,7 +3700,7 @@ deparseRowExpr(RowExpr *node, deparse_expr_cxt *context)
 }
 
 static void
-deparseCoerceViaIO(CoerceViaIO *node, deparse_expr_cxt *context)
+deparseCoerceViaIO(CoerceViaIO * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 
@@ -3675,7 +3725,7 @@ deparseCoerceViaIO(CoerceViaIO *node, deparse_expr_cxt *context)
 }
 
 static void
-deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context)
+deparseCoalesceExpr(CoalesceExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	ListCell   *lc;
@@ -3684,9 +3734,9 @@ deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context)
 	appendStringInfoString(buf, "COALESCE(");
 
 	first = true;
-	foreach (lc, node->args)
+	foreach(lc, node->args)
 	{
-		Expr *arg = lfirst(lc);
+		Expr	   *arg = lfirst(lc);
 
 		if (!first)
 			appendStringInfoString(buf, ", ");
@@ -3709,7 +3759,7 @@ deparseCoalesceExpr(CoalesceExpr *node, deparse_expr_cxt *context)
 }
 
 static void
-deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context)
+deparseMinMaxExpr(MinMaxExpr * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	ListCell   *lc;
@@ -3722,7 +3772,7 @@ deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context)
 
 	appendStringInfoChar(buf, '(');
 	first = true;
-	foreach (lc, node->args)
+	foreach(lc, node->args)
 	{
 		if (!first)
 			appendStringInfoString(buf, ", ");
@@ -3738,7 +3788,7 @@ deparseMinMaxExpr(MinMaxExpr *node, deparse_expr_cxt *context)
  * Deparse GROUP BY clause.
  */
 static void
-appendGroupByClause(List *tlist, deparse_expr_cxt *context)
+appendGroupByClause(List * tlist, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	Query	   *query = context->root->parse;
@@ -3757,7 +3807,7 @@ appendGroupByClause(List *tlist, deparse_expr_cxt *context)
 	 */
 	Assert(!query->groupingSets);
 
-	foreach (lc, query->groupClause)
+	foreach(lc, query->groupClause)
 	{
 		SortGroupClause *grp = (SortGroupClause *) lfirst(lc);
 
@@ -3776,8 +3826,8 @@ appendGroupByClause(List *tlist, deparse_expr_cxt *context)
  * base relation are obtained and deparsed.
  */
 static void
-appendOrderByClause(List *pathkeys, bool has_final_sort,
-					deparse_expr_cxt *context)
+appendOrderByClause(List * pathkeys, bool has_final_sort,
+					deparse_expr_cxt * context)
 {
 	ListCell   *lcell;
 	char	   *delim = " ";
@@ -3797,8 +3847,8 @@ appendOrderByClause(List *pathkeys, bool has_final_sort,
 			 * the final sort.
 			 */
 			em_expr = chfdw_find_em_expr_for_input_target(context->root,
-													pathkey->pk_eclass,
-													context->foreignrel->reltarget);
+														  pathkey->pk_eclass,
+														  context->foreignrel->reltarget);
 		}
 		else
 			em_expr = chfdw_find_em_expr_for_rel(pathkey->pk_eclass, baserel);
@@ -3818,10 +3868,10 @@ appendOrderByClause(List *pathkeys, bool has_final_sort,
 
 		if (pathkey->pk_nulls_first)
 			appendStringInfoString(buf, " NULLS FIRST");
-		//else
-		//	appendStringInfoString(buf, " NULLS LAST");
+		else
+			/* appendStringInfoString(buf, " NULLS LAST"); */
 
-		delim = ", ";
+			delim = ", ";
 	}
 }
 
@@ -3829,7 +3879,7 @@ appendOrderByClause(List *pathkeys, bool has_final_sort,
  * Deparse LIMIT/OFFSET clause.
  */
 static void
-appendLimitClause(deparse_expr_cxt *context)
+appendLimitClause(deparse_expr_cxt * context)
 {
 	PlannerInfo *root = context->root;
 	StringInfo	buf = context->buf;
@@ -3852,13 +3902,13 @@ appendLimitClause(deparse_expr_cxt *context)
  *		Returns was custom or not.
  */
 static CustomObjectDef *
-appendFunctionName(Oid funcid, deparse_expr_cxt *context)
+appendFunctionName(Oid funcid, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	HeapTuple	proctup;
 	Form_pg_proc procform;
 	const char *proname;
-	CustomObjectDef	*cdef;
+	CustomObjectDef *cdef;
 	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
 
 	cdef = chfdw_check_for_custom_function(funcid);
@@ -3878,7 +3928,7 @@ appendFunctionName(Oid funcid, deparse_expr_cxt *context)
 
 	/* we have some additional conditions on aggregation functions */
 	if (chfdw_is_builtin(funcid) && procform->prokind == PROKIND_AGGREGATE
-			&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
+		&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
 	{
 		cdef = palloc(sizeof(CustomObjectDef));
 		cdef->cf_oid = funcid;
@@ -3917,8 +3967,8 @@ appendFunctionName(Oid funcid, deparse_expr_cxt *context)
  * need not find it again.
  */
 static Node *
-deparseSortGroupClause(Index ref, List *tlist, bool force_colno,
-                       deparse_expr_cxt *context)
+deparseSortGroupClause(Index ref, List * tlist, bool force_colno,
+					   deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
 	TargetEntry *tle;
@@ -3958,7 +4008,7 @@ deparseSortGroupClause(Index ref, List *tlist, bool force_colno,
  * column alias to the Var provided by the subquery.
  */
 static bool
-is_subquery_var(Var *node, RelOptInfo *foreignrel, int *relno, int *colno)
+is_subquery_var(Var * node, RelOptInfo * foreignrel, int *relno, int *colno)
 {
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
 	RelOptInfo *outerrel = fpinfo->outerrel;
@@ -4020,8 +4070,8 @@ is_subquery_var(Var *node, RelOptInfo *foreignrel, int *relno, int *colno)
  * given relation, which are returned into *relno and *colno.
  */
 static void
-get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel,
-                              int *relno, int *colno)
+get_relation_column_alias_ids(Var * node, RelOptInfo * foreignrel,
+							  int *relno, int *colno)
 {
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
 	int			i;
@@ -4032,7 +4082,7 @@ get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel,
 
 	/* Get the column alias ID */
 	i = 1;
-	foreach (lc, foreignrel->reltarget->exprs)
+	foreach(lc, foreignrel->reltarget->exprs)
 	{
 		if (equal(lfirst(lc), (Node *) node))
 		{

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -2,7 +2,7 @@
 	A PostgreSQL extension for connecting to ClickHouse servers.
 */
 
-// PostgreSQL includes.
+/* PostgreSQL includes. */
 #include "postgres.h"
 #include "catalog/pg_class_d.h"
 #include "commands/explain.h"
@@ -33,15 +33,15 @@
 #include "commands/explain_state.h"
 #endif
 
-// extension includes.
+/* extension includes. */
 #include "utils/builtins.h"
 #include "binary.hh"
 #include "internal.h"
 #include "fdw.h"
 
-// Extension metadata for the server.
+/* Extension metadata for the server. */
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "pg_clickhouse", .version = "__VERSION__");
+PG_MODULE_MAGIC_EXT(.name = "pg_clickhouse",.version = "__VERSION__");
 #else
 PG_MODULE_MAGIC;
 #endif
@@ -59,7 +59,7 @@ PG_MODULE_MAGIC;
  * Indexes of FDW-private information stored in fdw_private lists.
  *
  * These items are indexed with the enum FdwScanPrivateIndex, so an item
- * can be fetched with list_nth().  For example, to get the SELECT statement:
+ * can be fetched with list_nth(). For example, to get the SELECT statement:
  *		sql = strVal(list_nth(fdw_private, FdwScanPrivateSelectSql));
  */
 enum FdwScanPrivateIndex
@@ -80,7 +80,7 @@ enum FdwScanPrivateIndex
 
 /*
  * Similarly, this enum describes what's kept in the fdw_private list for
- * a ModifyTable node referencing a postgres_fdw foreign table.  We store:
+ * a ModifyTable node referencing a postgres_fdw foreign table. We store:
  *
  * 0) INSERT statement text to be sent to the remote server
  * 1) Integer list of target attribute numbers for INSERT
@@ -103,7 +103,7 @@ enum FdwModifyPrivateIndex
 typedef struct ChFdwScanState
 {
 	Relation	rel;			/* relcache entry for the foreign table. NULL
-						 * for a foreign join scan. */
+								 * for a foreign join scan. */
 	TupleDesc	tupdesc;		/* tuple descriptor of scan */
 	AttInMetadata *attinmeta;	/* attribute datatype conversion metadata */
 
@@ -112,7 +112,7 @@ typedef struct ChFdwScanState
 	List	   *retrieved_attrs;	/* list of retrieved attribute numbers */
 
 	/* for remote query execution */
-	ch_connection	conn;			/* connection for the scan */
+	ch_connection conn;			/* connection for the scan */
 	int			numParams;		/* number of parameters passed to query */
 	FmgrInfo   *param_flinfo;	/* output conversion functions for them */
 	List	   *param_exprs;	/* executable expressions for param values */
@@ -120,14 +120,14 @@ typedef struct ChFdwScanState
 	ch_cursor  *ch_cursor;		/* result of query from clickhouse */
 
 	/* for storing result tuple */
-	HeapTuple  tuple;			/* array of currently-retrieved tuples */
+	HeapTuple	tuple;			/* array of currently-retrieved tuples */
 
 	/* working memory contexts */
 	MemoryContext batch_cxt;	/* context holding current batch of tuples */
 	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
 
 	int			fetch_size;		/* number of tuples per fetch */
-} ChFdwScanState;
+}			ChFdwScanState;
 
 /*
  * Execution state of a foreign insert.
@@ -138,7 +138,7 @@ typedef struct CHFdwModifyState
 	AttInMetadata *attinmeta;	/* attribute datatype conversion metadata */
 
 	/* for remote query execution */
-	ch_connection	conn;		/* connection for the scan */
+	ch_connection conn;			/* connection for the scan */
 
 	/* extracted fdw_private data */
 	char	   *query;			/* text of INSERT/UPDATE/DELETE command */
@@ -146,7 +146,7 @@ typedef struct CHFdwModifyState
 
 	/* working memory context */
 	MemoryContext temp_cxt;		/* context for per-tuple temporary data */
-} CHFdwModifyState;
+}			CHFdwModifyState;
 
 /*
  * This enum describes what's kept in the fdw_private list for a ForeignPath.
@@ -172,7 +172,7 @@ typedef struct
 	double		limit_tuples;
 	int64		count_est;
 	int64		offset_est;
-} ChFdwPathExtraData;
+}			ChFdwPathExtraData;
 
 
 /*
@@ -189,111 +189,114 @@ static double time_used = 0;
 /*
  * FDW callback routines
  */
-static void clickhouseGetForeignRelSize(PlannerInfo *root,
-                                        RelOptInfo *baserel,
-                                        Oid foreigntableid);
-static ForeignScan *clickhouseGetForeignPlan(PlannerInfo *root,
-        RelOptInfo *foreignrel,
-        Oid foreigntableid,
-        ForeignPath *best_path,
-        List *tlist,
-        List *scan_clauses,
-        Plan *outer_plan);
+static void clickhouseGetForeignRelSize(PlannerInfo * root,
+										RelOptInfo * baserel,
+										Oid foreigntableid);
+static ForeignScan * clickhouseGetForeignPlan(PlannerInfo * root,
+											  RelOptInfo * foreignrel,
+											  Oid foreigntableid,
+											  ForeignPath * best_path,
+											  List * tlist,
+											  List * scan_clauses,
+											  Plan * outer_plan);
 static int
-clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
-                                HeapTuple *rows, int targrows,
-                                double *totalrows,
-                                double *totaldeadrows);
-static void clickhouseBeginForeignScan(ForeignScanState *node, int eflags);
-static TupleTableSlot *clickhouseIterateForeignScan(ForeignScanState *node);
-static void clickhouseEndForeignScan(ForeignScanState *node);
-static List *clickhousePlanForeignModify(PlannerInfo *root,
-        ModifyTable *plan,
-        Index resultRelation,
-        int subplan_index);
-static void clickhouseBeginForeignModify(ModifyTableState *mtstate,
-        ResultRelInfo *resultRelInfo,
-        List *fdw_private,
-        int subplan_index,
-        int eflags);
-static TupleTableSlot *clickhouseExecForeignInsert(EState *estate,
-        ResultRelInfo *resultRelInfo,
-        TupleTableSlot *slot,
-        TupleTableSlot *planSlot);
-static void clickhouseBeginForeignInsert(ModifyTableState *mtstate,
-        ResultRelInfo *resultRelInfo);
-static void clickhouseEndForeignInsert(EState *estate,
-                                       ResultRelInfo *resultRelInfo);
-static void clickhouseExplainForeignScan(ForeignScanState *node,
-        ExplainState *es);
-static void clickhouseGetForeignUpperPaths(PlannerInfo *root,
-        UpperRelationKind stage,
-        RelOptInfo *input_rel, RelOptInfo *output_rel,
-        void *extra);
+			clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
+											HeapTuple * rows, int targrows,
+											double *totalrows,
+											double *totaldeadrows);
+static void clickhouseBeginForeignScan(ForeignScanState * node, int eflags);
+static TupleTableSlot * clickhouseIterateForeignScan(ForeignScanState * node);
+static void clickhouseEndForeignScan(ForeignScanState * node);
+static List * clickhousePlanForeignModify(PlannerInfo * root,
+										  ModifyTable * plan,
+										  Index resultRelation,
+										  int subplan_index);
+static void clickhouseBeginForeignModify(ModifyTableState * mtstate,
+										 ResultRelInfo * resultRelInfo,
+										 List * fdw_private,
+										 int subplan_index,
+										 int eflags);
+static TupleTableSlot * clickhouseExecForeignInsert(EState * estate,
+													ResultRelInfo * resultRelInfo,
+													TupleTableSlot * slot,
+													TupleTableSlot * planSlot);
+static void clickhouseBeginForeignInsert(ModifyTableState * mtstate,
+										 ResultRelInfo * resultRelInfo);
+static void clickhouseEndForeignInsert(EState * estate,
+									   ResultRelInfo * resultRelInfo);
+static void clickhouseExplainForeignScan(ForeignScanState * node,
+										 ExplainState * es);
+static void clickhouseGetForeignUpperPaths(PlannerInfo * root,
+										   UpperRelationKind stage,
+										   RelOptInfo * input_rel, RelOptInfo * output_rel,
+										   void *extra);
 static bool clickhouseAnalyzeForeignTable(Relation relation,
-        AcquireSampleRowsFunc *func,
-        BlockNumber *totalpages);
-static bool clickhouseRecheckForeignScan(ForeignScanState *node,
-        TupleTableSlot *slot);
+										  AcquireSampleRowsFunc * func,
+										  BlockNumber * totalpages);
+static bool clickhouseRecheckForeignScan(ForeignScanState * node,
+										 TupleTableSlot * slot);
 
 /*
  * Helper functions
  */
 static void estimate_path_cost_size(double *p_rows, int *p_width,
-                                    Cost *p_startup_cost, Cost *p_total_cost,
+									Cost * p_startup_cost, Cost * p_total_cost,
 									double coef);
-static CHFdwModifyState *create_foreign_modify(EState *estate,
-        RangeTblEntry *rte,
-        ResultRelInfo *resultRelInfo,
-        CmdType operation,
-        Plan *subplan,
-        char *query,
-        List *target_attrs,
-		char *table_name);
-static void finish_foreign_modify(CHFdwModifyState *fmstate);
-static void prepare_query_params(PlanState *node,
-                                 List *fdw_exprs,
-                                 int numParams,
-                                 FmgrInfo **param_flinfo,
-                                 List **param_exprs,
-                                 const char ***param_values);
-static bool foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel,
-                            JoinType jointype, RelOptInfo *outerrel, RelOptInfo *innerrel,
-                            JoinPathExtraData *extra);
-static bool foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
-                                Node *havingQual);
-static List *get_useful_pathkeys_for_relation(PlannerInfo *root,
-        RelOptInfo *rel);
-static void add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
-        Path *epq_path);
-static void add_foreign_grouping_paths(PlannerInfo *root,
-                                       RelOptInfo *input_rel,
-                                       RelOptInfo *grouped_rel,
-                                       GroupPathExtraData *extra);
-static void add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
-						  RelOptInfo *ordered_rel);
-static void add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
-						RelOptInfo *final_rel,
-						void *fextra);
-static void merge_fdw_options(CHFdwRelationInfo *fpinfo,
-                              const CHFdwRelationInfo *fpinfo_o,
-                              const CHFdwRelationInfo *fpinfo_i);
+static CHFdwModifyState * create_foreign_modify(EState * estate,
+												RangeTblEntry * rte,
+												ResultRelInfo * resultRelInfo,
+												CmdType operation,
+												Plan * subplan,
+												char *query,
+												List * target_attrs,
+												char *table_name);
+static void finish_foreign_modify(CHFdwModifyState * fmstate);
+static void prepare_query_params(PlanState * node,
+								 List * fdw_exprs,
+								 int numParams,
+								 FmgrInfo * *param_flinfo,
+								 List * *param_exprs,
+								 const char ***param_values);
+static bool foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel,
+							JoinType jointype, RelOptInfo * outerrel, RelOptInfo * innerrel,
+							JoinPathExtraData * extra);
+static bool foreign_grouping_ok(PlannerInfo * root, RelOptInfo * grouped_rel,
+								Node * havingQual);
+static List * get_useful_pathkeys_for_relation(PlannerInfo * root,
+											   RelOptInfo * rel);
+static void add_paths_with_pathkeys_for_rel(PlannerInfo * root, RelOptInfo * rel,
+											Path * epq_path);
+static void add_foreign_grouping_paths(PlannerInfo * root,
+									   RelOptInfo * input_rel,
+									   RelOptInfo * grouped_rel,
+									   GroupPathExtraData * extra);
+static void add_foreign_ordered_paths(PlannerInfo * root, RelOptInfo * input_rel,
+									  RelOptInfo * ordered_rel);
+static void add_foreign_final_paths(PlannerInfo * root, RelOptInfo * input_rel,
+									RelOptInfo * final_rel,
+									void *fextra);
+static void merge_fdw_options(CHFdwRelationInfo * fpinfo,
+							  const CHFdwRelationInfo * fpinfo_o,
+							  const CHFdwRelationInfo * fpinfo_i);
 
 /* empty _PG_init_ function */
-void _PG_init(void){}
+void
+_PG_init(void)
+{
+}
 
 
 /* Make one query and close the connection */
 Datum
 clickhouse_raw_query(PG_FUNCTION_ARGS)
 {
-	char *connstring = text_to_cstring(PG_GETARG_TEXT_P(1)),
-		 *query = text_to_cstring(PG_GETARG_TEXT_P(0));
+	char	   *connstring = text_to_cstring(PG_GETARG_TEXT_P(1)),
+			   *query = text_to_cstring(PG_GETARG_TEXT_P(0));
 
 	ch_connection_details *details = connstring_parse(connstring);
-	ch_connection	conn = chfdw_http_connect(details);
-	ch_cursor	   *cursor = conn.methods->simple_query(conn.conn, query);
-	text		   *res = chfdw_http_fetch_raw_data(cursor);
+	ch_connection conn = chfdw_http_connect(details);
+	ch_cursor  *cursor = conn.methods->simple_query(conn.conn, query);
+	text	   *res = chfdw_http_fetch_raw_data(cursor);
 
 	MemoryContextDelete(cursor->memcxt);
 	conn.methods->disconnect(conn.conn);
@@ -304,13 +307,13 @@ clickhouse_raw_query(PG_FUNCTION_ARGS)
 	PG_RETURN_NULL();
 }
 
-//calculate difference
+/* calculate difference */
 double
-time_diff(struct timeval * prior, struct timeval * latter)
+time_diff(struct timeval *prior, struct timeval *latter)
 {
-	double x =
-		(double)(latter->tv_usec - prior->tv_usec) / 1000.0L +
-		(double)(latter->tv_sec - prior->tv_sec) * 1000.0L;
+	double		x =
+		(double) (latter->tv_usec - prior->tv_usec) / 1000.0L +
+		(double) (latter->tv_sec - prior->tv_sec) * 1000.0L;
 
 	return x;
 }
@@ -323,15 +326,15 @@ time_diff(struct timeval * prior, struct timeval * latter)
  * not any join clauses.
  */
 static void
-clickhouseGetForeignRelSize(PlannerInfo *root,
-                            RelOptInfo *baserel,
-                            Oid foreigntableid)
+clickhouseGetForeignRelSize(PlannerInfo * root,
+							RelOptInfo * baserel,
+							Oid foreigntableid)
 {
 	CHFdwRelationInfo *fpinfo;
 	ListCell   *lc;
 	RangeTblEntry *rte = planner_rt_fetch(baserel->relid, root);
-	char *relname,
-		 *refname;
+	char	   *relname,
+			   *refname;
 
 	/*
 	 * We use CHFdwRelationInfo to pass various information to subsequent
@@ -348,7 +351,7 @@ clickhouseGetForeignRelSize(PlannerInfo *root,
 	fpinfo->server = GetForeignServer(fpinfo->table->serverid);
 
 	/*
-	 * Extract user-settable option values.  Note that per-table setting of
+	 * Extract user-settable option values. Note that per-table setting of
 	 * use_remote_estimate overrides per-server setting.
 	 */
 	fpinfo->fdw_startup_cost = DEFAULT_FDW_STARTUP_COST;
@@ -364,37 +367,37 @@ clickhouseGetForeignRelSize(PlannerInfo *root,
 	 * server and which can't.
 	 */
 	chfdw_classify_conditions(root, baserel, baserel->baserestrictinfo,
-	                   &fpinfo->remote_conds, &fpinfo->local_conds);
+							  &fpinfo->remote_conds, &fpinfo->local_conds);
 
 	/*
 	 * Identify which attributes will need to be retrieved from the remote
-	 * server.  These include all attrs needed for joins or final output, plus
-	 * all attrs used in the local_conds.  (Note: if we end up using a
+	 * server. These include all attrs needed for joins or final output, plus
+	 * all attrs used in the local_conds. (Note: if we end up using a
 	 * parameterized scan, it's possible that some of the join clauses will be
 	 * sent to the remote and thus we wouldn't really need to retrieve the
-	 * columns used in them.  Doesn't seem worth detecting that case though.)
+	 * columns used in them. Doesn't seem worth detecting that case though.)
 	 */
 	fpinfo->attrs_used = NULL;
 	pull_varattnos((Node *) baserel->reltarget->exprs, baserel->relid,
-	               &fpinfo->attrs_used);
-	foreach (lc, fpinfo->local_conds)
+				   &fpinfo->attrs_used);
+	foreach(lc, fpinfo->local_conds)
 	{
 		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
 
 		pull_varattnos((Node *) rinfo->clause, baserel->relid,
-		               &fpinfo->attrs_used);
+					   &fpinfo->attrs_used);
 	}
 
 	/*
 	 * Compute the selectivity and cost of the local_conds, so we don't have
-	 * to do it over again for each path.  The best we can do for these
+	 * to do it over again for each path. The best we can do for these
 	 * conditions is to estimate selectivity on the basis of local statistics.
 	 */
 	fpinfo->local_conds_sel = clauselist_selectivity(root,
-	                          fpinfo->local_conds,
-	                          baserel->relid,
-	                          JOIN_INNER,
-	                          NULL);
+													 fpinfo->local_conds,
+													 baserel->relid,
+													 JOIN_INNER,
+													 NULL);
 
 	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
 
@@ -418,7 +421,7 @@ clickhouseGetForeignRelSize(PlannerInfo *root,
 	appendStringInfo(fpinfo->relation_name, "%s", quote_identifier(relname));
 	if (*refname && strcmp(refname, relname) != 0)
 		appendStringInfo(fpinfo->relation_name, " %s",
-		                 quote_identifier(rte->eref->aliasname));
+						 quote_identifier(rte->eref->aliasname));
 
 	/* No outer and inner relations. */
 	fpinfo->make_outerrel_subquery = false;
@@ -434,11 +437,11 @@ clickhouseGetForeignRelSize(PlannerInfo *root,
  *
  * Getting data in sorted order can be useful either because the requested
  * order matches the final output ordering for the overall query we're
- * planning, or because it enables an efficient merge join.  Here, we try
+ * planning, or because it enables an efficient merge join. Here, we try
  * to figure out which pathkeys to consider.
  */
 static List *
-get_useful_pathkeys_for_relation(PlannerInfo *root, RelOptInfo *rel)
+get_useful_pathkeys_for_relation(PlannerInfo * root, RelOptInfo * rel)
 {
 	List	   *useful_pathkeys_list = NIL;
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) rel->fdw_private;
@@ -463,11 +466,11 @@ get_useful_pathkeys_for_relation(PlannerInfo *root, RelOptInfo *rel)
 			 * The planner and executor don't have any clever strategy for
 			 * taking data sorted by a prefix of the query's pathkeys and
 			 * getting it to be sorted by all of those pathkeys. We'll just
-			 * end up resorting the entire data set.  So, unless we can push
+			 * end up resorting the entire data set. So, unless we can push
 			 * down all of the query pathkeys, forget it.
 			 *
-			 * chfdw_is_foreign_expr would detect volatile expressions as well, but
-			 * checking ec_has_volatile here saves some cycles.
+			 * chfdw_is_foreign_expr would detect volatile expressions as
+			 * well, but checking ec_has_volatile here saves some cycles.
 			 */
 			if (pathkey_ec->ec_has_volatile ||
 				!(em_expr = chfdw_find_em_expr_for_rel(pathkey_ec, rel)) ||
@@ -493,22 +496,22 @@ get_useful_pathkeys_for_relation(PlannerInfo *root, RelOptInfo *rel)
  *		Create possible scan paths for a scan on the foreign table
  */
 static void
-clickhouseGetForeignPaths(PlannerInfo *root,
-                          RelOptInfo *baserel,
-                          Oid foreigntableid)
+clickhouseGetForeignPaths(PlannerInfo * root,
+						  RelOptInfo * baserel,
+						  Oid foreigntableid)
 {
-	ForeignPath			*path;
-	CHFdwRelationInfo	*fpinfo = (CHFdwRelationInfo *) baserel->fdw_private;
+	ForeignPath *path;
+	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) baserel->fdw_private;
 
 	path = create_foreignscan_path(root, baserel, NULL,
-		fpinfo->rows,
+								   fpinfo->rows,
 #if PG_VERSION_NUM >= 180000
-		0,
+								   0,
 #endif
-		fpinfo->startup_cost, fpinfo->total_cost,
-		NULL, NULL, NULL, NIL
+								   fpinfo->startup_cost, fpinfo->total_cost,
+								   NULL, NULL, NULL, NIL
 #if PG_VERSION_NUM >= 170000
-		, NIL
+								   ,NIL
 #endif
 		);
 
@@ -521,13 +524,13 @@ clickhouseGetForeignPaths(PlannerInfo *root,
  *		Create ForeignScan plan node which implements selected best path
  */
 static ForeignScan *
-clickhouseGetForeignPlan(PlannerInfo *root,
-                         RelOptInfo *foreignrel,
-                         Oid foreigntableid,
-                         ForeignPath *best_path,
-                         List *tlist,
-                         List *scan_clauses,
-                         Plan *outer_plan)
+clickhouseGetForeignPlan(PlannerInfo * root,
+						 RelOptInfo * foreignrel,
+						 Oid foreigntableid,
+						 ForeignPath * best_path,
+						 List * tlist,
+						 List * scan_clauses,
+						 Plan * outer_plan)
 {
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) foreignrel->fdw_private;
 	Index		scan_relid;
@@ -542,12 +545,14 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 	bool		has_final_sort = false;
 	bool		has_limit = false;
 	ListCell   *lc;
-	struct timeval time1,time2;
+	struct timeval time1,
+				time2;
 
 	gettimeofday(&time1, NULL);
 
 	/*
-	 * Get FDW private data created by clickhouseGetForeignUpperPaths(), if any.
+	 * Get FDW private data created by clickhouseGetForeignUpperPaths(), if
+	 * any.
 	 */
 	if (best_path->fdw_private)
 	{
@@ -568,14 +573,14 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 		 * In a base-relation scan, we must apply the given scan_clauses.
 		 *
 		 * Separate the scan_clauses into those that can be executed remotely
-		 * and those that can't.  baserestrictinfo clauses that were
-		 * previously determined to be safe or unsafe by chfdw_classify_conditions
-		 * are found in fpinfo->remote_conds and fpinfo->local_conds. Anything
+		 * and those that can't. baserestrictinfo clauses that were previously
+		 * determined to be safe or unsafe by chfdw_classify_conditions are
+		 * found in fpinfo->remote_conds and fpinfo->local_conds. Anything
 		 * else in the scan_clauses list will be a join clause, which we have
 		 * to check for remote-safety.
 		 *
 		 * Note: the join clauses we see here should be the exact same ones
-		 * previously examined by postgresGetForeignPaths.  Possibly it'd be
+		 * previously examined by postgresGetForeignPaths. Possibly it'd be
 		 * worth passing forward the classification work done then, rather
 		 * than repeating it here.
 		 *
@@ -630,9 +635,9 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 
 		/*
 		 * We leave fdw_recheck_quals empty in this case, since we never need
-		 * to apply EPQ recheck clauses.  In the case of a joinrel, EPQ
-		 * recheck is handled elsewhere --- see clickhouseGetForeignJoinPaths().
-		 * If we're planning an upperrel (ie, remote grouping or aggregation)
+		 * to apply EPQ recheck clauses. In the case of a joinrel, EPQ recheck
+		 * is handled elsewhere --- see clickhouseGetForeignJoinPaths(). If
+		 * we're planning an upperrel (ie, remote grouping or aggregation)
 		 * then there's no EPQ to do because SELECT FOR UPDATE wouldn't be
 		 * allowed, and indeed we *can't* put the remote clauses into
 		 * fdw_recheck_quals because the unaggregated Vars won't be available
@@ -663,7 +668,7 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 
 			outer_plan->targetlist = fdw_scan_tlist;
 
-			foreach (outer_lc, local_exprs)
+			foreach(outer_lc, local_exprs)
 			{
 				Join	   *join_plan = (Join *) outer_plan;
 				Node	   *qual = lfirst(outer_lc);
@@ -676,7 +681,7 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 				 */
 				if (join_plan->jointype == JOIN_INNER)
 					join_plan->joinqual = list_delete(join_plan->joinqual,
-					                                  qual);
+													  qual);
 			}
 		}
 	}
@@ -687,9 +692,9 @@ clickhouseGetForeignPlan(PlannerInfo *root,
 	 */
 	initStringInfo(&sql);
 	chfdw_deparse_select_stmt_for_rel(&sql, root, foreignrel, fdw_scan_tlist,
-	                        remote_exprs, best_path->path.pathkeys,
-							has_final_sort, has_limit, false,
-							&retrieved_attrs, &params_list);
+									  remote_exprs, best_path->path.pathkeys,
+									  has_final_sort, has_limit, false,
+									  &retrieved_attrs, &params_list);
 
 	/* Remember remote_exprs for possible use by postgresPlanDirectModify */
 	fpinfo->final_remote_exprs = remote_exprs;
@@ -730,7 +735,7 @@ clickhouseGetForeignPlan(PlannerInfo *root,
  *		Initiate an executor scan of a foreign PostgreSQL table.
  */
 static void
-clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
+clickhouseBeginForeignScan(ForeignScanState * node, int eflags)
 {
 	ForeignScan *fsplan = (ForeignScan *) node->ss.ps.plan;
 	EState	   *estate = node->ss.ps.state;
@@ -743,7 +748,7 @@ clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
 	int			numParams;
 
 	/*
-	 * Do nothing in EXPLAIN (no ANALYZE) case.  node->fdw_state stays NULL.
+	 * Do nothing in EXPLAIN (no ANALYZE) case. node->fdw_state stays NULL.
 	 */
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
 		return;
@@ -755,8 +760,8 @@ clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
 	node->fdw_state = (void *) fsstate;
 
 	/*
-	 * Identify which user to do the remote access as.  This should match what
-	 * ExecCheckRTEPerms() does.  In case of a join or aggregate, use the
+	 * Identify which user to do the remote access as. This should match what
+	 * ExecCheckRTEPerms() does. In case of a join or aggregate, use the
 	 * lowest-numbered member RTE as a representative; we would get the same
 	 * result from any.
 	 */
@@ -776,8 +781,8 @@ clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
 	user = GetUserMapping(userid, table->serverid);
 
 	/*
-	 * Get connection to the foreign server.  Connection manager will
-	 * establish new connection if necessary.
+	 * Get connection to the foreign server. Connection manager will establish
+	 * new connection if necessary.
 	 */
 	fsstate->conn = chfdw_get_connection(user);
 
@@ -791,11 +796,11 @@ clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
 
 	/* Create contexts for batches of tuples and per-tuple temp workspace. */
 	fsstate->batch_cxt = AllocSetContextCreate(estate->es_query_cxt,
-	                     "pg_clickhouse tuple data",
-	                     ALLOCSET_DEFAULT_SIZES);
+											   "pg_clickhouse tuple data",
+											   ALLOCSET_DEFAULT_SIZES);
 	fsstate->temp_cxt = AllocSetContextCreate(estate->es_query_cxt,
-	                    "pg_clickhouse temporary data",
-	                    ALLOCSET_SMALL_SIZES);
+											  "pg_clickhouse temporary data",
+											  ALLOCSET_SMALL_SIZES);
 
 	/*
 	 * Get info we'll need for converting data fetched from the foreign server
@@ -837,7 +842,7 @@ clickhouseBeginForeignScan(ForeignScanState *node, int eflags)
  * temp_context is a working context that can be reset after each tuple.
  */
 static HeapTuple
-fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
+fetch_tuple(ChFdwScanState * fsstate, TupleDesc tupdesc)
 {
 	AttInMetadata *attinmeta = fsstate->attinmeta;
 	Datum	   *values;
@@ -847,7 +852,7 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 	MemoryContext oldcontext;
 	bool	   *nulls;
 	int			j;
-	void      **row_values;
+	void	  **row_values;
 
 	oldcontext = MemoryContextSwitchTo(fsstate->temp_cxt);
 
@@ -858,7 +863,7 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 	memset(nulls, true, tupdesc->natts * sizeof(bool));
 
 	row_values = fsstate->conn.methods->fetch_row(fsstate->ch_cursor,
-		fsstate->retrieved_attrs, tupdesc, values, nulls);
+												  fsstate->retrieved_attrs, tupdesc, values, nulls);
 
 	/* in both cases (binary and non binary), NULL means end of tuples */
 	if (row_values == NULL)
@@ -874,16 +879,19 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 		j = 0;
 		foreach(lc, fsstate->retrieved_attrs)
 		{
-			int		i = lfirst_int(lc);
-			char   *valstr = (char *) row_values[j];
+			int			i = lfirst_int(lc);
+			char	   *valstr = (char *) row_values[j];
 
-			Oid pgtype = TupleDescAttr(tupdesc, i - 1)->atttypid;
-			bool is_array = type_is_array_domain(pgtype);
+			Oid			pgtype = TupleDescAttr(tupdesc, i - 1)->atttypid;
+			bool		is_array = type_is_array_domain(pgtype);
 
-			/* that's the easy way to check array, otherwise use get_element_type on pgtype */
+			/*
+			 * that's the easy way to check array, otherwise use
+			 * get_element_type on pgtype
+			 */
 			if (valstr && is_array && valstr[0] == '[')
 			{
-				size_t	pos = 0;
+				size_t		pos = 0;
 
 				while (valstr[pos] != '\0')
 				{
@@ -895,17 +903,19 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 				}
 			}
 			else if (valstr && valstr[0] == '0' && valstr[1] == '0')
-            {
-                /* clickhouse supports such values which are invalid in postgres,
-                 * so we just set set as NULL
-                 */
-                if (strcmp(valstr, "0000-00-00 00:00:00") == 0)
-                    valstr = NULL;
-            }
-			else if (valstr && pgtype == VARCHAROID
-					&& TupleDescAttr(tupdesc, i - 1)->atttypmod != 0)
 			{
-				char *pos;
+				/*
+				 * clickhouse supports such values which are invalid in
+				 * postgres, so we just set set as NULL
+				 */
+				if (strcmp(valstr, "0000-00-00 00:00:00") == 0)
+					valstr = NULL;
+			}
+			else if (valstr && pgtype == VARCHAROID
+					 && TupleDescAttr(tupdesc, i - 1)->atttypmod != 0)
+			{
+				char	   *pos;
+
 				if ((pos = strstr(valstr, "\\0")) != NULL)
 					pos[0] = '\0';
 			}
@@ -913,9 +923,9 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 			/* Apply the input function even to nulls, to support domains */
 			nulls[i - 1] = (valstr == NULL);
 			values[i - 1] = InputFunctionCall(&attinmeta->attinfuncs[i - 1],
-										  valstr,
-										  attinmeta->attioparams[i - 1],
-										  attinmeta->atttypmods[i - 1]);
+											  valstr,
+											  attinmeta->attioparams[i - 1],
+											  attinmeta->atttypmods[i - 1]);
 			j++;
 		}
 	}
@@ -935,10 +945,10 @@ fetch_tuple(ChFdwScanState *fsstate, TupleDesc tupdesc)
 
 	/*
 	 * Stomp on the xmin, xmax, and cmin fields from the tuple created by
-	 * heap_form_tuple.  heap_form_tuple actually creates the tuple with
+	 * heap_form_tuple. heap_form_tuple actually creates the tuple with
 	 * DatumTupleFields, not HeapTupleFields, but the executor expects
 	 * HeapTupleFields and will happily extract system columns on that
-	 * assumption.  If we don't do this then, for example, the tuple length
+	 * assumption. If we don't do this then, for example, the tuple length
 	 * ends up in the xmin field, which isn't what we want.
 	 */
 	HeapTupleHeaderSetXmax(tuple->t_data, InvalidTransactionId);
@@ -956,20 +966,22 @@ cleanup:
  *		EOF.
  */
 static TupleTableSlot *
-clickhouseIterateForeignScan(ForeignScanState *node)
+clickhouseIterateForeignScan(ForeignScanState * node)
 {
-	HeapTuple		tup;
+	HeapTuple	tup;
 	ChFdwScanState *fsstate = (ChFdwScanState *) node->fdw_state;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
-	struct timeval time1,time2;
-	TupleDesc		tupdesc;
+	struct timeval time1,
+				time2;
+	TupleDesc	tupdesc;
 
 	/* make query if needed */
 	if (fsstate->ch_cursor == NULL)
 	{
-		MemoryContext	old = MemoryContextSwitchTo(fsstate->batch_cxt);
+		MemoryContext old = MemoryContextSwitchTo(fsstate->batch_cxt);
+
 		fsstate->ch_cursor = fsstate->conn.methods->simple_query(fsstate->conn.conn,
-				fsstate->query);
+																 fsstate->query);
 
 		time_used += fsstate->ch_cursor->request_time;
 		MemoryContextSwitchTo(old);
@@ -1003,7 +1015,7 @@ clickhouseIterateForeignScan(ForeignScanState *node)
  *		Finish scanning foreign table and dispose objects used for this scan
  */
 static void
-clickhouseEndForeignScan(ForeignScanState *node)
+clickhouseEndForeignScan(ForeignScanState * node)
 {
 	ChFdwScanState *fsstate = (ChFdwScanState *) node->fdw_state;
 
@@ -1020,10 +1032,10 @@ clickhouseEndForeignScan(ForeignScanState *node)
  *		Plan an insert operation on a foreign table
  */
 static List *
-clickhousePlanForeignModify(PlannerInfo *root,
-                            ModifyTable *plan,
-                            Index resultRelation,
-                            int subplan_index)
+clickhousePlanForeignModify(PlannerInfo * root,
+							ModifyTable * plan,
+							Index resultRelation,
+							int subplan_index)
 {
 	CmdType		operation = plan->operation;
 	RangeTblEntry *rte = planner_rt_fetch(resultRelation, root);
@@ -1055,23 +1067,27 @@ clickhousePlanForeignModify(PlannerInfo *root,
 	/*
 	 * Construct the SQL command string.
 	 */
-	char *table_name;
+	char	   *table_name;
 
 	switch (operation)
 	{
-	case CMD_INSERT:
-		// Write start of INSERT statement to &sql: INSERT INTO table (col list)
-		table_name = chfdw_deparse_insert_sql(&sql, rte, resultRelation, rel, targetAttrs);
-		break;
-	case CMD_UPDATE:
-		elog(ERROR, "ClickHouse does not support updates");
-		break;
-	case CMD_DELETE:
-		elog(ERROR, "ClickHouse does not support deletes");
-		break;
-	default:
-		elog(ERROR, "unexpected operation: %d", (int) operation);
-		break;
+		case CMD_INSERT:
+
+			/*
+			 * Write start of INSERT statement to & sql:INSERT INTO table(col
+			 * list)
+			 */
+			table_name = chfdw_deparse_insert_sql(&sql, rte, resultRelation, rel, targetAttrs);
+			break;
+		case CMD_UPDATE:
+			elog(ERROR, "ClickHouse does not support updates");
+			break;
+		case CMD_DELETE:
+			elog(ERROR, "ClickHouse does not support deletes");
+			break;
+		default:
+			elog(ERROR, "unexpected operation: %d", (int) operation);
+			break;
 	}
 
 	table_close_compat(rel, NoLock);
@@ -1089,11 +1105,11 @@ clickhousePlanForeignModify(PlannerInfo *root,
  *		Begin an insertoperation on a foreign table
  */
 static void
-clickhouseBeginForeignModify(ModifyTableState *mtstate,
-                             ResultRelInfo *resultRelInfo,
-                             List *fdw_private,
-                             int subplan_index,
-                             int eflags)
+clickhouseBeginForeignModify(ModifyTableState * mtstate,
+							 ResultRelInfo * resultRelInfo,
+							 List * fdw_private,
+							 int subplan_index,
+							 int eflags)
 {
 	CHFdwModifyState *fmstate;
 	char	   *query;
@@ -1102,7 +1118,7 @@ clickhouseBeginForeignModify(ModifyTableState *mtstate,
 	char	   *table_name;
 
 	/*
-	 * Do nothing in EXPLAIN (no ANALYZE) case.  resultRelInfo->ri_FdwState
+	 * Do nothing in EXPLAIN (no ANALYZE) case. resultRelInfo->ri_FdwState
 	 * stays NULL.
 	 */
 	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
@@ -1115,20 +1131,20 @@ clickhouseBeginForeignModify(ModifyTableState *mtstate,
 
 	/* Find RTE. */
 	rte = rt_fetch(resultRelInfo->ri_RangeTableIndex,
-	               mtstate->ps.state->es_range_table);
+				   mtstate->ps.state->es_range_table);
 
 	/* Construct an execution state. */
 	fmstate = create_foreign_modify(mtstate->ps.state,
-	                                rte,
-	                                resultRelInfo,
-	                                mtstate->operation,
+									rte,
+									resultRelInfo,
+									mtstate->operation,
 #if PG_VERSION_NUM < 140000
-	                                mtstate->mt_plans[subplan_index]->plan,
+									mtstate->mt_plans[subplan_index]->plan,
 #else
-	                                outerPlanState(mtstate)->plan,
+									outerPlanState(mtstate)->plan,
 #endif
-	                                query,
-	                                target_attrs,
+									query,
+									target_attrs,
 									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
@@ -1137,8 +1153,8 @@ clickhouseBeginForeignModify(ModifyTableState *mtstate,
 ForeignServer *
 chfdw_get_foreign_server(Relation rel)
 {
-	ForeignServer       *server;
-	ForeignTable        *table;
+	ForeignServer *server;
+	ForeignTable *table;
 
 	table = GetForeignTable(RelationGetRelid(rel));
 	server = GetForeignServer(table->serverid);
@@ -1150,8 +1166,8 @@ chfdw_get_foreign_server(Relation rel)
  *		Begin an insert operation on a foreign table
  */
 static void
-clickhouseBeginForeignInsert(ModifyTableState *mtstate,
-                             ResultRelInfo *resultRelInfo)
+clickhouseBeginForeignInsert(ModifyTableState * mtstate,
+							 ResultRelInfo * resultRelInfo)
 {
 	CHFdwModifyState *fmstate;
 	EState	   *estate = mtstate->ps.state;
@@ -1161,7 +1177,7 @@ clickhouseBeginForeignInsert(ModifyTableState *mtstate,
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	int			attnum;
 	List	   *targetAttrs = NIL;
-	StringInfoData	sql;
+	StringInfoData sql;
 	char	   *table_name;
 
 	/* We transmit all columns that are defined in the foreign table. */
@@ -1195,13 +1211,13 @@ clickhouseBeginForeignInsert(ModifyTableState *mtstate,
 
 	/* Construct an execution state. */
 	fmstate = create_foreign_modify(mtstate->ps.state,
-	                                rte,
-	                                resultRelInfo,
-	                                CMD_INSERT,
-	                                NULL,
-	                                sql.data,
-	                                targetAttrs,
-					table_name);
+									rte,
+									resultRelInfo,
+									CMD_INSERT,
+									NULL,
+									sql.data,
+									targetAttrs,
+									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
 }
@@ -1211,10 +1227,10 @@ clickhouseBeginForeignInsert(ModifyTableState *mtstate,
  *		Put one row to buffer, if buffer is big enough push it to ClickHouse
  */
 static TupleTableSlot *
-clickhouseExecForeignInsert(EState *estate,
-                            ResultRelInfo *resultRelInfo,
-                            TupleTableSlot *slot,
-                            TupleTableSlot *planSlot)
+clickhouseExecForeignInsert(EState * estate,
+							ResultRelInfo * resultRelInfo,
+							TupleTableSlot * slot,
+							TupleTableSlot * planSlot)
 {
 	MemoryContext oldcontext;
 
@@ -1235,8 +1251,8 @@ clickhouseExecForeignInsert(EState *estate,
  *		Finish an insert operation on a foreign table
  */
 static void
-clickhouseEndForeignInsert(EState *estate,
-                           ResultRelInfo *resultRelInfo)
+clickhouseEndForeignInsert(EState * estate,
+						   ResultRelInfo * resultRelInfo)
 {
 	MemoryContext oldcontext;
 
@@ -1260,7 +1276,7 @@ clickhouseEndForeignInsert(EState *estate,
  *		Execute a local join execution plan for a foreign join
  */
 static bool
-clickhouseRecheckForeignScan(ForeignScanState *node, TupleTableSlot *slot)
+clickhouseRecheckForeignScan(ForeignScanState * node, TupleTableSlot * slot)
 {
 	Index		scanrelid = ((Scan *) node->ss.ps.plan)->scanrelid;
 	PlanState  *outerPlan = outerPlanState(node);
@@ -1289,7 +1305,7 @@ clickhouseRecheckForeignScan(ForeignScanState *node, TupleTableSlot *slot)
  *		Produce extra output for EXPLAIN of a ForeignScan on a foreign table
  */
 static void
-clickhouseExplainForeignScan(ForeignScanState *node, ExplainState *es)
+clickhouseExplainForeignScan(ForeignScanState * node, ExplainState * es)
 {
 	List	   *fdw_private;
 	char	   *sql;
@@ -1334,7 +1350,7 @@ clickhouseExplainForeignScan(ForeignScanState *node, ExplainState *es)
  */
 static void
 estimate_path_cost_size(double *p_rows, int *p_width,
-                        Cost *p_startup_cost, Cost *p_total_cost, double coef)
+						Cost * p_startup_cost, Cost * p_total_cost, double coef)
 {
 	*p_rows = 1;
 	*p_width = 1;
@@ -1348,20 +1364,20 @@ estimate_path_cost_size(double *p_rows, int *p_width,
  *		operation
  */
 static CHFdwModifyState *
-create_foreign_modify(EState *estate,
-                      RangeTblEntry *rte,
-                      ResultRelInfo *rri,
-                      CmdType operation,
-                      Plan *subplan,
-                      char *query,
-                      List *target_attrs,
+create_foreign_modify(EState * estate,
+					  RangeTblEntry * rte,
+					  ResultRelInfo * rri,
+					  CmdType operation,
+					  Plan * subplan,
+					  char *query,
+					  List * target_attrs,
 					  char *table_name)
 {
 	CHFdwModifyState *fmstate;
 	Oid			userid;
 	ForeignTable *table;
 	UserMapping *user;
-	MemoryContext	old_mcxt;
+	MemoryContext old_mcxt;
 	Relation	rel = rri->ri_RelationDesc;
 
 	/* Begin constructing CHFdwModifyState. */
@@ -1369,7 +1385,7 @@ create_foreign_modify(EState *estate,
 	fmstate->rel = rel;
 
 	/*
-	 * Identify which user to do the remote access as.  This should match what
+	 * Identify which user to do the remote access as. This should match what
 	 * ExecCheckRTEPerms() does.
 	 */
 #if PG_VERSION_NUM >= 160000
@@ -1387,13 +1403,13 @@ create_foreign_modify(EState *estate,
 
 	old_mcxt = MemoryContextSwitchTo(PortalContext);
 	fmstate->state = fmstate->conn.methods->prepare_insert(fmstate->conn.conn,
-			rri, target_attrs, query, table_name);
+														   rri, target_attrs, query, table_name);
 	MemoryContextSwitchTo(old_mcxt);
 
 	/* Create context for per-query temp workspace. */
 	fmstate->temp_cxt = AllocSetContextCreate(estate->es_query_cxt,
-	                    "pg_clickhouse temporary data",
-	                    ALLOCSET_SMALL_SIZES);
+											  "pg_clickhouse temporary data",
+											  ALLOCSET_SMALL_SIZES);
 
 	/* Set up remote query information. */
 	fmstate->query = query;
@@ -1405,7 +1421,7 @@ create_foreign_modify(EState *estate,
  *		Release resources for a foreign insert/delete operation
  */
 static void
-finish_foreign_modify(CHFdwModifyState *fmstate)
+finish_foreign_modify(CHFdwModifyState * fmstate)
 {
 	Assert(fmstate != NULL);
 	memset(&fmstate->conn, 0, sizeof(fmstate->conn));
@@ -1415,12 +1431,12 @@ finish_foreign_modify(CHFdwModifyState *fmstate)
  * Prepare for processing of parameters used in remote query.
  */
 static void
-prepare_query_params(PlanState *node,
-                     List *fdw_exprs,
-                     int numParams,
-                     FmgrInfo **param_flinfo,
-                     List **param_exprs,
-                     const char ***param_values)
+prepare_query_params(PlanState * node,
+					 List * fdw_exprs,
+					 int numParams,
+					 FmgrInfo * *param_flinfo,
+					 List * *param_exprs,
+					 const char ***param_values)
 {
 	int			i;
 	ListCell   *lc;
@@ -1431,7 +1447,7 @@ prepare_query_params(PlanState *node,
 	*param_flinfo = (FmgrInfo *) palloc0(sizeof(FmgrInfo) * numParams);
 
 	i = 0;
-	foreach (lc, fdw_exprs)
+	foreach(lc, fdw_exprs)
 	{
 		Node	   *param_expr = (Node *) lfirst(lc);
 		Oid			typefnoid;
@@ -1443,10 +1459,10 @@ prepare_query_params(PlanState *node,
 	}
 
 	/*
-	 * Prepare remote-parameter expressions for evaluation.  (Note: in
+	 * Prepare remote-parameter expressions for evaluation. (Note: in
 	 * practice, we expect that all these expressions will be just Params, so
 	 * we could possibly do something more efficient than using the full
-	 * expression-eval machinery for this.  But probably there would be little
+	 * expression-eval machinery for this. But probably there would be little
 	 * benefit, and it'd require postgres_fdw to know more than is desirable
 	 * about Param evaluation.)
 	 */
@@ -1462,8 +1478,8 @@ prepare_query_params(PlanState *node,
  */
 static bool
 clickhouseAnalyzeForeignTable(Relation relation,
-                              AcquireSampleRowsFunc *func,
-                              BlockNumber *totalpages)
+							  AcquireSampleRowsFunc * func,
+							  BlockNumber * totalpages)
 {
 	*func = clickhouseAcquireSampleRowsFunc;
 	return true;
@@ -1478,24 +1494,24 @@ clickhouseAnalyzeForeignTable(Relation relation,
  * which must have at least targrows entries.
  * The actual number of rows selected is returned as the function result.
  * We also count the total number of rows in the table and return it into
- * *totalrows.  Note that *totaldeadrows is always set to 0.
+ * *totalrows. Note that *totaldeadrows is always set to 0.
  *
  * Note that the returned list of rows is not always in order by physical
- * position in the table.  Therefore, correlation estimates derived later
+ * position in the table. Therefore, correlation estimates derived later
  * may be meaningless, but it's OK because we don't use the estimates
  * currently (the planner only pays attention to correlation for indexscans).
  */
 static int
 clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
-                                HeapTuple *rows, int targrows,
-                                double *totalrows,
-                                double *totaldeadrows)
+								HeapTuple * rows, int targrows,
+								double *totalrows,
+								double *totaldeadrows)
 {
 	return 0;
 }
 
 static bool
-is_simple_join_clause(Expr *expr)
+is_simple_join_clause(Expr * expr)
 {
 	if (IsA(expr, RestrictInfo))
 	{
@@ -1504,24 +1520,27 @@ is_simple_join_clause(Expr *expr)
 
 	if (IsA(expr, OpExpr))
 	{
-		OpExpr	*opexpr = (OpExpr *) expr;
+		OpExpr	   *opexpr = (OpExpr *) expr;
+
 		if (chfdw_is_equal_op(opexpr->opno) == 1
-				&& list_length(opexpr->args) == 2
-				&& IsA(list_nth(opexpr->args, 0), Var)
-				&& IsA(list_nth(opexpr->args, 1), Var))
+			&& list_length(opexpr->args) == 2
+			&& IsA(list_nth(opexpr->args, 0), Var)
+			&& IsA(list_nth(opexpr->args, 1), Var))
 			return true;
 	}
 	return false;
 }
 
 static List *
-extract_join_equals(List *conds, List **to)
+extract_join_equals(List * conds, List * *to)
 {
-	ListCell *lc;
-	List *res = NIL;
-	foreach (lc, conds)
+	ListCell   *lc;
+	List	   *res = NIL;
+
+	foreach(lc, conds)
 	{
 		Expr	   *expr = (Expr *) lfirst(lc);
+
 		if (is_simple_join_clause(expr))
 			*to = lappend(*to, expr);
 		else
@@ -1536,9 +1555,9 @@ extract_join_equals(List *conds, List **to)
  * function to CHFdwRelationInfo passed in.
  */
 static bool
-foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
-                RelOptInfo *outerrel, RelOptInfo *innerrel,
-                JoinPathExtraData *extra)
+foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel, JoinType jointype,
+				RelOptInfo * outerrel, RelOptInfo * innerrel,
+				JoinPathExtraData * extra)
 {
 	CHFdwRelationInfo *fpinfo;
 	CHFdwRelationInfo *fpinfo_o;
@@ -1552,7 +1571,7 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	 * not considered right now.
 	 */
 	if (jointype != JOIN_INNER && jointype != JOIN_LEFT &&
-	        jointype != JOIN_RIGHT && jointype != JOIN_FULL)
+		jointype != JOIN_RIGHT && jointype != JOIN_FULL)
 	{
 		return false;
 	}
@@ -1565,7 +1584,7 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	fpinfo_o = (CHFdwRelationInfo *) outerrel->fdw_private;
 	fpinfo_i = (CHFdwRelationInfo *) innerrel->fdw_private;
 	if (!fpinfo_o || !fpinfo_o->pushdown_safe ||
-	        !fpinfo_i || !fpinfo_i->pushdown_safe)
+		!fpinfo_i || !fpinfo_i->pushdown_safe)
 	{
 		return false;
 	}
@@ -1581,8 +1600,8 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	}
 
 	/*
-	 * Merge FDW options.  We might be tempted to do this after we have deemed
-	 * the foreign join to be OK.  But we must do this beforehand so that we
+	 * Merge FDW options. We might be tempted to do this after we have deemed
+	 * the foreign join to be OK. But we must do this beforehand so that we
 	 * know which quals can be evaluated on the foreign server, which might
 	 * depend on shippable_extensions.
 	 */
@@ -1593,15 +1612,15 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	 * Separate restrict list into join quals and pushed-down (other) quals.
 	 *
 	 * Join quals belonging to an outer join must all be shippable, else we
-	 * cannot execute the join remotely.  Add such quals to 'joinclauses'.
+	 * cannot execute the join remotely. Add such quals to 'joinclauses'.
 	 *
 	 * Add other quals to fpinfo->remote_conds if they are shippable, else to
-	 * fpinfo->local_conds.  In an inner join it's okay to execute conditions
+	 * fpinfo->local_conds. In an inner join it's okay to execute conditions
 	 * either locally or remotely; the same is true for pushed-down conditions
 	 * at an outer join.
 	 *
 	 * Note we might return failure after having already scribbled on
-	 * fpinfo->remote_conds and fpinfo->local_conds.  That's okay because we
+	 * fpinfo->remote_conds and fpinfo->local_conds. That's okay because we
 	 * won't consult those lists again if we deem the join unshippable.
 	 */
 	joinclauses = NIL;
@@ -1609,7 +1628,7 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	{
 		RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
 		bool		is_remote_clause = chfdw_is_foreign_expr(root, joinrel,
-													   rinfo->clause);
+															 rinfo->clause);
 
 		if (IS_OUTER_JOIN(jointype) &&
 			!RINFO_IS_PUSHED_DOWN(rinfo, joinrel->relids))
@@ -1629,25 +1648,25 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 
 	/*
 	 * deparseExplicitTargetList() isn't smart enough to handle anything other
-	 * than a Var.  In particular, if there's some PlaceHolderVar that would
+	 * than a Var. In particular, if there's some PlaceHolderVar that would
 	 * need to be evaluated within this join tree (because there's an upper
 	 * reference to a quantity that may go to NULL as a result of an outer
 	 * join), then we can't try to push the join down because we'll fail when
-	 * we get to deparseExplicitTargetList().  However, a PlaceHolderVar that
+	 * we get to deparseExplicitTargetList(). However, a PlaceHolderVar that
 	 * needs to be evaluated *at the top* of this join tree is OK, because we
 	 * can do that locally after fetching the results from the remote side.
 	 */
-	foreach (lc, root->placeholder_list)
+	foreach(lc, root->placeholder_list)
 	{
 		PlaceHolderInfo *phinfo = lfirst(lc);
 		Relids		relids;
 
 		/* PlaceHolderInfo refers to parent relids, not child relids. */
 		relids = IS_OTHER_REL(joinrel) ?
-		         joinrel->top_parent_relids : joinrel->relids;
+			joinrel->top_parent_relids : joinrel->relids;
 
 		if (bms_is_subset(phinfo->ph_eval_at, relids) &&
-		        bms_nonempty_difference(relids, phinfo->ph_eval_at))
+			bms_nonempty_difference(relids, phinfo->ph_eval_at))
 		{
 			return false;
 		}
@@ -1671,7 +1690,7 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	Assert(bms_is_subset(fpinfo_o->lower_subquery_rels, outerrel->relids));
 	Assert(bms_is_subset(fpinfo_i->lower_subquery_rels, innerrel->relids));
 	fpinfo->lower_subquery_rels = bms_union(fpinfo_o->lower_subquery_rels,
-	                                        fpinfo_i->lower_subquery_rels);
+											fpinfo_i->lower_subquery_rels);
 
 	/*
 	 * Pull the other remote conditions from the joining relations into join
@@ -1694,65 +1713,66 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 	 */
 	switch (jointype)
 	{
-	case JOIN_INNER:
-		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
-		                                   list_copy(fpinfo_i->remote_conds));
-		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
-		                                   list_copy(fpinfo_o->remote_conds));
+		case JOIN_INNER:
+			fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+											   list_copy(fpinfo_i->remote_conds));
+			fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+											   list_copy(fpinfo_o->remote_conds));
 
-		/*
-		 * For an inner join, some restrictions can be treated alike. Treating the
-		 * pushed down conditions as join conditions allows a top level full outer
-		 * join to be deparsed without requiring subqueries.
-		 */
-		Assert(!fpinfo->joinclauses);
-		fpinfo->remote_conds = extract_join_equals(fpinfo->remote_conds,
-										&fpinfo->joinclauses);
-		break;
+			/*
+			 * For an inner join, some restrictions can be treated alike.
+			 * Treating the pushed down conditions as join conditions allows a
+			 * top level full outer join to be deparsed without requiring
+			 * subqueries.
+			 */
+			Assert(!fpinfo->joinclauses);
+			fpinfo->remote_conds = extract_join_equals(fpinfo->remote_conds,
+													   &fpinfo->joinclauses);
+			break;
 
-	case JOIN_LEFT:
-		fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
-		                                  list_copy(fpinfo_i->remote_conds));
-		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
-		                                   list_copy(fpinfo_o->remote_conds));
-		break;
+		case JOIN_LEFT:
+			fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
+											  list_copy(fpinfo_i->remote_conds));
+			fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+											   list_copy(fpinfo_o->remote_conds));
+			break;
 
-	case JOIN_RIGHT:
-		fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
-		                                  list_copy(fpinfo_o->remote_conds));
-		fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
-		                                   list_copy(fpinfo_i->remote_conds));
-		break;
+		case JOIN_RIGHT:
+			fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
+											  list_copy(fpinfo_o->remote_conds));
+			fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+											   list_copy(fpinfo_i->remote_conds));
+			break;
 
-	case JOIN_FULL:
+		case JOIN_FULL:
 
-		/*
-		 * In this case, if any of the input relations has conditions, we
-		 * need to deparse that relation as a subquery so that the
-		 * conditions can be evaluated before the join.  Remember it in
-		 * the fpinfo of this relation so that the deparser can take
-		 * appropriate action.  Also, save the relids of base relations
-		 * covered by that relation for later use by the deparser.
-		 */
-		if (fpinfo_o->remote_conds)
-		{
-			fpinfo->make_outerrel_subquery = true;
-			fpinfo->lower_subquery_rels =
-			    bms_add_members(fpinfo->lower_subquery_rels,
-			                    outerrel->relids);
-		}
-		if (fpinfo_i->remote_conds)
-		{
-			fpinfo->make_innerrel_subquery = true;
-			fpinfo->lower_subquery_rels =
-			    bms_add_members(fpinfo->lower_subquery_rels,
-			                    innerrel->relids);
-		}
-		break;
+			/*
+			 * In this case, if any of the input relations has conditions, we
+			 * need to deparse that relation as a subquery so that the
+			 * conditions can be evaluated before the join. Remember it in the
+			 * fpinfo of this relation so that the deparser can take
+			 * appropriate action. Also, save the relids of base relations
+			 * covered by that relation for later use by the deparser.
+			 */
+			if (fpinfo_o->remote_conds)
+			{
+				fpinfo->make_outerrel_subquery = true;
+				fpinfo->lower_subquery_rels =
+					bms_add_members(fpinfo->lower_subquery_rels,
+									outerrel->relids);
+			}
+			if (fpinfo_i->remote_conds)
+			{
+				fpinfo->make_innerrel_subquery = true;
+				fpinfo->lower_subquery_rels =
+					bms_add_members(fpinfo->lower_subquery_rels,
+									innerrel->relids);
+			}
+			break;
 
-	default:
-		/* Should not happen, we have just checked this above */
-		elog(ERROR, "unsupported join type %d", jointype);
+		default:
+			/* Should not happen, we have just checked this above */
+			elog(ERROR, "unsupported join type %d", jointype);
 	}
 
 	/* Mark that this join can be pushed down safely */
@@ -1788,10 +1808,10 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 					 fpinfo_i->relation_name->data);
 
 	/*
-	 * Set the relation index.  This is defined as the position of this
-	 * joinrel in the join_rel_list list plus the length of the rtable list.
-	 * Note that since this joinrel is at the end of the join_rel_list list
-	 * when we are called, we can get the position by list_length.
+	 * Set the relation index. This is defined as the position of this joinrel
+	 * in the join_rel_list list plus the length of the rtable list. Note that
+	 * since this joinrel is at the end of the join_rel_list list when we are
+	 * called, we can get the position by list_length.
 	 */
 	Assert(fpinfo->relation_index == 0);	/* shouldn't be set yet */
 	fpinfo->relation_index =
@@ -1801,8 +1821,8 @@ foreign_join_ok(PlannerInfo *root, RelOptInfo *joinrel, JoinType jointype,
 }
 
 static void
-add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
-								Path *epq_path)
+add_paths_with_pathkeys_for_rel(PlannerInfo * root, RelOptInfo * rel,
+								Path * epq_path)
 {
 	List	   *useful_pathkeys_list = NIL; /* List of all pathkeys */
 	ListCell   *lc;
@@ -1859,7 +1879,7 @@ add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
 											  NULL,
 											  rows,
 #if PG_VERSION_NUM >= 180000
-											 0,
+											  0,
 #endif
 											  startup_cost,
 											  total_cost,
@@ -1878,14 +1898,14 @@ add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel,
  * or an upper rel.
  *
  * For a join relation, FDW-specific information about the inner and outer
- * relations is provided using fpinfo_i and fpinfo_o.  For an upper relation,
+ * relations is provided using fpinfo_i and fpinfo_o. For an upper relation,
  * fpinfo_o provides the information for the input relation; fpinfo_i is
  * expected to NULL.
  */
 static void
-merge_fdw_options(CHFdwRelationInfo *fpinfo,
-                  const CHFdwRelationInfo *fpinfo_o,
-                  const CHFdwRelationInfo *fpinfo_i)
+merge_fdw_options(CHFdwRelationInfo * fpinfo,
+				  const CHFdwRelationInfo * fpinfo_o,
+				  const CHFdwRelationInfo * fpinfo_i)
 {
 	/* We must always have fpinfo_o. */
 	Assert(fpinfo_o);
@@ -1895,7 +1915,7 @@ merge_fdw_options(CHFdwRelationInfo *fpinfo,
 		   fpinfo_i->server->serverid == fpinfo_o->server->serverid);
 
 	/*
-	 * Copy the server specific FDW options.  (For a join, both relations come
+	 * Copy the server specific FDW options. (For a join, both relations come
 	 * from the same server, so the server options should have the same value
 	 * for both relations.)
 	 */
@@ -1910,9 +1930,9 @@ merge_fdw_options(CHFdwRelationInfo *fpinfo,
 	{
 		/*
 		 * We'll prefer to use remote estimates for this join if any table
-		 * from either side of the join is using remote estimates.  This is
+		 * from either side of the join is using remote estimates. This is
 		 * most likely going to be preferred since they're already willing to
-		 * pay the price of a round trip to get the remote EXPLAIN.  In any
+		 * pay the price of a round trip to get the remote EXPLAIN. In any
 		 * case it's not entirely clear how we might otherwise handle this
 		 * best.
 		 */
@@ -1933,12 +1953,12 @@ merge_fdw_options(CHFdwRelationInfo *fpinfo,
  *		Add possible ForeignPath to joinrel, if join is safe to push down.
  */
 static void
-clickhouseGetForeignJoinPaths(PlannerInfo *root,
-                              RelOptInfo *joinrel,
-                              RelOptInfo *outerrel,
-                              RelOptInfo *innerrel,
-                              JoinType jointype,
-                              JoinPathExtraData *extra)
+clickhouseGetForeignJoinPaths(PlannerInfo * root,
+							  RelOptInfo * joinrel,
+							  RelOptInfo * outerrel,
+							  RelOptInfo * innerrel,
+							  JoinType jointype,
+							  JoinPathExtraData * extra)
 {
 	CHFdwRelationInfo *fpinfo;
 	ForeignPath *joinpath;
@@ -1947,9 +1967,11 @@ clickhouseGetForeignJoinPaths(PlannerInfo *root,
 	Cost		startup_cost;
 	Cost		total_cost;
 	Path	   *epq_path;		/* Path to create plan to be executed when
-					 * EvalPlanQual gets triggered. */
+								 * EvalPlanQual gets triggered. */
 
-	struct timeval time1,time2;
+	struct timeval time1,
+				time2;
+
 	gettimeofday(&time1, NULL);
 
 	/*
@@ -2024,7 +2046,7 @@ clickhouseGetForeignJoinPaths(PlannerInfo *root,
 										NULL,	/* default pathtarget */
 										rows,
 #if PG_VERSION_NUM >= 180000
-											 0,
+										0,
 #endif
 										startup_cost,
 										total_cost,
@@ -2048,12 +2070,12 @@ clickhouseGetForeignJoinPaths(PlannerInfo *root,
 
 /*
  * Assess whether the aggregation, grouping and having operations can be pushed
- * down to the foreign server.  As a side effect, save information we obtain in
+ * down to the foreign server. As a side effect, save information we obtain in
  * this function to CHFdwRelationInfo of the input relation.
  */
 static bool
-foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
-                    Node *havingQual)
+foreign_grouping_ok(PlannerInfo * root, RelOptInfo * grouped_rel,
+					Node * havingQual)
 {
 	Query	   *query = root->parse;
 	CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) grouped_rel->fdw_private;
@@ -2073,7 +2095,7 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 
 	/*
 	 * If underlying scan relation has any local conditions, those conditions
-	 * are required to be applied before performing aggregation.  Hence the
+	 * are required to be applied before performing aggregation. Hence the
 	 * aggregate cannot be pushed down.
 	 */
 	if (ofpinfo->local_conds)
@@ -2082,8 +2104,8 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 	/*
 	 * Examine grouping expressions, as well as other expressions we'd need to
 	 * compute, and check whether they are safe to push down to the foreign
-	 * server.  All GROUP BY expressions will be part of the grouping target
-	 * and thus there is no need to search for them separately.  Add grouping
+	 * server. All GROUP BY expressions will be part of the grouping target
+	 * and thus there is no need to search for them separately. Add grouping
 	 * expressions into target list which will be passed to foreign server.
 	 */
 	i = 0;
@@ -2106,10 +2128,10 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 				return false;
 
 			/*
-			 * Pushable, so add to tlist.  We need to create a TLE for this
-			 * expression and apply the sortgroupref to it.  We cannot use
+			 * Pushable, so add to tlist. We need to create a TLE for this
+			 * expression and apply the sortgroupref to it. We cannot use
 			 * add_to_flat_tlist() here because that avoids making duplicate
-			 * entries in the tlist.  If there are duplicate entries with
+			 * entries in the tlist. If there are duplicate entries with
 			 * distinct sortgrouprefs, we have to duplicate that situation in
 			 * the output tlist.
 			 */
@@ -2120,7 +2142,7 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 		else
 		{
 			/*
-			 * Non-grouping expression we need to compute.  Is it shippable?
+			 * Non-grouping expression we need to compute. Is it shippable?
 			 */
 			if (chfdw_is_foreign_expr(root, grouped_rel, expr))
 			{
@@ -2131,7 +2153,7 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 			{
 				/* Not pushable as a whole; extract its Vars and aggregates */
 				aggvars = pull_var_clause((Node *) expr,
-				                          PVC_INCLUDE_AGGREGATES);
+										  PVC_INCLUDE_AGGREGATES);
 
 				/*
 				 * If any aggregate expression is not shippable, then we
@@ -2141,18 +2163,18 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 					return false;
 
 				/*
-				 * Add aggregates, if any, into the targetlist.  Plain Vars
+				 * Add aggregates, if any, into the targetlist. Plain Vars
 				 * outside an aggregate can be ignored, because they should be
 				 * either same as some GROUP BY column or part of some GROUP
-				 * BY expression.  In either case, they are already part of
-				 * the targetlist and thus no need to add them again.  In fact
+				 * BY expression. In either case, they are already part of the
+				 * targetlist and thus no need to add them again. In fact
 				 * including plain Vars in the tlist when they do not match a
 				 * GROUP BY column would cause the foreign server to complain
 				 * that the shipped query is invalid.
 				 */
 				foreach(l, aggvars)
 				{
-					Expr	*first_expr = (Expr *) lfirst(l);
+					Expr	   *first_expr = (Expr *) lfirst(l);
 
 					if (IsA(first_expr, Aggref))
 						tlist = add_to_flat_tlist(tlist, list_make1(first_expr));
@@ -2217,8 +2239,8 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 			RestrictInfo *rinfo = lfirst_node(RestrictInfo, agg_lc);
 
 			local_aggvars = list_concat(local_aggvars,
-								  pull_var_clause((Node *) rinfo->clause,
-												  PVC_INCLUDE_AGGREGATES));
+										pull_var_clause((Node *) rinfo->clause,
+														PVC_INCLUDE_AGGREGATES));
 		}
 
 		foreach(agg_lc, local_aggvars)
@@ -2227,8 +2249,8 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
 
 			/*
 			 * If aggregates within local conditions are not safe to push
-			 * down, then we cannot push down the query.  Vars are already
-			 * part of GROUP BY clause which are checked above, so no need to
+			 * down, then we cannot push down the query. Vars are already part
+			 * of GROUP BY clause which are checked above, so no need to
 			 * access them again here.
 			 */
 			if (IsA(expr, Aggref))
@@ -2274,12 +2296,13 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel,
  * Right now, we only support aggregate, grouping and having clause pushdown.
  */
 static void
-clickhouseGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
-                               RelOptInfo *input_rel, RelOptInfo *output_rel,
-                               void *extra)
+clickhouseGetForeignUpperPaths(PlannerInfo * root, UpperRelationKind stage,
+							   RelOptInfo * input_rel, RelOptInfo * output_rel,
+							   void *extra)
 {
 	CHFdwRelationInfo *fpinfo;
-	struct timeval time1,time2;
+	struct timeval time1,
+				time2;
 
 	gettimeofday(&time1, NULL);
 
@@ -2288,7 +2311,7 @@ clickhouseGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
 	 * perform any post-join operations on the foreign server.
 	 */
 	if (!input_rel->fdw_private ||
-	        !((CHFdwRelationInfo *) input_rel->fdw_private)->pushdown_safe)
+		!((CHFdwRelationInfo *) input_rel->fdw_private)->pushdown_safe)
 		return;
 
 	/* Ignore stages we don't support; and skip any duplicate calls. */
@@ -2328,13 +2351,13 @@ clickhouseGetForeignUpperPaths(PlannerInfo *root, UpperRelationKind stage,
  * add_foreign_grouping_paths
  *		Add foreign path for grouping and/or aggregation.
  *
- * Given input_rel represents the underlying scan.  The paths are added to the
+ * Given input_rel represents the underlying scan. The paths are added to the
  * given grouped_rel.
  */
 static void
-add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
-                           RelOptInfo *grouped_rel,
-                           GroupPathExtraData *extra)
+add_foreign_grouping_paths(PlannerInfo * root, RelOptInfo * input_rel,
+						   RelOptInfo * grouped_rel,
+						   GroupPathExtraData * extra)
 {
 	Query	   *parse = root->parse;
 	CHFdwRelationInfo *ifpinfo = input_rel->fdw_private;
@@ -2386,22 +2409,22 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	/* Create and add foreign path to the grouping relation. */
 #if (PG_VERSION_NUM < 120000)
 	grouppath = create_foreignscan_path(root,
-	                                    grouped_rel,
-	                                    grouped_rel->reltarget,
-	                                    rows,
-	                                    startup_cost,
-	                                    total_cost,
-	                                    NIL,	/* no pathkeys */
-	                                    NULL,	/* no required_outer */
-	                                    NULL,
-	                                    NIL);	/* no fdw_private */
+										grouped_rel,
+										grouped_rel->reltarget,
+										rows,
+										startup_cost,
+										total_cost,
+										NIL,	/* no pathkeys */
+										NULL,	/* no required_outer */
+										NULL,
+										NIL);	/* no fdw_private */
 #else
 	grouppath = create_foreign_upper_path(root,
 										  grouped_rel,
 										  grouped_rel->reltarget,
 										  rows,
 #if PG_VERSION_NUM >= 180000
-											 0,
+										  0,
 #endif
 										  startup_cost,
 										  total_cost,
@@ -2421,12 +2444,12 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
  * add_foreign_ordered_paths
  *		Add foreign paths for performing the final sort remotely.
  *
- * Given input_rel contains the source-data Paths.  The paths are added to the
+ * Given input_rel contains the source-data Paths. The paths are added to the
  * given ordered_rel.
  */
 static void
-add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
-						  RelOptInfo *ordered_rel)
+add_foreign_ordered_paths(PlannerInfo * root, RelOptInfo * input_rel,
+						  RelOptInfo * ordered_rel)
 {
 	Query	   *parse = root->parse;
 	CHFdwRelationInfo *ifpinfo = input_rel->fdw_private;
@@ -2495,16 +2518,16 @@ add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
 		Expr	   *sort_expr;
 
 		/*
-		 * chfdw_is_foreign_expr would detect volatile expressions as well, but
-		 * checking ec_has_volatile here saves some cycles.
+		 * chfdw_is_foreign_expr would detect volatile expressions as well,
+		 * but checking ec_has_volatile here saves some cycles.
 		 */
 		if (pathkey_ec->ec_has_volatile)
 			return;
 
 		/* Get the sort expression for the pathkey_ec */
 		sort_expr = chfdw_find_em_expr_for_input_target(root,
-												  pathkey_ec,
-												  input_rel->reltarget);
+														pathkey_ec,
+														input_rel->reltarget);
 
 		/* If it's unsafe to remote, we cannot push down the final sort */
 		if (!chfdw_is_foreign_expr(root, input_rel, sort_expr))
@@ -2530,15 +2553,15 @@ add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	/* Create foreign ordering path */
 #if (PG_VERSION_NUM < 120000)
 	ordered_path = create_foreignscan_path(root,
-											input_rel,
-											root->upper_targets[UPPERREL_ORDERED],
-											rows,
-											startup_cost,
-											total_cost,
-											root->sort_pathkeys,
-											NULL,	/* no required_outer */
-											NULL,
-											fdw_private);
+										   input_rel,
+										   root->upper_targets[UPPERREL_ORDERED],
+										   rows,
+										   startup_cost,
+										   total_cost,
+										   root->sort_pathkeys,
+										   NULL,	/* no required_outer */
+										   NULL,
+										   fdw_private);
 #else
 	ordered_path = create_foreign_upper_path(root,
 											 input_rel,
@@ -2565,16 +2588,16 @@ add_foreign_ordered_paths(PlannerInfo *root, RelOptInfo *input_rel,
  * add_foreign_final_paths
  *		Add foreign paths for performing the final processing remotely.
  *
- * Given input_rel contains the source-data Paths.  The paths are added to the
+ * Given input_rel contains the source-data Paths. The paths are added to the
  * given final_rel.
  */
 static void
-add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
-						RelOptInfo *final_rel,
+add_foreign_final_paths(PlannerInfo * root, RelOptInfo * input_rel,
+						RelOptInfo * final_rel,
 						void *fextra)
 {
 #if (PG_VERSION_NUM < 120000)
-	// final paths supported only on pg >= v12
+	/* final paths supported only on pg >= v12 */
 	return;
 #else
 	Query	   *parse = root->parse;
@@ -2641,9 +2664,8 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	 * We try to create a path below by extending a simple foreign path for
 	 * the underlying base, join, or grouping relation to perform the final
 	 * sort (if has_final_sort) and the LIMIT restriction remotely, which is
-	 * stored into the fdw_private list of the resulting path.  (We
-	 * re-estimate the costs of sorting the underlying relation, if
-	 * has_final_sort.)
+	 * stored into the fdw_private list of the resulting path. (We re-estimate
+	 * the costs of sorting the underlying relation, if has_final_sort.)
 	 */
 
 	/*
@@ -2695,7 +2717,7 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
 										   root->upper_targets[UPPERREL_FINAL],
 										   1,
 #if PG_VERSION_NUM >= 180000
-											 0,
+										   0,
 #endif
 										   0,
 										   -10,
@@ -2715,8 +2737,8 @@ add_foreign_final_paths(PlannerInfo *root, RelOptInfo *input_rel,
  * Find an equivalence class member expression, all of whose Vars, come from
  * the indicated relation.
  */
-Expr *
-chfdw_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
+Expr	   *
+chfdw_find_em_expr_for_rel(EquivalenceClass * ec, RelOptInfo * rel)
 {
 	ListCell   *lc_em;
 
@@ -2744,10 +2766,10 @@ chfdw_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
  * Find an equivalence class member expression to be computed as a sort column
  * in the given target.
  */
-Expr *
-chfdw_find_em_expr_for_input_target(PlannerInfo *root,
-							  EquivalenceClass *ec,
-							  PathTarget *target)
+Expr	   *
+chfdw_find_em_expr_for_input_target(PlannerInfo * root,
+									EquivalenceClass * ec,
+									PathTarget * target)
 {
 	ListCell   *lc1;
 	int			i;
@@ -2803,9 +2825,9 @@ chfdw_find_em_expr_for_input_target(PlannerInfo *root,
 }
 
 static List *
-clickhouseImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid)
+clickhouseImportForeignSchema(ImportForeignSchemaStmt * stmt, Oid serverOid)
 {
-	ForeignServer       *server;
+	ForeignServer *server;
 
 	server = GetForeignServer(serverOid);
 	return chfdw_construct_create_tables(stmt, server);
@@ -2836,10 +2858,15 @@ clickhouse_fdw_handler(PG_FUNCTION_ARGS)
 	routine->BeginForeignInsert = clickhouseBeginForeignInsert;
 	routine->ExecForeignInsert = clickhouseExecForeignInsert;
 
-	// TODO: Add support for ClickHouse 25.8 and later.
-	// routine->ExecForeignBatchInsert = XXX;
-	// routine->ExecForeignUpdate = XXX;
-	// routine->ExecForeignDelete = XXX;
+	/*
+	 * TODO:Add support for ClickHouse 25.8 and later.
+	 *
+	 * routine->ExecForeignBatchInsert = XXX;
+	 *
+	 * routine->ExecForeignUpdate = XXX;
+	 *
+	 * routine->ExecForeignDelete = XXX;
+	 */
 
 	routine->EndForeignInsert = clickhouseEndForeignInsert;
 	routine->EndForeignModify = clickhouseEndForeignInsert;
@@ -2882,11 +2909,12 @@ clickhouse_noop(PG_FUNCTION_ARGS)
 Datum
 clickhouse_op_push_fail(PG_FUNCTION_ARGS)
 {
-	text* name = PG_GETARG_TEXT_PP(0);
+	text	   *name = PG_GETARG_TEXT_PP(0);
+
 	ereport(ERROR,
-		errcode(ERRCODE_FDW_ERROR),
-		errmsg("pg_clickhouse: failed to push down %s", text_to_cstring(name))
-	);
+			errcode(ERRCODE_FDW_ERROR),
+			errmsg("pg_clickhouse: failed to push down %s", text_to_cstring(name))
+		);
 }
 
 /*
@@ -2896,9 +2924,10 @@ clickhouse_op_push_fail(PG_FUNCTION_ARGS)
 Datum
 clickhouse_push_fail(PG_FUNCTION_ARGS)
 {
-	char *name = get_func_name(fcinfo->flinfo->fn_oid);
+	char	   *name = get_func_name(fcinfo->flinfo->fn_oid);
+
 	ereport(ERROR,
-		errcode(ERRCODE_FDW_ERROR),
-		errmsg("pg_clickhouse: failed to push down %s()", name)
-	);
+			errcode(ERRCODE_FDW_ERROR),
+			errmsg("pg_clickhouse: failed to push down %s()", name)
+		);
 }

--- a/src/include/binary.hh
+++ b/src/include/binary.hh
@@ -2,92 +2,97 @@
 #define CLICKHOUSE_BINARY_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct ch_binary_connection_t ch_binary_connection_t;
-typedef struct ch_insert_block_h ch_insert_block_h;
-typedef struct ch_binary_response_t
-{
-	void			   *values;
-	size_t				columns_count;
-	size_t				blocks_count;
-	char			   *error;
-	bool				success;
-} ch_binary_response_t;
+	typedef struct ch_binary_connection_t ch_binary_connection_t;
+	typedef struct ch_insert_block_h ch_insert_block_h;
+	typedef struct ch_binary_response_t
+	{
+		void	   *values;
+		size_t		columns_count;
+		size_t		blocks_count;
+		char	   *error;
+		bool		success;
+	}			ch_binary_response_t;
 
-typedef struct {
-	ch_binary_response_t	*resp;
-	Oid		*coltypes;
-	Datum	*values;
-	bool	*nulls;
+	typedef struct
+	{
+		ch_binary_response_t *resp;
+		Oid		   *coltypes;
+		Datum	   *values;
+		bool	   *nulls;
 
-	size_t	block;		/* current block */
-	size_t	row;		/* row in current block */
-	void   *gc;			/* allocated objects while reading */
-	char   *error;
-	bool	done;
-} ch_binary_read_state_t;
+		size_t		block;		/* current block */
+		size_t		row;		/* row in current block */
+		void	   *gc;			/* allocated objects while reading */
+		char	   *error;
+		bool		done;
+	}			ch_binary_read_state_t;
 
-typedef struct {
-	Datum	*datums;
-	bool	*nulls;
-	size_t	 len;
-	Oid		*types;
-} ch_binary_tuple_t;
+	typedef struct
+	{
+		Datum	   *datums;
+		bool	   *nulls;
+		size_t		len;
+		Oid		   *types;
+	}			ch_binary_tuple_t;
 
-typedef struct {
-	Datum  *datums;
-	bool   *nulls;
-	size_t	len;
-	Oid		item_type;	/* used on selects */
-	Oid		array_type;	/* used on selects */
-} ch_binary_array_t;
+	typedef struct
+	{
+		Datum	   *datums;
+		bool	   *nulls;
+		size_t		len;
+		Oid			item_type;	/* used on selects */
+		Oid			array_type; /* used on selects */
+	}			ch_binary_array_t;
 
-typedef struct {
-	MemoryContext	memcxt;	/* used for cleanup */
-	MemoryContextCallback callback;
+	typedef struct
+	{
+		MemoryContext memcxt;	/* used for cleanup */
+		MemoryContextCallback callback;
 
-	TupleDesc	outdesc;
-	ch_insert_block_h *insert_block; /* clickhouse::Block */
-	size_t	len;
-	void  *conversion_states;
-	char *table_name;
+		TupleDesc	outdesc;
+		ch_insert_block_h *insert_block;	/* clickhouse::Block */
+		size_t		len;
+		void	   *conversion_states;
+		char	   *table_name;
 
-	Datum	*values;
-	bool	*nulls;
-	bool	 success;
+		Datum	   *values;
+		bool	   *nulls;
+		bool		success;
 
-	ch_binary_connection_t *conn;
-} ch_binary_insert_state;
+		ch_binary_connection_t *conn;
+	}			ch_binary_insert_state;
 
-extern ch_binary_connection_t *ch_binary_connect(char *host, int port,
-		char *database, char *user, char *password, char **error);
-extern void ch_binary_close(ch_binary_connection_t *conn);
-extern ch_binary_response_t *ch_binary_simple_query(ch_binary_connection_t *conn,
-		const char *query, bool (*check_cancel)(void));
-extern void ch_binary_response_free(ch_binary_response_t *resp);
+	extern ch_binary_connection_t * ch_binary_connect(char *host, int port,
+													  char *database, char *user, char *password, char **error);
+	extern void ch_binary_close(ch_binary_connection_t * conn);
+	extern ch_binary_response_t * ch_binary_simple_query(ch_binary_connection_t * conn,
+														 const char *query, bool (*check_cancel) (void));
+	extern void ch_binary_response_free(ch_binary_response_t * resp);
 
 /* reading */
-void ch_binary_read_state_init(ch_binary_read_state_t *state, ch_binary_response_t *resp);
-void ch_binary_read_state_free(ch_binary_read_state_t *state);
-bool ch_binary_read_row(ch_binary_read_state_t *state);
-Datum ch_binary_convert_datum(void *state, Datum val);
-void *ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype);
-void ch_binary_free_convert_state(void *);
+	void		ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_response_t * resp);
+	void		ch_binary_read_state_free(ch_binary_read_state_t * state);
+	bool		ch_binary_read_row(ch_binary_read_state_t * state);
+	Datum		ch_binary_convert_datum(void *state, Datum val);
+	void	   *ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype);
+	void		ch_binary_free_convert_state(void *);
 
 /* insertion */
-void ch_binary_prepare_insert(void *conn, char *query,
-		ch_binary_insert_state *state);
-void ch_binary_insert_columns(ch_binary_insert_state *state);
-void ch_binary_column_append_data(ch_binary_insert_state *state, size_t colidx);
-void *ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc);
-void ch_binary_insert_state_free(void *c);
-void ch_binary_do_output_convertion(ch_binary_insert_state *insert_state,
-		TupleTableSlot *slot);
+	void		ch_binary_prepare_insert(void *conn, char *query,
+										 ch_binary_insert_state * state);
+	void		ch_binary_insert_columns(ch_binary_insert_state * state);
+	void		ch_binary_column_append_data(ch_binary_insert_state * state, size_t colidx);
+	void	   *ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc);
+	void		ch_binary_insert_state_free(void *c);
+	void		ch_binary_do_output_convertion(ch_binary_insert_state * insert_state,
+											   TupleTableSlot * slot);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif   /* CLICKHOUSE_BINARY_H */
+#endif							/* CLICKHOUSE_BINARY_H */

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -8,49 +8,51 @@
 typedef struct ch_http_connection_t ch_http_connection_t;
 typedef struct ch_http_response_t
 {
-	char			   *data;
-	size_t				datasize;
-	long				http_status;
-	char				query_id[37];
-	double				pretransfer_time;
-	double				total_time;
-} ch_http_response_t;
+	char	   *data;
+	size_t		datasize;
+	long		http_status;
+	char		query_id[37];
+	double		pretransfer_time;
+	double		total_time;
+}			ch_http_response_t;
 
 typedef enum
 {
 	CH_CONT,
 	CH_EOL,
 	CH_EOF
-} ch_read_status;
+}			ch_read_status;
 
-typedef struct {
-	char   *data;
-	size_t	buflen;
-	size_t	curpos;
-	size_t	maxpos;
-	char   *val;
-	bool	done;
-} ch_http_read_state;
+typedef struct
+{
+	char	   *data;
+	size_t		buflen;
+	size_t		curpos;
+	size_t		maxpos;
+	char	   *val;
+	bool		done;
+}			ch_http_read_state;
 
-typedef struct {
-	StringInfoData	sql;
-	char		   *sql_begin;		/* beginning part of constructed sql */
-	List		   *target_attrs;	/* list of target attribute numbers */
-	int				p_nums;			/* number of parameters to transmit */
+typedef struct
+{
+	StringInfoData sql;
+	char	   *sql_begin;		/* beginning part of constructed sql */
+	List	   *target_attrs;	/* list of target attribute numbers */
+	int			p_nums;			/* number of parameters to transmit */
 	ch_http_connection_t *conn;
-} ch_http_insert_state;
+}			ch_http_insert_state;
 
-void ch_http_init(int verbose, uint32_t query_id_prefix);
-void ch_http_set_progress_func(void *progressfunc);
+void		ch_http_init(int verbose, uint32_t query_id_prefix);
+void		ch_http_set_progress_func(void *progressfunc);
 ch_http_connection_t *ch_http_connection(char *, int, char *, char *);
-void ch_http_close(ch_http_connection_t *conn);
-ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char *query);
-char *ch_http_last_error(void);
+void		ch_http_close(ch_http_connection_t * conn);
+ch_http_response_t *ch_http_simple_query(ch_http_connection_t * conn, const char *query);
+char	   *ch_http_last_error(void);
 
 /* read */
-void ch_http_read_state_init(ch_http_read_state *state, char *data, size_t datalen);
-void ch_http_read_state_free(ch_http_read_state *state);
-int ch_http_read_next(ch_http_read_state *state);
-void ch_http_response_free(ch_http_response_t *resp);
+void		ch_http_read_state_init(ch_http_read_state * state, char *data, size_t datalen);
+void		ch_http_read_state_free(ch_http_read_state * state);
+int			ch_http_read_next(ch_http_read_state * state);
+void		ch_http_response_free(ch_http_response_t * resp);
 
-#endif  /* CLICKHOUSE_HTTP_H */
+#endif							/* CLICKHOUSE_HTTP_H */

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -5,22 +5,22 @@
 
 typedef struct ch_http_connection_t
 {
-	CURL			   *curl;
-	char			   *base_url;
-	size_t				base_url_len;
-} ch_http_connection_t;
+	CURL	   *curl;
+	char	   *base_url;
+	size_t		base_url_len;
+}			ch_http_connection_t;
 
 typedef struct ch_binary_connection_t
 {
-	void			  *client;
-	void			  *options;
-	char			  *error;
-} ch_binary_connection_t;
+	void	   *client;
+	void	   *options;
+	char	   *error;
+}			ch_binary_connection_t;
 
 /*
  * Check whether the given string matches a ClickHouse Cloud host name.
  */
-extern int ch_is_cloud_host(const char *host);
-int ends_with(const char *s, const char *suffix);
+extern int	ch_is_cloud_host(const char *host);
+int			ends_with(const char *s, const char *suffix);
 
-#endif /* CLICKHOUSE_INTERNAL_H */
+#endif							/* CLICKHOUSE_INTERNAL_H */

--- a/src/internal.c
+++ b/src/internal.c
@@ -1,18 +1,23 @@
 #include <string.h>
 #include <internal.h>
 
-int ends_with(const char *s, const char *suffix) {
-	size_t slen = strlen(s);
-	size_t suffix_len = strlen(suffix);
+int
+ends_with(const char *s, const char *suffix)
+{
+	size_t		slen = strlen(s);
+	size_t		suffix_len = strlen(suffix);
+
 	return suffix_len <= slen && !strcmp(s + slen - suffix_len, suffix);
 }
 
 /*
  * Check whether the given string matches a ClickHouse Cloud host name.
  */
-int ch_is_cloud_host(const char *host)
+int
+ch_is_cloud_host(const char *host)
 {
-	if (!host) return 0;
+	if (!host)
+		return 0;
 	return ends_with(host, ".clickhouse.cloud")
 		|| ends_with(host, ".clickhouse-staging.com")
 		|| ends_with(host, ".clickhouse-dev.com");

--- a/src/option.c
+++ b/src/option.c
@@ -34,15 +34,15 @@ typedef struct ChFdwOption
 {
 	const char *keyword;
 	Oid			optcontext;		/* OID of catalog in which option may appear */
-	bool		is_ch_opt;	  /* true if it's used in clickhouseclient */
-	char    dispchar[10];
-} ChFdwOption;
+	bool		is_ch_opt;		/* true if it's used in clickhouseclient */
+	char		dispchar[10];
+}			ChFdwOption;
 
 /*
  * Valid options for clickhouse_fdw.
  * Allocated and filled in InitChFdwOptions.
  */
-static ChFdwOption *clickhouse_fdw_options;
+static ChFdwOption * clickhouse_fdw_options;
 
 /*
  * Valid options for clickhouse client.
@@ -84,10 +84,10 @@ clickhouse_fdw_validator(PG_FUNCTION_ARGS)
 	InitChFdwOptions();
 
 	/*
-	 * Check that only options supported by clickhouse_fdw, and allowed for the
-	 * current object type, are given.
+	 * Check that only options supported by clickhouse_fdw, and allowed for
+	 * the current object type, are given.
 	 */
-	foreach (cell, options_list)
+	foreach(cell, options_list)
 	{
 		DefElem    *def = (DefElem *) lfirst(cell);
 
@@ -126,7 +126,7 @@ static void
 InitChFdwOptions(void)
 {
 	int			num_ch_opts;
-	const ChFdwOption *lopt;
+	const		ChFdwOption *lopt;
 	ChFdwOption *popt;
 
 	/* non-clickhouseclient FDW-specific FDW options */
@@ -159,12 +159,11 @@ InitChFdwOptions(void)
 
 	/*
 	 * We use plain malloc here to allocate clickhouse_fdw_options because it
-	 * lives as long as the backend process does.  Besides, keeping
-	 * ch_options in memory allows us to avoid copying every keyword
-	 * string.
+	 * lives as long as the backend process does. Besides, keeping ch_options
+	 * in memory allows us to avoid copying every keyword string.
 	 */
 	clickhouse_fdw_options = (ChFdwOption *) malloc(sizeof(
-								   ChFdwOption) * num_ch_opts + sizeof(non_ch_options));
+														   ChFdwOption) * num_ch_opts + sizeof(non_ch_options));
 	if (clickhouse_fdw_options == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
@@ -181,8 +180,8 @@ InitChFdwOptions(void)
 		 * Everything else is a server option.
 		 */
 		if (strcmp(lopt->keyword, "user") == 0 ||
-				strcmp(lopt->keyword, "password") == 0 ||
-				strchr(lopt->dispchar, '*'))
+			strcmp(lopt->keyword, "password") == 0 ||
+			strchr(lopt->dispchar, '*'))
 		{
 			popt->optcontext = UserMappingRelationId;
 		}
@@ -210,7 +209,7 @@ is_valid_option(const char *keyword, Oid context)
 {
 	ChFdwOption *opt;
 
-	Assert(clickhouse_fdw_options);	/* must be initialized already */
+	Assert(clickhouse_fdw_options); /* must be initialized already */
 
 	for (opt = clickhouse_fdw_options; opt->keyword; opt++)
 	{
@@ -231,7 +230,7 @@ is_ch_option(const char *keyword)
 {
 	ChFdwOption *opt;
 
-	Assert(clickhouse_fdw_options);	/* must be initialized already */
+	Assert(clickhouse_fdw_options); /* must be initialized already */
 
 	for (opt = clickhouse_fdw_options; opt->keyword; opt++)
 	{
@@ -246,21 +245,21 @@ is_ch_option(const char *keyword)
 
 /*
  * Generate key-value arrays which include only clickhouseclient options from the
- * given list (which can contain any kind of options).  Caller must have
- * allocated large-enough arrays.  Returns number of options found.
+ * given list (which can contain any kind of options). Caller must have
+ * allocated large-enough arrays. Returns number of options found.
  */
 void
-chfdw_extract_options(List *defelems, char **driver,  char **host, int *port,
-                         char **dbname, char **username, char **password)
+chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
+					  char **dbname, char **username, char **password)
 {
 	ListCell   *lc;
 
 	/* Build our options lists if we didn't yet. */
 	InitChFdwOptions();
 
-	foreach (lc, defelems)
+	foreach(lc, defelems)
 	{
-		DefElem *def = (DefElem *) lfirst(lc);
+		DefElem    *def = (DefElem *) lfirst(lc);
 
 		if (driver && strcmp(def->defname, "driver") == 0)
 			*driver = defGetString(def);
@@ -276,11 +275,11 @@ chfdw_extract_options(List *defelems, char **driver,  char **host, int *port,
 			else if (password && strcmp(def->defname, "password") == 0)
 				*password = defGetString(def);
 			else if (dbname && strcmp(def->defname, "dbname") == 0)
-            {
+			{
 				*dbname = defGetString(def);
-                if (*dbname[0] == '\0')
-                    *dbname = DEFAULT_DBNAME;
-            }
+				if (*dbname[0] == '\0')
+					*dbname = DEFAULT_DBNAME;
+			}
 		}
 	}
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -8,7 +8,8 @@
 #include <http.h>
 #include <internal.h>
 
-void ch_http_read_state_init(ch_http_read_state *state, char *data, size_t datalen)
+void
+ch_http_read_state_init(ch_http_read_state * state, char *data, size_t datalen)
 {
 	state->data = datalen > 0 ? data : NULL;
 	state->maxpos = datalen - 1;
@@ -17,16 +18,18 @@ void ch_http_read_state_init(ch_http_read_state *state, char *data, size_t datal
 	state->done = false;
 }
 
-void ch_http_read_state_free(ch_http_read_state *state)
+void
+ch_http_read_state_free(ch_http_read_state * state)
 {
 	free(state->val);
 }
 
-int ch_http_read_next(ch_http_read_state *state)
+int
+ch_http_read_next(ch_http_read_state * state)
 {
-	size_t pos = state->curpos,
-		   len = 0;
-	char  *data = state->data;
+	size_t		pos = state->curpos,
+				len = 0;
+	char	   *data = state->data;
 
 	state->val[0] = '\0';
 	if (state->done)
@@ -36,16 +39,33 @@ int ch_http_read_next(ch_http_read_state *state)
 	{
 		if (data[pos] == '\\')
 		{
-			// unescape some sequences
-			switch (data[pos+1]) {
-				case '\\': state->val[len] = '\\'; break;
-				case '\'': state->val[len] = '\''; break;
-				case 'n': state->val[len] = '\n'; break;
-				case 't': state->val[len] = '\t'; break;
-				case '0': state->val[len] = '\0'; break;
-				case 'r': state->val[len] = '\r'; break;
-				case 'b': state->val[len] = '\b'; break;
-				case 'f': state->val[len] = '\f'; break;
+			/* unescape some sequences */
+			switch (data[pos + 1])
+			{
+				case '\\':
+					state->val[len] = '\\';
+					break;
+				case '\'':
+					state->val[len] = '\'';
+					break;
+				case 'n':
+					state->val[len] = '\n';
+					break;
+				case 't':
+					state->val[len] = '\t';
+					break;
+				case '0':
+					state->val[len] = '\0';
+					break;
+				case 'r':
+					state->val[len] = '\r';
+					break;
+				case 'b':
+					state->val[len] = '\b';
+					break;
+				case 'f':
+					state->val[len] = '\f';
+					break;
 				default:
 					goto copy;
 			}
@@ -53,7 +73,7 @@ int ch_http_read_next(ch_http_read_state *state)
 			pos += 2;
 		}
 		else
-copy:
+	copy:
 			state->val[len++] = data[pos++];
 
 		/* extend the value size if needed */
@@ -71,7 +91,8 @@ copy:
 		return CH_CONT;
 
 	assert(data[pos] == '\n');
-	int res = pos < state->maxpos ? CH_EOL : CH_EOF;
+	int			res = pos < state->maxpos ? CH_EOL : CH_EOF;
+
 	state->done = (res == CH_EOF);
 
 	return res;


### PR DESCRIPTION
And replace `//` comments with `/* */` comments; otherwise `pg_bsd_indent` makes some funky indentation choices around them.