### PR TITLE
Fix Decimal stringification bug

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -765,10 +765,15 @@ nested_col:
 				str.erase(0, 1);
 			}
 
-			if (str.length() <= scale)
+			if (scale == 0)
+			{
+				/* No decimal point, just output the entire value. */
+				res << str;
+			}
+			else if (str.length() <= scale)
 			{
 				/* Append the entire value prepended with zeros after the decimal. */
-				res << "0." << std::string(scale-1, '0') << str;
+				res << "0." << std::string(scale-str.length(), '0') << str;
 			}
 			else
 			{


### PR DESCRIPTION
Need to output leading zeros relative to the number of digits, not 1. Also handle the simple and fairly common case of scale zero more simply.