### PR TITLE
Flesh out docs, add tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 PG_CONFIG   ?= pg_config
 MODULE_big   = $(EXTENSION)
 CURL_CONFIG ?= curl-config
-OS 	        ?= $(shell uname -s)
+OS 	        ?= $(shell uname -s | tr A-Z a-z)
+ARCH         = $(shell uname -m)
 
 # Collect all the C++ and C files to compile into MODULE_big.
 OBJS = $(sort \
@@ -24,8 +25,7 @@ OBJS = $(sort \
 
 # clickhouse-cpp source and build directories.
 CH_CPP_DIR = vendor/clickhouse-cpp
-MACHINE = $(shell echo "$$(uname -s)-$$(uname -m)" | tr '[:upper:]' '[:lower:]')
-CH_CPP_BUILD_DIR = vendor/_build/$(MACHINE)
+CH_CPP_BUILD_DIR = vendor/_build/$(OS)-$(ARCH)
 
 # List the clickhouse-cpp libraries we require.
 CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)
@@ -33,7 +33,7 @@ CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
 
 # Build static on Darwin by default.
 ifndef ($(CH_BUILD))
-# ifeq ($(OS),Darwin)
+# ifeq ($(OS),darwin)
 	CH_BUILD = static
 # endif
 endif
@@ -66,7 +66,7 @@ PG_CXXFLAGS = -std=c++17
 PG_CFLAGS = -Wno-declaration-after-statement $(shell $(CURL_CONFIG) --cflags)
 
 # We'll need libuuid except on darwin, where it's included in the OS.
-ifneq ($(OS),Darwin)
+ifneq ($(OS),darwin)
 	PG_LDFLAGS += -luuid
 endif
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,66 @@ This library contains the PostgreSQL extension `pg_clickhouse`, including a
 foreign data wrapper for ClickHouse databases. It supports ClickHouse v22 and
 later.
 
-## Installation
+## Getting Started
+
+The simplest way to try pg_clickhouse is the [Docker image][🐳], which
+contains the standard PostgreSQL Docker image with the pg_clickhouse
+extension:
+
+```sh
+docker run --name pg_clickhouse -e POSTGRES_PASSWORD=my_pass \
+       -d ghcr.io/clickhouse/pg_clickhouse:18
+docker exec -it pg_clickhouse psql
+```
+
+See the [tutorial](doc/tutorial.md) to get started importing ClickHouse tables
+and pushing down queries.
+
+## Documentation
+
+*   [Reference](doc/pg_clickhouse.md)
+*   [Tutorial](doc/tutorial.md)
+
+## Test Case: TPC-H
+
+This table compares [TPC-H] query performance between regular PostgreSQL
+tables and pg_clickhouse connected to ClickHouse, both loaded at scaling
+factor 1; ✅ indicates full pushdown, while a dash indicates a query
+cancellation after 1m. All tests run on a MacBook Pro M4 Max with 36 GB of
+memory.
+
+| Query              | Pushdown | pg_clickhouse | PostgreSQL |
+| -----------------: | :------: | ------------: | ---------: |
+|  [Query 1](#r2q1)  |     ✅    |         73ms  |     4478ms |
+|  [Query 2](#r2q2)  |          |             - |      560ms |
+|  [Query 3](#r2q3)  |     ✅    |          74ms |     1454ms |
+|  [Query 4](#r2q4)  |     ✅    |          67ms |      650ms |
+|  [Query 5](#r2q5)  |     ✅    |         104ms |      452ms |
+|  [Query 6](#r2q6)  |     ✅    |          42ms |      740ms |
+|  [Query 7](#r2q7)  |     ✅    |          83ms |      633ms |
+|  [Query 8](#r2q8)  |     ✅    |         114ms |      320ms |
+|  [Query 9](#r2q9)  |     ✅    |         136ms |     3028ms |
+| [Query 10](#r2q10) |     ✅    |          10ms |        6ms |
+| [Query 11](#r2q11) |     ✅    |          78ms |      213ms |
+| [Query 12](#r2q12) |     ✅    |          37ms |     1101ms |
+| [Query 13](#r2q13) |          |        1242ms |      967ms |
+| [Query 14](#r2q14) |     ✅    |          51ms |      193ms |
+| [Query 15](#r2q15) |          |         522ms |     1095ms |
+| [Query 16](#r2q16) |          |        1797ms |      492ms |
+| [Query 17](#r2q17) |          |           9ms |     1802ms |
+| [Query 18](#r2q18) |          |          10ms |     6185ms |
+| [Query 19](#r2q19) |          |         532ms |       64ms |
+| [Query 20](#r2q20) |          |        4595ms |      473ms |
+| [Query 21](#r2q21) |          |        1702ms |     1334ms |
+| [Query 22](#r2q22) |          |         268ms |      257ms |
 
 ### Compile From Source
 
 #### General Unix
 
-If you have PostgreSQL devel packages and curl devel packages installed, you
-should have `pg_config` and `curl-config` on your path, so you should be able
-to just run `make` (or `gmake`), then `make install`, then in your database
-`CREATE EXTENSION http`.
+The PostgreSQL and curl development packages include `pg_config` and
+`curl-config` in the path, so you should be able to just run `make` (or
+`gmake`), then `make install`, then in your database `CREATE EXTENSION http`.
 
 #### Debian / Ubuntu / APT
 
@@ -27,11 +77,26 @@ sudo apt install \
   postgresql-server-18 \
   libcurl4-openssl-dev \
   uuid-dev \
+  libssl-dev \
   make \
   cmake \
-  libssl-dev \
   g++
 ```
+
+#### RedHat / CentOS / Yum
+
+```sh
+sudo yum install \
+  postgresql-server \
+  libcurl-devel \
+  libuuid-devel \
+  openssl-libs \
+  automake \
+  cmake \
+  gcc
+```
+
+See [PostgreSQL Yum] for details on pulling from the PostgreSQL Yum repository.
 
 #### Compile and Install
 
@@ -42,6 +107,7 @@ make
 sudo make install
 ```
 
+<!-- XXX DSO currently disabled.
 By default `make` dynamically links the `clickhouse-cpp` library (except on
 macOS, where a dynamic `clickhouse-cpp` library is not yet supported). To
 statically compile the ClickHouse library into `pg_clickhouse`, pass
@@ -51,6 +117,7 @@ statically compile the ClickHouse library into `pg_clickhouse`, pass
 make CH_BUILD=static
 sudo make install CH_BUILD=static
 ```
+ -->
 
 If your host has several PostgreSQL installations, you might need to specify
 the appropriate version of `pg_config`:
@@ -141,7 +208,7 @@ make installcheck PGUSER=postgres
 ### Loading
 
 Once `pg_clickhouse` is installed, you can add it to a database by connecting
-to a database as a super user and running:
+as a super user and running:
 
 ``` sql
 CREATE EXTENSION pg_clickhouse;
@@ -157,21 +224,39 @@ CREATE EXTENSION pg_clickhouse SCHEMA env;
 
 ## Dependencies
 
-The `pg_clickhouse` extension requires PostgreSQL 13 or higher, [libcurl], and
-[libuuid]. Building the extension requires a compiler, GNU `make`, and
-[CMake].
+The `pg_clickhouse` extension requires [PostgreSQL] 13 or higher, [libcurl],
+[libuuid]. Building the extension requires a C and C++ compiler, [libSSL], [GNU
+make], and [CMake].
+
+## Road Map
+
+Our top focus is finishing pushdown coverage for analytic workloads before
+adding DML features. Our road map:
+
+*   Get the remaining 10 un-pushed-down TPC-H queries optimally planned
+*   Test and fix pushdown for the ClickBench queries
+*   Support transparent pushdown of all PostgreSQL aggregate functions
+*   Support transparent pushdown of all PostgreSQL functions
+*   Allow server-level and session-level ClickHouse settings via CREATE SERVER and GUCs
+*   Support all ClickHouse data types
+*   Support lightweight DELETEs and UPDATEs
+*   Support batch insertion via COPY
+*   Add a function to execute an arbitrary ClickHouse query and return its results as a tables
+*   Add support for pushdown of UNION queries when they all query the remote
+*   database
+
 
 ## Authors
 
-*   [Ildus Kurbangaliev](https://github.com/ildus)
-*   [Ibrar Ahmed](www.linkedin.com/in/ibrarahmed74)
 *   [David E. Wheeler](https://justatheory.com/)
+*   [Ildus Kurbangaliev](https://github.com/ildus)
+*   [Ibrar Ahmed](https://github.com/ibrarahmad)
 
 ## Copyright
 
-*   Portions Copyright (c) 2025, ClickHouse
+*   Copyright (c) 2025, ClickHouse
+*   Portions Copyright (c) 2023-2025, Ildus Kurbangaliev
 *   Portions Copyright (c) 2019-2023, Adjust GmbH
-*   Portions Copyright (c) 2019, Percona
 *   Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
 
   [PGXN]: https://badge.fury.io/pg/pg_clickhouse.svg
@@ -180,11 +265,16 @@ The `pg_clickhouse` extension requires PostgreSQL 13 or higher, [libcurl], and
   [🐘]:        https://github.com/clickhouse/pg_clickhouse/actions/workflows/postgres.yml "Tested with PostgreSQL 13-18"
   [ClickHouse]: https://github.com/clickhouse/pg_clickhouse/actions/workflows/clickhouse.yml/badge.svg
   [🏠]:          https://github.com/clickhouse/pg_clickhouse/actions/workflows/clickhouse.yml "Tested with ClickHouse v22–25"
-  [Docker]:    https://ghcr-badge.egpl.dev/clickhouse/pg_clickhouse/latest_tag?color=%2344cc11&ignore=latest&label=version
+  [Docker]:    https://ghcr-badge.egpl.dev/clickhouse/pg_clickhouse/latest_tag?color=%2344cc11&ignore=latest&label=Docker
   [🐳]:        https://github.com/ClickHouse/pg_clickhouse/pkgs/container/pg_clickhouse "Latest version on Docker Hub"
 
+  [PostgreSQL Apt]: https://wiki.postgresql.org/wiki/Apt
+  [PostgreSQL Yum]: https://yum.postgresql.org
   [`postgresql.conf` parameters]: https://www.postgresql.org/docs/devel/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-OTHER
+  [PostgreSQL]: https://www.postgresql.org "PostgreSQL: The World's Most Advanced Open Source Relational Database"
   [libcurl]: https://curl.se/libcurl/ "libcurl — your network transfer library"
   [libuuid]: https://linux.die.net/man/3/libuuid "libuuid - DCE compatible Universally Unique Identifier library"
+  [GNU make]: https://www.gnu.org/software/make "GNU Make"
   [CMake]: https://cmake.org/ "CMake: A Powerful Software Build System"
-  [PostgreSQL Apt]: https://wiki.postgresql.org/wiki/Apt
+  [LibSSL]: https://openssl-library.org "OpenSSL Library"
+  [TPC-H]: https://www.tpc.org/tpch/

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -3,17 +3,321 @@ pg_clickhouse 0.1.0
 
 ## Synopsis
 
-```pgsql
+```sql
 CREATE EXTENSION pg_clickhouse;
 ```
 
 ## Description
 
-This library contains a single PostgreSQL extension that enables remote query
-execution on ClickHouse databases, including a [foreign data wrapper]. It
-supports PostgreSQL 13 and higher and ClickHouse 22 and higher.
+This library contains PostgreSQL extension that enables remote query execution
+on ClickHouse databases, including a [foreign data wrapper]. It supports
+PostgreSQL 13 and higher and ClickHouse 22 and higher.
+
+## Getting Started
+
+The simplest way to try pg_clickhouse is the [Docker image], which contains
+the standard PostgreSQL Docker image with the pg_clickhouse extension:
+
+```sh
+docker run --name pg_clickhouse -e POSTGRES_PASSWORD=my_pass \
+       -d ghcr.io/clickhouse/pg_clickhouse:18
+docker exec -it pg_clickhouse psql
+```
+
+See the [tutorial](tutorial.md) to get started importing ClickHouse tables and
+pushing down queries.
+
+## Documentation
+
+*   [Installation](../README.md)
+*   [Tutorial](doc/tutorial.md)
 
 ## Usage
+
+```sql
+CREATE EXTENSION pg_clickhouse;
+CREATE SERVER taxi_srv FOREIGN DATA WRAPPER clickhouse_fdw
+       OPTIONS(driver 'binary', host 'localhost', dbname 'taxi');
+CREATE USER MAPPING FOR CURRENT_USER SERVER taxi_srv
+       OPTIONS (user 'default');
+CREATE SCHEMA taxi;
+IMPORT FOREIGN SCHEMA taxi FROM SERVER taxi_srv INTO taxi;
+```
+
+## SQL Reference
+
+The following SQL expressions use pg_clickhouse.
+
+### CREATE EXTENSION
+
+Use [CREATE EXTENSION] to add pg_clickhouse to a database:
+
+```sql
+CREATE EXTENSION pg_clickhouse;
+```
+
+Use `WITH SCHEMA` to install it into a specific schema (recommended):
+
+```sql
+CREATE SCHEMA ch;
+CREATE EXTENSION pg_clickhouse WITH SCHEMA ch;
+```
+
+### ALTER EXTENSION
+
+Use [ALTER EXTENSION] to change pg_clickhouse. Examples:
+
+*   After installing a new release of pg_clickhouse, use the `UPDATE` clause:
+
+    ```sql
+    ALTER EXTENSION pg_clickhouse UPDATE;
+    ```
+
+*   Use `SET SCHEMA` to move the extension to a new schema:
+
+    ```sql
+    CREATE SCHEMA ch;
+    ALTER EXTENSION pg_clickhouse SET SCHEMA ch;
+    ```
+
+### DROP EXTENSION
+
+Use [DROP EXTENSION] to remove pg_clickhouse from a database:
+
+```sql
+DROP EXTENSION pg_clickhouse;
+```
+
+This command fails if there are any objects that depend on pg_clickhouse. Use
+the `CASCADE` clause to drop them, too:
+
+```sql
+DROP EXTENSION pg_clickhouse CASCADE;
+```
+
+### CREATE SERVER
+
+Use [CREATE SERVER] to create a foreign server that connects to a ClickHouse
+server. Example:
+
+```sql
+CREATE SERVER taxi_srv FOREIGN DATA WRAPPER clickhouse_fdw
+       OPTIONS(driver 'binary', host 'localhost', dbname 'taxi');
+```
+
+The supported options are:
+
+*   `driver`: The ClickHouse connection driver to use, either "binary" or
+    "http". **Required.**
+*   `dbname`: The ClickHouse database to use upon connecting. Defaults to
+    "default".
+*   `host`: The host name of the ClickHouse server. Defaults to "localhost";
+*   `port`: The port to connect to on the ClickHouse server. Defaults as
+    follows:
+    *   9440 if `driver` is "binary" and `host` is a ClickHouse Cloud host
+    *   9004 if `driver` is "binary" and `host` is not a ClickHouse Cloud host
+    *   8443 if `driver` is "http" and `host` is a ClickHouse Cloud host
+    *   8123 if `driver` is "http" and `host` is not a ClickHouse Cloud host
+
+### ALTER SERVER
+
+Use [ALTER SERVER] to change a foreign server. Example:
+
+```sql
+ALTER SERVER taxi_srv OPTIONS (SET driver 'http');
+```
+
+The options are the same as for [CREATE SERVER](#create-server).
+
+### DROP SERVER
+
+Use [DROP SERVER] to remove a foreign server:
+
+```sql
+DROP SERVER taxi_srv;
+```
+
+This command fails if any other objects depend on the server. Use `CASCADE` to
+also drop those dependencies:
+
+```sql
+DROP SERVER taxi_srv CASCADE;
+```
+
+### CREATE USER MAPPING
+
+Use [CREATE USER MAPPING] to map a PostgreSQL user to a ClickHouse user. For
+example, to map the current PostgreSQL user to the remote ClickHouse user when
+connecting with the `taxi_srv` foreign server:
+
+```sql
+CREATE USER MAPPING FOR CURRENT_USER SERVER taxi_srv
+       OPTIONS (user 'demo');
+```
+
+The The supported options are:
+
+*   `user`: The name of the ClickHouse user. Defaults to "default".
+*   `password`: The password of the ClickHouse user.
+
+### ALTER USER MAPPING
+
+Use [ALTER USER MAPPING] to change the definition of a user mapping:
+
+```sql
+ALTER USER MAPPING FOR CURRENT_USER SERVER taxi_srv
+       OPTIONS (SET user 'default');
+```
+
+The options are the same as for [CREATE USER MAPPING](#create-user-mapping).
+
+### DROP USER MAPPING
+
+Use [DROP USER MAPPING] to remove a user mapping:
+
+```sql
+DROP USER MAPPING FOR CURRENT_USER SERVER taxi_srv;
+```
+
+### IMPORT FOREIGN SCHEMA
+
+Use [IMPORT FOREIGN SCHEMA] to import all the tables defines in a ClickHouse
+database as foreign tables into a PostgreSQL schema:
+
+```sql
+CREATE SCHEMA taxi;
+IMPORT FOREIGN SCHEMA demo FROM SERVER taxi_srv INTO taxi;
+```
+
+Use `LIMIT TO` to limit the import to specific tables:
+
+```sql
+IMPORT FOREIGN SCHEMA demo LIMIT TO (trips) FROM SERVER taxi_srv INTO taxi;
+```
+
+Use `EXCEPT` to exclude tables:
+
+```sql
+IMPORT FOREIGN SCHEMA demo EXCEPT (users) FROM SERVER taxi_srv INTO taxi;
+```
+
+pg_clickhouse will fetch a list of all the tables in the specified ClickHouse
+database ("demo" in the above examples), fetch column definitions for each,
+and execute [CREATE FOREIGN TABLE](#create-foreign-table) commands to create
+the foreign tables. Columns will be defined using the [supported data
+types](#data-types) and, were detectible, the options supported by [CREATE
+FOREIGN TABLE](#create-foreign-table).
+
+### CREATE FOREIGN TABLE
+
+Use [IMPORT FOREIGN SCHEMA] to create a foreign table that can query data from
+a ClickHouse database:
+
+```sql
+CREATE FOREIGN TABLE uact (
+    user_id    bigint NOT NULL,
+    page_views int,
+    duration   smallint,
+    sign       smallint
+) SERVER taxi_srv OPTIONS(
+    table_name 'uact'
+    engine 'CollapsingMergeTree'
+);
+```
+
+The supported table options are:
+
+*   `database`: The name of the remote database. Defaults to the database
+    defined for the foreign server.
+*   `table_name`: The name of the remote table. Default to the name specified
+    for the foreign table.
+*   `engine`: The [table engine] used by the ClickHouse table. For
+    `CollapsingMergeTree()` and `AggregatingMergeTree()`, pg_clickhouse
+    automatically applies the parameters to function expressions executed on
+    the table.
+
+Use the [data type](#data-types) appropriate for the remote ClickHouse data
+type of each column. For [AggregateFunction Type] and [SimpleAggregateFunction
+Type] columns, map the data type to the ClickHouse type passed to the function
+and specify the name of the aggregate function via the appropriate column
+option:
+
+*   `AggregateFunction`: The name of the aggregate function applied to an
+    [AggregateFunction Type] column
+*   `SimpleAggregateFunction`: The name of the aggregate function applied to
+    an [SimpleAggregateFunction Type] column
+
+Example:
+
+(aggregatefunction 'sum')
+
+```sql
+CREATE FOREIGN TABLE test (
+    column1 bigint  OPTIONS(AggregateFunction 'uniq'),
+    column2 integer OPTIONS(AggregateFunction 'anyIf'),
+    column3 bigint  OPTIONS(AggregateFunction 'quantiles(0.5, 0.9)')
+) SERVER clickhouse_srv;
+```
+
+For columns with the `AggregateFunction` function, pg_clickhouse will
+automatically append `Merge` to an aggregate function evaluating the column.
+
+### ALTER FOREIGN TABLE
+
+Use [ALTER FOREIGN TABLE] to change the definition of a foreign table:
+
+```sql
+ALTER TABLE table ALTER COLUMN b OPTIONS (SET AggregateFunction 'count');
+```
+
+The supported table and column options are the same as for [CREATE FOREIGN
+TABLE].
+
+### DROP FOREIGN TABLE
+
+Use [DROP FOREIGN TABLE] to remove a foreign table:
+
+```sql
+DROP FOREIGN TABLE uact;
+```
+
+This command fails if there are any objects that depend on the foreign table.
+Use the `CASCADE` clause to drop them, too:
+
+```sql
+DROP FOREIGN TABLE uact CASCADE;
+```
+
+## Function and Operator Reference
+
+### Data Types
+
+pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
+types:
+
+```
+ ClickHouse |    PostgreSQL    |             Notes             
+------------+------------------+-------------------------------
+ Bool       | boolean          | 
+ Date       | date             | 
+ DateTime   | timestamp        | 
+ Decimal    | numeric          | 
+ Float32    | real             | 
+ Float64    | double precision | 
+ IPv4       | inet             | 
+ IPv6       | inet             | 
+ Int16      | smallint         | 
+ Int32      | integer          | 
+ Int64      | bigint           | 
+ Int8       | smallint         | 
+ JSON       | json             | HTTP engine only
+ String     | text             | 
+ UInt16     | integer          | 
+ UInt32     | bigint           | 
+ UInt64     | bigint           | Errors on values > BIGINT max
+ UInt8      | smallint         | 
+ UUID       | uuid             | 
+```
 
 ### Functions
 
@@ -27,12 +331,6 @@ SELECT clickhouse_raw_query(
     'host=localhost port=8123'
 );
 ```
-```pgsql
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-```
 
 Connect to a ClickHouse service via its HTTP interface, execute a single
 query, and disconnect. The optional second argument specifies a connection
@@ -42,6 +340,7 @@ parameters are:
 *   `host`: The host to connect to; required.
 *   `port`: The HTTP port to connect to; defaults to `8123` unless `host` is a
     ClickHouse Cloud host, in which case it defaults to `8443`
+*   `dbname`: The name of the database to connect to.
 *   `username`: The username to connect as; defaults to `default`
 *   `password`: The password to use to authenticate; defaults to no password
 
@@ -54,7 +353,7 @@ SELECT clickhouse_raw_query(
     'host=localhost port=8123'
 );
 ```
-```pgsql
+```sql
       clickhouse_raw_query       
 ---------------------------------
  INFORMATION_SCHEMA      default+
@@ -99,7 +398,7 @@ maps the following functions:
 *   `array_position`: [toTimeZone](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf)
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 *   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
-*   `regexp_like` => [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 
 ### Custom Functions
 
@@ -108,6 +407,17 @@ pushdown for select ClickHouse functions with no PostgreSQL equivalents. If
 any of these functions cannot be pushed down they will raise an exception.
 
 *   [dictGet](https://clickhouse.com/docs/sql-reference/functions/ext-dict-functions#dictget-dictgetordefault-dictgetornull)
+
+### Pushdown Casts
+
+pg_clickhouse pushes down casts such as `CAST(x AS bigint)` for compatible
+data types. For incompatible types the pushdown will fail; if `x` in this
+example is a ClickHouse `UInt64`, ClickHouse will refuse to cast the value.
+
+In order to push down casts to incompatible data types, pg_clickhouse provides
+the following functions. They raise an exception in PostgreSQL if they are not
+pushed down.
+
 *   [toUInt8](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint8)
 *   [toUInt16](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint16)
 *   [toUInt32](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#touint32)
@@ -157,9 +467,9 @@ SELECT quantile(0.25)(a) FROM t1;
 Note that the non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST`
 are not supported and will raise an error.
 
-*   `percentile_cont(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
-*   `quantile(double)` => [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
-*   `quantileExact(double)` => [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
+*   `percentile_cont(double)`: [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   `quantile(double)`: [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   `quantileExact(double)`: [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
 
 ### Session Settings
 
@@ -192,6 +502,27 @@ using [dollar quoting] to avoid the need to double-quote:
 SET pg_clickhouse.session_settings = $$join_algorithm = 'grace_hash,hash'$$;
 ```
 
+If you care about legibility and need to set many settings, use multiple
+lines, for example:
+
+```sql
+SET pg_clickhouse.session_settings TO $$
+    connect_timeout = 2,
+    count_distinct_implementation = uniq,
+    groupby_use_nulls = 0,
+    join_algorithm = 'prefer_partial_merge',
+    join_use_nulls = 1,
+    log_queries_min_type = QUERY_FINISH,
+    max_block_size = 32768,
+    max_execution_time = 45,
+    max_result_rows = 1024,
+    metrics_perf_events_list = 'this,that',
+    network_compression_method = ZSTD,
+    poll_interval = 5,
+    totals_mode = after_having_auto
+$$;
+```
+
 pg_clickhouse does not validate the settings, but passes them on to ClickHouse
 for every query. It thus supports all settings for each ClickHouse version.
 
@@ -201,20 +532,48 @@ use one of the objects in the extension to ensure it loads.
 
 ## Authors
 
-*   [Ildus Kurbangaliev](https://github.com/ildus)
-*   [Ibrar Ahmed](www.linkedin.com/in/ibrarahmed74)
 *   [David E. Wheeler](https://justatheory.com/)
+*   [Ildus Kurbangaliev](https://github.com/ildus)
+*   [Ibrar Ahmed](https://github.com/ibrarahmad)
 
 ## Copyright
 
-*   Portions Copyright (c) 2025 ClickHouse
+*   Copyright (c) 2025, ClickHouse
+*   Portions Copyright (c) 2023-2025, Ildus Kurbangaliev
 *   Portions Copyright (c) 2019-2023, Adjust GmbH
-*   Portions Copyright (c) 2019 Percona
 *   Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
 
   [foreign data wrapper]: https://www.postgresql.org/docs/current/fdwhandler.html
     "PostgreSQL Docs: Writing a Foreign Data Wrapper"
+  [Docker image]: https://github.com/ClickHouse/pg_clickhouse/pkgs/container/pg_clickhouse
+    "Latest version on Docker Hub"
   [ClickHouse]: https://clickhouse.com/clickhouse
+  [CREATE EXTENSION]: https://www.postgresql.org/docs/current/sql-createextension.html
+    "PostgreSQL Docs: CREATE EXTENSION"
+  [ALTER EXTENSION]: https://www.postgresql.org/docs/current/sql-alterextension.html
+    "PostgreSQL Docs: ALTER EXTENSION"
+  [DROP EXTENSION]: https://www.postgresql.org/docs/current/sql-dropextension.html
+    "PostgreSQL Docs: DROP EXTENSION"
+  [CREATE SERVER]: https://www.postgresql.org/docs/current/sql-createserver.html
+    "PostgreSQL Docs: CREATE SERVER"
+  [ALTER SERVER]: https://www.postgresql.org/docs/current/sql-alterserver.html
+    "PostgreSQL Docs: ALTER SERVER"
+  [DROP SERVER]: https://www.postgresql.org/docs/current/sql-dropserver.html
+    "PostgreSQL Docs: DROP SERVER"
+  [CREATE USER MAPPING]: https://www.postgresql.org/docs/current/sql-createusermapping.html
+    "PostgreSQL Docs: CREATE USER MAPPING"
+  [ALTER USER MAPPING]: https://www.postgresql.org/docs/current/sql-alterusermapping.html
+    "PostgreSQL Docs: ALTER USER MAPPING"
+  [DROP USER MAPPING]: https://www.postgresql.org/docs/current/sql-dropusermapping.html
+    "PostgreSQL Docs: DROP USER MAPPING"
+  [IMPORT FOREIGN SCHEMA]: https://www.postgresql.org/docs/current/sql-importforeignschema.html
+    "PostgreSQL Docs: IMPORT FOREIGN SCHEMA"
+  [table engine]: https://clickhouse.com/docs/engines/table-engines
+    "ClickHouse Docs: Table engines"
+  [AggregateFunction Type]: https://clickhouse.com/docs/sql-reference/data-types/aggregatefunction
+    "ClickHouse Docs: AggregateFunction Type"
+  [SimpleAggregateFunction Type]: https://clickhouse.com/docs/sql-reference/data-types/simpleaggregatefunction
+    "ClickHouse Docs: SimpleAggregateFunction Type"
   [ordered-set aggregate functions]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
   [Parametric aggregate functions]: https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions
   [ClickHouse settings]: https://clickhouse.com/docs/operations/settings/settings

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1,0 +1,638 @@
+pg_clickhouse Tutorial
+======================
+
+## Overview
+
+This tutorial follows the [ClickHouse tutorial] but runs all its queries via
+pg_clickhouse.
+
+## Start ClickHouse
+
+First, create a ClickHouse database if you don't already have one. A quick way
+to start is with the Docker image:
+
+```sh
+docker run -d --name clickhouse -p 8123:8123 -p9000:9000 --ulimit nofile=262144:262144 clickhouse
+docker exec -it clickhouse clickhouse-client
+```
+
+## Create a Table
+
+Let's borrow from the [ClickHouse tutorial] to create a simple database with The New York
+City taxi dataset:
+
+```sql
+CREATE DATABASE taxi;
+CREATE TABLE taxi.trips
+(
+    trip_id UInt32,
+    vendor_id Enum8(
+        '1'      =  1, '2'      =  2, '3'      =  3, '4'      =  4,
+        'CMT'    =  5, 'VTS'    =  6, 'DDS'    =  7, 'B02512' = 10,
+        'B02598' = 11, 'B02617' = 12, 'B02682' = 13, 'B02764' = 14,
+        ''       = 15
+    ),
+    pickup_date Date,
+    pickup_datetime DateTime,
+    dropoff_date Date,
+    dropoff_datetime DateTime,
+    store_and_fwd_flag UInt8,
+    rate_code_id UInt8,
+    pickup_longitude Float64,
+    pickup_latitude Float64,
+    dropoff_longitude Float64,
+    dropoff_latitude Float64,
+    passenger_count UInt8,
+    trip_distance Float64,
+    fare_amount Decimal(10, 2),
+    extra Decimal(10, 2),
+    mta_tax Decimal(10, 2),
+    tip_amount Decimal(10, 2),
+    tolls_amount Decimal(10, 2),
+    ehail_fee Decimal(10, 2),
+    improvement_surcharge Decimal(10, 2),
+    total_amount Decimal(10, 2),
+    payment_type Enum8('UNK' = 0, 'CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4),
+    trip_type UInt8,
+    pickup FixedString(25),
+    dropoff FixedString(25),
+    cab_type Enum8('yellow' = 1, 'green' = 2, 'uber' = 3),
+    pickup_nyct2010_gid Int8,
+    pickup_ctlabel Float32,
+    pickup_borocode Int8,
+    pickup_ct2010 String,
+    pickup_boroct2010 String,
+    pickup_cdeligibil String,
+    pickup_ntacode FixedString(4),
+    pickup_ntaname String,
+    pickup_puma UInt16,
+    dropoff_nyct2010_gid UInt8,
+    dropoff_ctlabel Float32,
+    dropoff_borocode UInt8,
+    dropoff_ct2010 String,
+    dropoff_boroct2010 String,
+    dropoff_cdeligibil String,
+    dropoff_ntacode FixedString(4),
+    dropoff_ntaname String,
+    dropoff_puma UInt16
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(pickup_date)
+ORDER BY pickup_datetime;
+```
+
+## Add the Data Set
+
+And then import the data:
+
+```sql
+INSERT INTO taxi.trips
+SELECT * FROM s3(
+    'https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/trips_{1..2}.gz',
+    'TabSeparatedWithNames', "
+    trip_id UInt32,
+    vendor_id Enum8(
+        '1'      =  1, '2'      =  2, '3'      =  3, '4'      =  4,
+        'CMT'    =  5, 'VTS'    =  6, 'DDS'    =  7, 'B02512' = 10,
+        'B02598' = 11, 'B02617' = 12, 'B02682' = 13, 'B02764' = 14,
+        ''       = 15
+    ),
+    pickup_date Date,
+    pickup_datetime DateTime,
+    dropoff_date Date,
+    dropoff_datetime DateTime,
+    store_and_fwd_flag UInt8,
+    rate_code_id UInt8,
+    pickup_longitude Float64,
+    pickup_latitude Float64,
+    dropoff_longitude Float64,
+    dropoff_latitude Float64,
+    passenger_count UInt8,
+    trip_distance Float64,
+    fare_amount Decimal(10, 2),
+    extra Decimal(10, 2),
+    mta_tax Decimal(10, 2),
+    tip_amount Decimal(10, 2),
+    tolls_amount Decimal(10, 2),
+    ehail_fee Decimal(10, 2),
+    improvement_surcharge Decimal(10, 2),
+    total_amount Decimal(10, 2),
+    payment_type Enum8('UNK' = 0, 'CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4),
+    trip_type UInt8,
+    pickup FixedString(25),
+    dropoff FixedString(25),
+    cab_type Enum8('yellow' = 1, 'green' = 2, 'uber' = 3),
+    pickup_nyct2010_gid Int8,
+    pickup_ctlabel Float32,
+    pickup_borocode Int8,
+    pickup_ct2010 String,
+    pickup_boroct2010 String,
+    pickup_cdeligibil String,
+    pickup_ntacode FixedString(4),
+    pickup_ntaname String,
+    pickup_puma UInt16,
+    dropoff_nyct2010_gid UInt8,
+    dropoff_ctlabel Float32,
+    dropoff_borocode UInt8,
+    dropoff_ct2010 String,
+    dropoff_boroct2010 String,
+    dropoff_cdeligibil String,
+    dropoff_ntacode FixedString(4),
+    dropoff_ntaname String,
+    dropoff_puma UInt16
+") SETTINGS input_format_try_infer_datetimes = 0
+```
+
+Make sure we can query it then quit the client:
+
+```
+SELECT count() FROM taxi.trips;
+quit
+```
+
+### Install pg_clickhouse
+
+Build and install pg_clickhouse from [PGXN] or [GitHub]. Or spin up a
+Docker container using the [pg_clickhouse image], which simply adds
+pg_clickhouse to the Docker [Postgres image]:
+
+```sh
+docker run --name pg_clickhouse -e POSTGRES_PASSWORD=my_pass \
+       -d ghcr.io/clickhouse/pg_clickhouse:18
+```
+
+### Connect pg_clickhouse
+
+Now connect to Postgres and create pg_clickhouse:
+
+```sql
+CREATE EXTENSION pg_clickhouse;
+```
+
+Create a foreign server using the host name, port, and database for your
+ClickHouse database.
+
+```sql
+CREATE SERVER taxi_srv FOREIGN DATA WRAPPER clickhouse_fdw
+       OPTIONS(driver 'binary', host 'localhost', dbname 'taxi');
+```
+
+Here we've elected to use the binary driver, which uses the ClickHouse binary
+protocol. You can also use the "http" driver, which uses the HTTP interface.
+
+Next, map a PostgreSQLu user to a ClickHouse user. The simplest way to do so
+is just to map the current PostgreSQL user to a remote user for the foreign
+server:
+
+```sql
+CREATE USER MAPPING FOR CURRENT_USER SERVER taxi_srv
+       OPTIONS (user 'default');
+```
+
+You can also specify a `password` option.
+
+Now, add the taxi table, just import it all of the tables from the remote
+ClickHouse database into a Postgres schema:
+
+```sql
+CREATE SCHEMA taxi;
+IMPORT FOREIGN SCHEMA taxi FROM SERVER taxi_srv INTO taxi;
+```
+
+And now the table should be imported: In [psql], use `\det+` to see it:
+
+```pgsql
+taxi=# \det+ taxi.*
+                                       List of foreign tables
+ Schema | Table |  Server  |                        FDW options                        | Description 
+--------+-------+----------+-----------------------------------------------------------+-------------
+ taxi   | trips | taxi_srv | (database 'taxi', table_name 'trips', engine 'MergeTree') | [null]
+(1 row)
+```
+
+Success! Use `\d` to show all the columns:
+
+```pgsql
+taxi=# \d taxi.trips
+                                     Foreign table "taxi.trips"
+        Column         |            Type             | Collation | Nullable | Default | FDW options 
+-----------------------+-----------------------------+-----------+----------+---------+-------------
+ trip_id               | bigint                      |           | not null |         | 
+ vendor_id             | text                        |           | not null |         | 
+ pickup_date           | date                        |           | not null |         | 
+ pickup_datetime       | timestamp without time zone |           | not null |         | 
+ dropoff_date          | date                        |           | not null |         | 
+ dropoff_datetime      | timestamp without time zone |           | not null |         | 
+ store_and_fwd_flag    | smallint                    |           | not null |         | 
+ rate_code_id          | smallint                    |           | not null |         | 
+ pickup_longitude      | double precision            |           | not null |         | 
+ pickup_latitude       | double precision            |           | not null |         | 
+ dropoff_longitude     | double precision            |           | not null |         | 
+ dropoff_latitude      | double precision            |           | not null |         | 
+ passenger_count       | smallint                    |           | not null |         | 
+ trip_distance         | double precision            |           | not null |         | 
+ fare_amount           | numeric(10,2)               |           | not null |         | 
+ extra                 | numeric(10,2)               |           | not null |         | 
+ mta_tax               | numeric(10,2)               |           | not null |         | 
+ tip_amount            | numeric(10,2)               |           | not null |         | 
+ tolls_amount          | numeric(10,2)               |           | not null |         | 
+ ehail_fee             | numeric(10,2)               |           | not null |         | 
+ improvement_surcharge | numeric(10,2)               |           | not null |         | 
+ total_amount          | numeric(10,2)               |           | not null |         | 
+ payment_type          | text                        |           | not null |         | 
+ trip_type             | smallint                    |           | not null |         | 
+ pickup                | character varying(25)       |           | not null |         | 
+ dropoff               | character varying(25)       |           | not null |         | 
+ cab_type              | text                        |           | not null |         | 
+ pickup_nyct2010_gid   | smallint                    |           | not null |         | 
+ pickup_ctlabel        | real                        |           | not null |         | 
+ pickup_borocode       | smallint                    |           | not null |         | 
+ pickup_ct2010         | text                        |           | not null |         | 
+ pickup_boroct2010     | text                        |           | not null |         | 
+ pickup_cdeligibil     | text                        |           | not null |         | 
+ pickup_ntacode        | character varying(4)        |           | not null |         | 
+ pickup_ntaname        | text                        |           | not null |         | 
+ pickup_puma           | integer                     |           | not null |         | 
+ dropoff_nyct2010_gid  | smallint                    |           | not null |         | 
+ dropoff_ctlabel       | real                        |           | not null |         | 
+ dropoff_borocode      | smallint                    |           | not null |         | 
+ dropoff_ct2010        | text                        |           | not null |         | 
+ dropoff_boroct2010    | text                        |           | not null |         | 
+ dropoff_cdeligibil    | text                        |           | not null |         | 
+ dropoff_ntacode       | character varying(4)        |           | not null |         | 
+ dropoff_ntaname       | text                        |           | not null |         | 
+ dropoff_puma          | integer                     |           | not null |         | 
+Server: taxi_srv
+FDW options: (database 'taxi', table_name 'trips', engine 'MergeTree')
+```
+
+Now query the table:
+
+ ```pgsql
+ SELECT count(*) FROM taxi.trips;
+   count  
+ ---------
+  1999657
+ (1 row)
+ ```
+
+ Note how quickly the query executed. pg_clickhouse pushes down the entire
+ query, including the `COUNT()` aggregate, so it runs on ClickHouse and only
+ returns the single row to Postgres. Use [EXPLAIN] to see it:
+ 
+ ```pgsql
+ EXPLAIN select count(*) from taxi.trips;
+                    QUERY PLAN                    
+ -------------------------------------------------
+  Foreign Scan  (cost=1.00..-0.90 rows=1 width=8)
+    Relations: Aggregate on (trips)
+ (2 rows)
+ ```
+ 
+ Note that "Foreign Scan" appears at the root of the plan, meaning that the
+ entire query was pushed down to ClickHouse.
+
+## Analyze the data
+
+Run some queries to analyze the data. Explore the following examples or try
+your own SQL query.
+
+*   Calculate the average tip amount:
+
+    ```sql
+    taxi=# \timing
+    Timing is on.
+    taxi=# SELECT round(avg(tip_amount), 2) FROM taxi.trips;
+     round 
+    -------
+      1.68
+    (1 row)
+
+    Time: 9.438 ms
+    ```
+
+*   Calculate the average cost based on the number of passengers:
+
+    ```pgsql
+    taxi=# SELECT
+            passenger_count,
+            avg(total_amount)::NUMERIC(10, 2) AS average_total_amount
+        FROM taxi.trips
+        GROUP BY passenger_count;
+     passenger_count | average_total_amount 
+    -----------------+----------------------
+                   0 |                22.68
+                   1 |                15.96
+                   2 |                17.14
+                   3 |                16.75
+                   4 |                17.32
+                   5 |                16.34
+                   6 |                16.03
+                   7 |                59.79
+                   8 |                36.40
+                   9 |                 9.79
+    (10 rows)
+    
+    Time: 27.266 ms
+    ```
+
+*   Calculate the daily number of pickups per neighborhood:
+
+    ```pgsql
+    taxi=# SELECT
+        pickup_date,
+        pickup_ntaname,
+        SUM(1) AS number_of_trips
+    FROM taxi.trips
+    GROUP BY pickup_date, pickup_ntaname
+    ORDER BY pickup_date ASC LIMIT 10;
+     pickup_date |         pickup_ntaname         | number_of_trips 
+    -------------+--------------------------------+-----------------
+     2015-07-01  | Williamsburg                   |               1
+     2015-07-01  | park-cemetery-etc-Queens       |               6
+     2015-07-01  | Maspeth                        |               1
+     2015-07-01  | Stuyvesant Town-Cooper Village |              44
+     2015-07-01  | Rego Park                      |               1
+     2015-07-01  | Greenpoint                     |               7
+     2015-07-01  | Highbridge                     |               1
+     2015-07-01  | Briarwood-Jamaica Hills        |               3
+     2015-07-01  | Airport                        |             550
+     2015-07-01  | East Harlem North              |              32
+    (10 rows)
+    
+    Time: 30.978 ms
+    ```
+
+*   Calculate the length of each trip in minutes, then group the results by
+    trip length:
+
+    ```pgsql
+    taxi=# SELECT
+        avg(tip_amount) AS avg_tip,
+        avg(fare_amount) AS avg_fare,
+        avg(passenger_count) AS avg_passenger,
+        count(*) AS count,
+        round((date_part('epoch', dropoff_datetime) - date_part('epoch', pickup_datetime)) / 60) as trip_minutes
+    FROM taxi.trips
+    WHERE round((date_part('epoch', dropoff_datetime) - date_part('epoch', pickup_datetime)) / 60) > 0
+    GROUP BY trip_minutes
+    ORDER BY trip_minutes DESC
+    LIMIT 5;
+          avg_tip      |     avg_fare     |  avg_passenger   | count | trip_minutes 
+    -------------------+------------------+------------------+-------+--------------
+                  1.96 |                8 |                1 |     1 |        27512
+                     0 |               12 |                2 |     1 |        27500
+     0.562727272727273 | 17.4545454545455 | 2.45454545454545 |    11 |         1440
+     0.716564885496183 | 14.2786259541985 | 1.94656488549618 |   131 |         1439
+      1.00945205479452 | 12.8787671232877 | 1.98630136986301 |   146 |         1438
+    (5 rows)
+    
+    Time: 45.477 ms
+    ```
+
+*   Show the number of pickups in each neighborhood broken down by hour of the day:
+
+    ```pgsql
+    taxi=# SELECT
+        pickup_ntaname,
+        date_part('hour', pickup_datetime) as pickup_hour,
+        SUM(1) AS pickups
+    FROM taxi.trips
+    WHERE pickup_ntaname != ''
+    GROUP BY pickup_ntaname, pickup_hour
+    ORDER BY pickup_ntaname, date_part('hour', pickup_datetime)
+    LIMIT 5;
+     pickup_ntaname | pickup_hour | pickups 
+    ----------------+-------------+---------
+     Airport        |           0 |    3509
+     Airport        |           1 |    1184
+     Airport        |           2 |     401
+     Airport        |           3 |     152
+     Airport        |           4 |     213
+    (5 rows)
+    
+    Time: 36.895 ms
+    ```
+
+*   Retrieve rides to LaGuardia or JFK airports:
+
+    ```pgsql
+    taxi=# SELECT
+        pickup_datetime,
+        dropoff_datetime,
+        total_amount,
+        pickup_nyct2010_gid,
+        dropoff_nyct2010_gid,
+        CASE
+            WHEN dropoff_nyct2010_gid = 138 THEN 'LGA'
+            WHEN dropoff_nyct2010_gid = 132 THEN 'JFK'
+        END AS airport_code,
+        EXTRACT(YEAR FROM pickup_datetime) AS year,
+        EXTRACT(DAY FROM pickup_datetime) AS day,
+        EXTRACT(HOUR FROM pickup_datetime) AS hour
+    FROM taxi.trips
+    WHERE dropoff_nyct2010_gid IN (132, 138)
+    ORDER BY pickup_datetime
+    LIMIT 5;
+       pickup_datetime   |  dropoff_datetime   | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour 
+    ---------------------+---------------------+--------------+---------------------+----------------------+--------------+------+-----+------
+     2015-07-01 00:04:14 | 2015-07-01 00:15:29 |        13.30 |                 -34 |                  132 | JFK          | 2015 |   1 |    0
+     2015-07-01 00:09:42 | 2015-07-01 00:12:55 |         6.80 |                  50 |                  138 | LGA          | 2015 |   1 |    0
+     2015-07-01 00:23:04 | 2015-07-01 00:24:39 |         4.80 |                -125 |                  132 | JFK          | 2015 |   1 |    0
+     2015-07-01 00:27:51 | 2015-07-01 00:39:02 |        14.72 |                -101 |                  138 | LGA          | 2015 |   1 |    0
+     2015-07-01 00:32:03 | 2015-07-01 00:55:39 |        39.34 |                  48 |                  138 | LGA          | 2015 |   1 |    0
+    (5 rows)
+    
+    Time: 17.450 ms
+    ```
+
+## Create a Dictionary
+
+Create a dictionary associated with a table in your ClickHouse service. The
+table and dictionary are based on a CSV file that contains a row for each
+neighborhood in New York City.
+
+The neighborhoods are mapped to the names of the five New York City boroughs
+(Bronx, Brooklyn, Manhattan, Queens and Staten Island), as well as Newark
+Airport (EWR).
+
+Here's an excerpt from the CSV file you're using in table format. The
+`LocationID` column in the file maps to the `pickup_nyct2010_gid` and
+`dropoff_nyct2010_gid` columns in your trips table:
+
+  | LocationID | Borough       |  Zone                   | service_zone |
+  | ---------: | ------------- | ----------------------- | ------------ |
+  |          1 | EWR           | Newark Airport          | EWR          |
+  |          2 | Queens        | Jamaica Bay             | Boro Zone    |
+  |          3 | Bronx         | Allerton/Pelham Gardens | Boro Zone    |
+  |          4 | Manhattan     | Alphabet City           | Yellow Zone  |
+  |          5 | Staten Island | Arden Heights           | Boro Zone    |
+
+
+1.  Still in Postgres, use the `clickhouse_raw_query` function to create a
+    ClickHouse [dictionary] named `taxi_zone_dictionary` and populate the
+    dictionary from the CSV file in S3:
+
+    ```sql
+    SELECT clickhouse_raw_query($$
+        CREATE DICTIONARY taxi.taxi_zone_dictionary (
+            LocationID Int64 DEFAULT 0,
+            Borough String,
+            zone String,
+            service_zone String
+        )
+        PRIMARY KEY LocationID
+        SOURCE(HTTP(URL 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/taxi_zone_lookup.csv' FORMAT 'CSVWithNames'))
+        LIFETIME(MIN 0 MAX 0)
+        LAYOUT(HASHED_ARRAY())
+    $$, 'host=localhost dbname=taxi');
+    ```
+    
+    > [!NOTE]
+    > Setting `LIFETIME` to 0 disables automatic updates to avoid unnecessary
+    > traffic to our S3 bucket. In other cases, you might configure it
+    > differently. For details, see [Refreshing dictionary data using
+    > LIFETIME](/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime).
+
+    2.  Now import it:
+    
+    ```sql
+    IMPORT FOREIGN SCHEMA taxi LIMIT TO (taxi_zone_dictionary)
+    FROM SERVER taxi_srv INTO taxi;
+    ```
+    
+    3.  Confirm we can query it:
+    
+    ```pgsql
+    taxi=# SELECT * FROM taxi.taxi_zone_dictionary limit 3;
+     LocationID |  Borough  |                     Zone                      | service_zone 
+    ------------+-----------+-----------------------------------------------+--------------
+             77 | Brooklyn  | East New York/Pennsylvania Avenue             | Boro Zone
+            106 | Brooklyn  | Gowanus                                       | Boro Zone
+            103 | Manhattan | Governor's Island/Ellis Island/Liberty Island | Yellow Zone
+    (3 rows)
+    ```
+    
+    4.  Excellent. Now use the `dictGet` function unction to retrieve a
+        borough's name in a query. For this query sums up the number of taxi
+        rides per borough that end at either the LaGuardia or JFK airport:
+    
+    ```pgsql
+    taxi=# SELECT
+            count(1) AS total,
+            COALESCE(NULLIF(dictGet(
+                'taxi.taxi_zone_dictionary', 'Borough',
+                toUInt64(pickup_nyct2010_gid)
+            ), ''), 'Unknown') AS borough_name
+        FROM taxi.trips
+        WHERE dropoff_nyct2010_gid = 132 OR dropoff_nyct2010_gid = 138
+        GROUP BY borough_name
+        ORDER BY total DESC;
+     total | borough_name  
+    -------+---------------
+     23683 | Unknown
+      7053 | Manhattan
+      6828 | Brooklyn
+      4458 | Queens
+      2670 | Bronx
+       554 | Staten Island
+        53 | EWR
+    (7 rows)
+    
+    Time: 66.245 ms
+    ```
+
+    This query sums up the number of taxi rides per borough that end at either
+    the LaGuardia or JFK airport. Notice there are quite a few trips where the
+    pickup neighborhood is unknown.
+
+## Perform a join
+
+Write some queries that join the `taxi_zone_dictionary` with your `trips`
+table.
+
+1.  Start with a simple `JOIN` that acts similarly to the previous airport
+    query above:
+
+    ```sql
+    taxi=# SELECT
+        count(1) AS total,
+        "Borough"
+    FROM taxi.trips
+    JOIN taxi.taxi_zone_dictionary
+      ON trips.pickup_nyct2010_gid = toUInt64(taxi.taxi_zone_dictionary."LocationID")
+    WHERE pickup_nyct2010_gid > 0
+      AND dropoff_nyct2010_gid IN (132, 138)
+    GROUP BY "Borough"
+    ORDER BY total DESC;
+     total | borough_name  
+    -------+---------------
+      7053 | Manhattan
+      6828 | Brooklyn
+      4458 | Queens
+      2670 | Bronx
+       554 | Staten Island
+        53 | EWR
+    (6 rows)
+
+    Time: 48.449 ms
+    ```
+
+    > [!NOTE]
+    > Notice the output of the above `JOIN` query is the same as the `dictGet`
+    > query above, (except that the `Unknown` values are not included). Behind
+    > the scenes, ClickHouse is actually calling the `dictGet` function for
+    > the `taxi_zone_dictionary` dictionary, but the `JOIN` syntax is more
+    > familiar for SQL developers.
+
+    ```pgsql
+    taxi=# explain SELECT
+            count(1) AS total,
+            "Borough"
+        FROM taxi.trips
+        JOIN taxi.taxi_zone_dictionary
+          ON trips.pickup_nyct2010_gid = toUInt64(taxi.taxi_zone_dictionary."LocationID")
+        WHERE pickup_nyct2010_gid > 0
+          AND dropoff_nyct2010_gid IN (132, 138)
+        GROUP BY "Borough"
+        ORDER BY total DESC;
+                                  QUERY PLAN                               
+    -----------------------------------------------------------------------
+     Foreign Scan  (cost=1.00..5.10 rows=1000 width=40)
+       Relations: Aggregate on ((trips) INNER JOIN (taxi_zone_dictionary))
+    (2 rows)
+    Time: 2.012 ms
+    ```
+
+2.  This query returns rows for the the 1000 trips with the highest tip
+    amount, then performs an inner join of each row with the dictionary:
+
+    ```sql
+    taxi=# SELECT *
+    FROM taxi.trips
+    JOIN taxi.taxi_zone_dictionary
+        ON trips.dropoff_nyct2010_gid = taxi.taxi_zone_dictionary."LocationID"
+    WHERE tip_amount > 0
+    ORDER BY tip_amount DESC
+    LIMIT 1000;
+    ```
+
+> [!NOTE]
+> Generally, we avoid using `SELECT *` in PostgreSQL and ClickHouse. You
+> should only retrieve the columns you actually need.
+
+  [tutorial]: https://clickhouse.com/docs/tutorial "ClickHouse Advanced Tutorial"
+  [psql]: https://www.postgresql.org/docs/current/app-psql.html
+    "PostgreSQL Client Applications: psql"
+  [EXPLAIN]: https://www.postgresql.org/docs/current/sql-explain.html
+    "SQL Commands: EXPLAIN"
+  [dictionary]: https://clickhouse.com/docs/sql-reference/dictionaries
+  [PGXN]: https://pgxn.org/dist/pg_clickhouse "pg_clickhouse on PGXN"
+  [GitHub]: https://github.com/ClickHouse/pg_clickhouse/releases
+    "pg_clickhouse Releases on GitHub"
+  [pg_clickhouse image]: https://github.com/ClickHouse/pg_clickhouse/pkgs/container/pg_clickhouse
+    "pg_clickhouse OCI Image on GitHub"
+  [Postgres image]: https://hub.docker.com/_/postgres
+    "Postgres OCI Image on Docker Hub"
+  [Refreshing dictionary data using LIFETIME]: https://clickhouse.com/docs/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime
+    "ClickHouse Doc: Refreshing dictionary data using LIFETIME"

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -761,6 +761,36 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 	}
 }
 
+/*
+ * Query to generate table for doc/pg_clickhouse.md. Keep in sync with
+ * str_types_map below. On change, re-run and paste the output into
+ * doc/pg_clickhouse.md.
+
+	SELECT * FROM ( VALUES
+		('Bool',     'boolean',          ''),
+		('Int8',     'smallint',         ''),
+		('UInt8',    'smallint',         ''),
+		('Int16',    'smallint',         ''),
+		('UInt16',   'integer',          ''),
+		('Int32',    'integer',          ''),
+		('UInt32',   'bigint',           ''),
+		('Int64',    'bigint',           ''),
+		('UInt64',   'bigint',           'Errors on values > BIGINT max'),
+		('Float32',  'real',             ''),
+		('Float64',  'double precision', ''),
+		('Decimal',  'numeric',          ''),
+		('String',   'text',             ''),
+		('DateTime', 'timestamp',        ''),
+		('Date',     'date',             ''),
+		('UUID',     'uuid',             ''),
+		('IPv4',     'inet',             ''),
+		('IPv6',     'inet',             ''),
+		('JSON',     'json',             'HTTP engine only')
+	) AS v("ClickHouse", "PostgreSQL", "Notes")
+	ORDER BY "ClickHouse";
+
+*/
+
 static char *str_types_map[][2] = {
 	{"Bool", "BOOLEAN"},
 	{"Int8", "INT2"},
@@ -770,7 +800,7 @@ static char *str_types_map[][2] = {
 	{"Int32", "INT4"},
 	{"UInt32", "INT8"},
 	{"Int64", "INT8"},
-	{"UInt64", "INT8"},			/* overflow risk */
+	{"UInt64", "INT8"},
 	{"Float32", "REAL"},
 	{"Float64", "DOUBLE PRECISION"},
 	{"Decimal", "NUMERIC"},


### PR DESCRIPTION
Flesh out some details in the README and base documentation and add a tutorial based on the ClickHouse advanced tutorial.

README.md:

*   Add likely Yum dependencies
*   Link to other docs
*   Add "Getting Started" section
*   Add table with TPC-H query results
*   Comment out the DSO instructions until support restored
*   Add "Road Map"
*   Rejigger Authors and Copyright, with thanks to @ildus for the history

doc/pg_clickhouse.md:

*   Add basic usage example
*   Add "Getting Started" section
*   Link to other docs
*   Add table of supported data types
*   Document foreign data wrapper SQL commands and supported options
*   Document `dbname` parameter to `clickhouse_raw_query()`
*   Document `cast()` pushdown
*   Add multi-line `pg_clickhouse.session_settings` example
*   Rejigger Authors and Copyright

Also: Simplify the handling of the OS and architecture in the `Makefile`.