### PR TITLE
Add LEFT SEMI JOIN pushdown for EXISTS subqueries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ _build/
 /src/fdw.c
 /sql/*--*.sql
 !/sql/*--*--*.sql
+compile_commands.json
+.envrc
+.env
+.cache/
+log/

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -409,6 +409,11 @@ clickhouseGetForeignRelSize(PlannerInfo * root,
 	fpinfo->rel_startup_cost = -1;
 	fpinfo->rel_total_cost = -1;
 
+	/* Make base scans more expensive than join pushdowns */
+	fpinfo->rows = baserel->rows;
+	fpinfo->startup_cost = 10.0;
+	fpinfo->total_cost = 10.0 + baserel->rows * 0.01;
+
 	/*
 	 * Set the name of relation in fpinfo, while we are constructing it here.
 	 * It will be used to build the string describing the join relation in
@@ -1352,10 +1357,11 @@ static void
 estimate_path_cost_size(double *p_rows, int *p_width,
 						Cost * p_startup_cost, Cost * p_total_cost, double coef)
 {
-	*p_rows = 1;
-	*p_width = 1;
+	/* Make pushdown paths attractive to the planner */
+	*p_rows = 1000;
+	*p_width = 32;
 	*p_startup_cost = 1.0;
-	*p_total_cost = -1 + coef;
+	*p_total_cost = 5.0 + coef;
 }
 
 /*
@@ -1550,6 +1556,43 @@ extract_join_equals(List * conds, List * *to)
 }
 
 /*
+ * Check if reltarget is safe for semi-join pushdown. Returns false if the
+ * target references columns from the inner relation that aren't in outer
+ * relation.
+ */
+static bool
+semijoin_target_ok(PlannerInfo * root, RelOptInfo * joinrel,
+				   RelOptInfo * outerrel, RelOptInfo * innerrel)
+{
+	List	   *vars;
+	ListCell   *lc;
+	bool		ok = true;
+
+	vars = pull_var_clause((Node *) joinrel->reltarget->exprs,
+						   PVC_RECURSE_AGGREGATES |
+						   PVC_RECURSE_WINDOWFUNCS |
+						   PVC_INCLUDE_PLACEHOLDERS);
+
+	foreach(lc, vars)
+	{
+		Var		   *var = (Var *) lfirst(lc);
+
+		if (!IsA(var, Var))
+			continue;
+
+		if (bms_is_member(var->varno, innerrel->relids) &&
+			!bms_is_member(var->varno, outerrel->relids))
+		{
+			ok = false;
+			break;
+		}
+	}
+
+	list_free(vars);
+	return ok;
+}
+
+/*
  * Assess whether the join between inner and outer relations can be pushed down
  * to the foreign server. As a side effect, save information we obtain in this
  * function to CHFdwRelationInfo passed in.
@@ -1566,15 +1609,18 @@ foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel, JoinType jointype,
 	List	   *joinclauses;
 
 	/*
-	 * We support pushing down INNER, LEFT, RIGHT and FULL OUTER joins.
-	 * Constructing queries representing SEMI and ANTI joins is hard, hence
-	 * not considered right now.
+	 * We support pushing down INNER, LEFT, RIGHT, FULL OUTER and SEMI joins.
+	 * ANTI joins are not supported.
 	 */
 	if (jointype != JOIN_INNER && jointype != JOIN_LEFT &&
-		jointype != JOIN_RIGHT && jointype != JOIN_FULL)
-	{
+		jointype != JOIN_RIGHT && jointype != JOIN_FULL &&
+		jointype != JOIN_SEMI)
 		return false;
-	}
+
+	/* Semi-join target can only reference the outer relation */
+	if (jointype == JOIN_SEMI &&
+		!semijoin_target_ok(root, joinrel, outerrel, innerrel))
+		return false;
 
 	/*
 	 * If either of the joining relations is marked as unsafe to pushdown, the
@@ -1744,6 +1790,21 @@ foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel, JoinType jointype,
 											   list_copy(fpinfo_i->remote_conds));
 			break;
 
+		case JOIN_SEMI:
+
+			/*
+			 * For semi-join, inner's conditions go to joinclauses (ON),
+			 * outer's conditions go to remote_conds (WHERE). Extract join key
+			 * equalities to joinclauses for the ON clause.
+			 */
+			fpinfo->joinclauses = list_concat(fpinfo->joinclauses,
+											  list_copy(fpinfo_i->remote_conds));
+			fpinfo->remote_conds = list_concat(fpinfo->remote_conds,
+											   list_copy(fpinfo_o->remote_conds));
+			fpinfo->remote_conds = extract_join_equals(fpinfo->remote_conds,
+													   &fpinfo->joinclauses);
+			break;
+
 		case JOIN_FULL:
 
 			/*
@@ -1774,6 +1835,17 @@ foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel, JoinType jointype,
 			/* Should not happen, we have just checked this above */
 			elog(ERROR, "unsupported join type %d", jointype);
 	}
+
+	/*
+	 * ClickHouse requires SEMI JOINs to have an ON clause with join
+	 * conditions. Reject uncorrelated EXISTS subqueries that have no join
+	 * keys.
+	 *
+	 * XXX Change to use ClickHouse EXISTS in this case?
+	 * https://clickhouse.com/docs/sql-reference/operators/exists
+	 */
+	if (jointype == JOIN_SEMI && fpinfo->joinclauses == NIL)
+		return false;
 
 	/* Mark that this join can be pushed down safely */
 	fpinfo->pushdown_safe = true;

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -294,15 +294,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=8)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=8)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=8)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -156,7 +156,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..-0.50 rows=1 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -353,15 +353,13 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 (4 rows)
 
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Limit  (cost=-0.99..-0.98 rows=1 width=1)
-   ->  Unique  (cost=-0.99..-0.98 rows=1 width=1)
-         ->  Sort  (cost=-0.99..-0.98 rows=1 width=1)
-               Sort Key: t1.c1, t2.c1
-               ->  Foreign Scan  (cost=1.00..-1.00 rows=1 width=1)
-                     Relations: (ft2 t1) LEFT JOIN (ft1 t2)
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Limit  (cost=1.00..1.09 rows=10 width=32)
+   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+               Relations: (ft2 t1) LEFT JOIN (ft1 t2)
+(4 rows)
 
 SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
  c1 | c1 

--- a/test/expected/import_schema.out
+++ b/test/expected/import_schema.out
@@ -640,18 +640,18 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) 
 
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on clickhouse.custom_option  (cost=0.00..0.00 rows=0 width=8)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on clickhouse.custom_option  (cost=10.00..20.00 rows=1000 width=8)
    Output: a
    Remote SQL: SELECT a FROM import_test_2.custom_option
 (3 rows)
 
 ALTER FOREIGN TABLE clickhouse.custom_option OPTIONS (DROP database);
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on clickhouse.custom_option  (cost=0.00..0.00 rows=0 width=8)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on clickhouse.custom_option  (cost=10.00..20.00 rows=1000 width=8)
    Output: a
    Remote SQL: SELECT a FROM import_test.custom_option
 (3 rows)

--- a/test/expected/import_schema_1.out
+++ b/test/expected/import_schema_1.out
@@ -540,18 +540,18 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) 
 
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on clickhouse.custom_option  (cost=0.00..0.00 rows=0 width=8)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on clickhouse.custom_option  (cost=10.00..20.00 rows=1000 width=8)
    Output: a
    Remote SQL: SELECT a FROM import_test_2.custom_option
 (3 rows)
 
 ALTER FOREIGN TABLE clickhouse.custom_option OPTIONS (DROP database);
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on clickhouse.custom_option  (cost=0.00..0.00 rows=0 width=8)
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on clickhouse.custom_option  (cost=10.00..20.00 rows=1000 width=8)
    Output: a
    Remote SQL: SELECT a FROM import_test.custom_option
 (3 rows)

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -113,3 +113,27 @@ json.sql
  25.8+      | json.out
  24.8-25.3  | json_1.out
  22-24.3    | json_2.out
+
+subquery_pushdown.sql
+---------------------
+
+ Postgres | File
+----------|-------------------------
+ 18       | subquery_pushdown.out
+ 13-17    | subquery_pushdown_1.out
+
+ ClickHouse | File
+------------|-----------------------
+ 22-25      | subquery_pushdown.out
+
+where_sub.sql
+-------------
+
+ Postgres | File
+----------|-----------------
+ 18       | where_sub.out
+ 13-17    | where_sub_1.out
+
+ ClickHouse | File
+------------|-----------------
+ 22-25      | where_sub.out

--- a/test/expected/subquery_pushdown.out
+++ b/test/expected/subquery_pushdown.out
@@ -1,0 +1,174 @@
+-- Test for TPC-H Q4 style EXISTS subquery pushdown
+-- TPC-H schema reference: https://raw.githubusercontent.com/Vonng/pgtpc/refs/heads/master/tpch/ddl/schema.ddl
+SET datestyle = 'ISO';
+CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create TPC-H orders table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
+	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
+	ENGINE = MergeTree ORDER BY o_orderkey;
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create TPC-H lineitem table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
+	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
+	 l_receiptdate Date, l_shipinstruct FixedString(25), l_shipmode FixedString(10), l_comment String)
+	ENGINE = MergeTree ORDER BY (l_orderkey, l_linenumber);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert sample orders data
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.orders VALUES
+	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
+	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
+	(3, 102, 'O', 3000.00, '1993-08-01', '1-URGENT', 'Clerk#000000003', 0, 'order3'),
+	(4, 103, 'O', 4000.00, '1993-08-15', '3-MEDIUM', 'Clerk#000000004', 0, 'order4'),
+	(5, 104, 'O', 5000.00, '1993-06-01', '1-URGENT', 'Clerk#000000005', 0, 'order5'),
+	(6, 105, 'O', 6000.00, '1993-09-15', '2-HIGH', 'Clerk#000000006', 0, 'order6'),
+	(7, 106, 'O', 7000.00, '1993-07-25', '4-NOT SPECIFIED', 'Clerk#000000007', 0, 'order7'),
+	(8, 107, 'O', 8000.00, '1993-08-20', '5-LOW', 'Clerk#000000008', 0, 'order8');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.lineitem VALUES
+	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
+	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
+	(3, 30, 3, 1, 30.00, 300.00, 0.10, 0.05, 'N', 'O', '1993-08-05', '1993-08-10', '1993-08-08', 'DELIVER IN PERSON', 'SHIP', 'item3'),
+	(4, 40, 4, 1, 40.00, 400.00, 0.10, 0.05, 'N', 'O', '1993-08-20', '1993-08-15', '1993-08-25', 'DELIVER IN PERSON', 'RAIL', 'item4'),
+	(7, 70, 7, 1, 70.00, 700.00, 0.10, 0.05, 'N', 'O', '1993-07-30', '1993-07-25', '1993-08-05', 'DELIVER IN PERSON', 'AIR', 'item7'),
+	(8, 80, 8, 1, 80.00, 800.00, 0.10, 0.05, 'N', 'O', '1993-08-25', '1993-08-30', '1993-08-28', 'DELIVER IN PERSON', 'TRUCK', 'item8');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create foreign tables (matching TPC-H schema types)
+CREATE SCHEMA subquery_test;
+IMPORT FOREIGN SCHEMA "subquery_test" FROM SERVER subquery_loopback INTO subquery_test;
+-- Disable hash and merge joins to get consistent explain output
+SET SESSION enable_hashjoin TO false;
+SET SESSION enable_mergejoin TO false;
+SET SESSION search_path = subquery_test,public;
+-- ===================================================================
+-- Test SEMI-JOIN / EXISTS subquery pushdown (TPC-H Q4 style query)
+-- ===================================================================
+-- First, show the explain plan - this should show SEMI JOIN being pushed down
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.o_orderpriority, (count(*))
+   Relations: Aggregate on ((orders) LEFT SEMI JOIN (lineitem))
+   Remote SQL: SELECT r1.o_orderpriority, count(*) FROM  subquery_test.orders r1 LEFT SEMI JOIN subquery_test.lineitem r3 ON (((r3.l_commitdate < r3.l_receiptdate)) AND ((r1.o_orderkey = r3.l_orderkey))) WHERE ((r1.o_orderdate >= '1993-07-01')) AND ((r1.o_orderdate < '1993-10-01')) GROUP BY r1.o_orderpriority ORDER BY r1.o_orderpriority ASC NULLS LAST
+(4 rows)
+
+-- Execute the actual query
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+ o_orderpriority | order_count 
+-----------------+-------------
+ 1-URGENT        |           1
+ 2-HIGH          |           1
+ 3-MEDIUM        |           1
+ 4-NOT SPECIFIED |           1
+(4 rows)
+
+-- Simpler EXISTS test without aggregation
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.o_orderkey, orders.o_orderpriority
+   Relations: (orders) LEFT SEMI JOIN (lineitem)
+   Remote SQL: SELECT r1.o_orderkey, r1.o_orderpriority FROM  subquery_test.orders r1 LEFT SEMI JOIN subquery_test.lineitem r2 ON (((r1.o_orderkey = r2.l_orderkey))) ORDER BY r1.o_orderkey ASC NULLS LAST
+(4 rows)
+
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+ o_orderkey | o_orderpriority 
+------------+-----------------
+          1 | 1-URGENT
+          2 | 2-HIGH
+          3 | 1-URGENT
+          4 | 3-MEDIUM
+          7 | 4-NOT SPECIFIED
+          8 | 5-LOW
+(6 rows)
+
+-- Cleanup
+SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+DROP SERVER subquery_loopback CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table lineitem
+drop cascades to foreign table orders

--- a/test/expected/subquery_pushdown_1.out
+++ b/test/expected/subquery_pushdown_1.out
@@ -1,0 +1,174 @@
+-- Test for TPC-H Q4 style EXISTS subquery pushdown
+-- TPC-H schema reference: https://raw.githubusercontent.com/Vonng/pgtpc/refs/heads/master/tpch/ddl/schema.ddl
+SET datestyle = 'ISO';
+CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create TPC-H orders table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
+	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
+	ENGINE = MergeTree ORDER BY o_orderkey;
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create TPC-H lineitem table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
+	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
+	 l_receiptdate Date, l_shipinstruct FixedString(25), l_shipmode FixedString(10), l_comment String)
+	ENGINE = MergeTree ORDER BY (l_orderkey, l_linenumber);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert sample orders data
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.orders VALUES
+	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
+	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
+	(3, 102, 'O', 3000.00, '1993-08-01', '1-URGENT', 'Clerk#000000003', 0, 'order3'),
+	(4, 103, 'O', 4000.00, '1993-08-15', '3-MEDIUM', 'Clerk#000000004', 0, 'order4'),
+	(5, 104, 'O', 5000.00, '1993-06-01', '1-URGENT', 'Clerk#000000005', 0, 'order5'),
+	(6, 105, 'O', 6000.00, '1993-09-15', '2-HIGH', 'Clerk#000000006', 0, 'order6'),
+	(7, 106, 'O', 7000.00, '1993-07-25', '4-NOT SPECIFIED', 'Clerk#000000007', 0, 'order7'),
+	(8, 107, 'O', 8000.00, '1993-08-20', '5-LOW', 'Clerk#000000008', 0, 'order8');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.lineitem VALUES
+	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
+	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
+	(3, 30, 3, 1, 30.00, 300.00, 0.10, 0.05, 'N', 'O', '1993-08-05', '1993-08-10', '1993-08-08', 'DELIVER IN PERSON', 'SHIP', 'item3'),
+	(4, 40, 4, 1, 40.00, 400.00, 0.10, 0.05, 'N', 'O', '1993-08-20', '1993-08-15', '1993-08-25', 'DELIVER IN PERSON', 'RAIL', 'item4'),
+	(7, 70, 7, 1, 70.00, 700.00, 0.10, 0.05, 'N', 'O', '1993-07-30', '1993-07-25', '1993-08-05', 'DELIVER IN PERSON', 'AIR', 'item7'),
+	(8, 80, 8, 1, 80.00, 800.00, 0.10, 0.05, 'N', 'O', '1993-08-25', '1993-08-30', '1993-08-28', 'DELIVER IN PERSON', 'TRUCK', 'item8');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Create foreign tables (matching TPC-H schema types)
+CREATE SCHEMA subquery_test;
+IMPORT FOREIGN SCHEMA "subquery_test" FROM SERVER subquery_loopback INTO subquery_test;
+-- Disable hash and merge joins to get consistent explain output
+SET SESSION enable_hashjoin TO false;
+SET SESSION enable_mergejoin TO false;
+SET SESSION search_path = subquery_test,public;
+-- ===================================================================
+-- Test SEMI-JOIN / EXISTS subquery pushdown (TPC-H Q4 style query)
+-- ===================================================================
+-- First, show the explain plan - this should show SEMI JOIN being pushed down
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.o_orderpriority, (count(*))
+   Relations: Aggregate on ((orders) LEFT SEMI JOIN (lineitem))
+   Remote SQL: SELECT r1.o_orderpriority, count(*) FROM  subquery_test.orders r1 LEFT SEMI JOIN subquery_test.lineitem r2 ON (((r2.l_commitdate < r2.l_receiptdate)) AND ((r1.o_orderkey = r2.l_orderkey))) WHERE ((r1.o_orderdate >= '1993-07-01')) AND ((r1.o_orderdate < '1993-10-01')) GROUP BY r1.o_orderpriority ORDER BY r1.o_orderpriority ASC NULLS LAST
+(4 rows)
+
+-- Execute the actual query
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+ o_orderpriority | order_count 
+-----------------+-------------
+ 1-URGENT        |           1
+ 2-HIGH          |           1
+ 3-MEDIUM        |           1
+ 4-NOT SPECIFIED |           1
+(4 rows)
+
+-- Simpler EXISTS test without aggregation
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.o_orderkey, orders.o_orderpriority
+   Relations: (orders) LEFT SEMI JOIN (lineitem)
+   Remote SQL: SELECT r1.o_orderkey, r1.o_orderpriority FROM  subquery_test.orders r1 LEFT SEMI JOIN subquery_test.lineitem r2 ON (((r1.o_orderkey = r2.l_orderkey))) ORDER BY r1.o_orderkey ASC NULLS LAST
+(4 rows)
+
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+ o_orderkey | o_orderpriority 
+------------+-----------------
+          1 | 1-URGENT
+          2 | 2-HIGH
+          3 | 1-URGENT
+          4 | 3-MEDIUM
+          7 | 4-NOT SPECIFIED
+          8 | 5-LOW
+(6 rows)
+
+-- Cleanup
+SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+DROP SERVER subquery_loopback CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table lineitem
+drop cascades to foreign table orders

--- a/test/expected/where_sub.out
+++ b/test/expected/where_sub.out
@@ -1,0 +1,73 @@
+CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.orders  (
+        id     Int32,
+        date   Date,
+        class  String
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.lines (
+        order_id    Int32,
+        num         Int32,
+        created_at  Date,
+        updated_at  Date
+    ) ENGINE = MergeTree ORDER BY (order_id, num);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE SCHEMA where_sub;
+IMPORT FOREIGN SCHEMA "where_sub_test" FROM SERVER where_sub_loopback INTO where_sub;
+-- \d where_sub.orders
+-- \d where_sub.lines
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT class, COUNT(*) AS order_count
+  FROM where_sub.orders
+ WHERE date >= date '2025-07-01'
+   AND date < date(date '2025-07-01' + interval '3month')
+   AND EXISTS (
+       SELECT * FROM where_sub.lines
+        WHERE order_id = id AND created_at < updated_at
+   )
+ GROUP BY class
+ ORDER BY class;
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.class, (count(*))
+   Relations: Aggregate on ((orders) LEFT SEMI JOIN (lines))
+   Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r3 ON (((r3.created_at < r3.updated_at)) AND ((r1.id = r3.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
+(4 rows)
+
+SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+DROP SERVER where_sub_loopback CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table where_sub.lines
+drop cascades to foreign table where_sub.orders

--- a/test/expected/where_sub_1.out
+++ b/test/expected/where_sub_1.out
@@ -1,0 +1,73 @@
+CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.orders  (
+        id     Int32,
+        date   Date,
+        class  String
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.lines (
+        order_id    Int32,
+        num         Int32,
+        created_at  Date,
+        updated_at  Date
+    ) ENGINE = MergeTree ORDER BY (order_id, num);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE SCHEMA where_sub;
+IMPORT FOREIGN SCHEMA "where_sub_test" FROM SERVER where_sub_loopback INTO where_sub;
+-- \d where_sub.orders
+-- \d where_sub.lines
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT class, COUNT(*) AS order_count
+  FROM where_sub.orders
+ WHERE date >= date '2025-07-01'
+   AND date < date(date '2025-07-01' + interval '3month')
+   AND EXISTS (
+       SELECT * FROM where_sub.lines
+        WHERE order_id = id AND created_at < updated_at
+   )
+ GROUP BY class
+ ORDER BY class;
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: orders.class, (count(*))
+   Relations: Aggregate on ((orders) LEFT SEMI JOIN (lines))
+   Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r2 ON (((r2.created_at < r2.updated_at)) AND ((r1.id = r2.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
+(4 rows)
+
+SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+DROP SERVER where_sub_loopback CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table where_sub.lines
+drop cascades to foreign table where_sub.orders

--- a/test/sql/subquery_pushdown.sql
+++ b/test/sql/subquery_pushdown.sql
@@ -1,0 +1,115 @@
+-- Test for TPC-H Q4 style EXISTS subquery pushdown
+-- TPC-H schema reference: https://raw.githubusercontent.com/Vonng/pgtpc/refs/heads/master/tpch/ddl/schema.ddl
+SET datestyle = 'ISO';
+CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
+SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
+
+-- Create TPC-H orders table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
+	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
+	ENGINE = MergeTree ORDER BY o_orderkey;
+');
+
+-- Create TPC-H lineitem table (matching official schema)
+SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
+	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
+	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
+	 l_receiptdate Date, l_shipinstruct FixedString(25), l_shipmode FixedString(10), l_comment String)
+	ENGINE = MergeTree ORDER BY (l_orderkey, l_linenumber);
+');
+
+-- Insert sample orders data
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.orders VALUES
+	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
+	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
+	(3, 102, 'O', 3000.00, '1993-08-01', '1-URGENT', 'Clerk#000000003', 0, 'order3'),
+	(4, 103, 'O', 4000.00, '1993-08-15', '3-MEDIUM', 'Clerk#000000004', 0, 'order4'),
+	(5, 104, 'O', 5000.00, '1993-06-01', '1-URGENT', 'Clerk#000000005', 0, 'order5'),
+	(6, 105, 'O', 6000.00, '1993-09-15', '2-HIGH', 'Clerk#000000006', 0, 'order6'),
+	(7, 106, 'O', 7000.00, '1993-07-25', '4-NOT SPECIFIED', 'Clerk#000000007', 0, 'order7'),
+	(8, 107, 'O', 8000.00, '1993-08-20', '5-LOW', 'Clerk#000000008', 0, 'order8');
+$$);
+
+-- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
+SELECT clickhouse_raw_query($$
+	INSERT INTO subquery_test.lineitem VALUES
+	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
+	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
+	(3, 30, 3, 1, 30.00, 300.00, 0.10, 0.05, 'N', 'O', '1993-08-05', '1993-08-10', '1993-08-08', 'DELIVER IN PERSON', 'SHIP', 'item3'),
+	(4, 40, 4, 1, 40.00, 400.00, 0.10, 0.05, 'N', 'O', '1993-08-20', '1993-08-15', '1993-08-25', 'DELIVER IN PERSON', 'RAIL', 'item4'),
+	(7, 70, 7, 1, 70.00, 700.00, 0.10, 0.05, 'N', 'O', '1993-07-30', '1993-07-25', '1993-08-05', 'DELIVER IN PERSON', 'AIR', 'item7'),
+	(8, 80, 8, 1, 80.00, 800.00, 0.10, 0.05, 'N', 'O', '1993-08-25', '1993-08-30', '1993-08-28', 'DELIVER IN PERSON', 'TRUCK', 'item8');
+$$);
+
+-- Create foreign tables (matching TPC-H schema types)
+CREATE SCHEMA subquery_test;
+IMPORT FOREIGN SCHEMA "subquery_test" FROM SERVER subquery_loopback INTO subquery_test;
+
+-- Disable hash and merge joins to get consistent explain output
+SET SESSION enable_hashjoin TO false;
+SET SESSION enable_mergejoin TO false;
+SET SESSION search_path = subquery_test,public;
+
+-- ===================================================================
+-- Test SEMI-JOIN / EXISTS subquery pushdown (TPC-H Q4 style query)
+-- ===================================================================
+
+-- First, show the explain plan - this should show SEMI JOIN being pushed down
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+
+-- Execute the actual query
+SELECT
+    o_orderpriority,
+    count(*) as order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= date '1993-07-01'
+    AND o_orderdate < date '1993-10-01'
+    AND EXISTS (
+        SELECT * FROM lineitem
+        WHERE l_orderkey = o_orderkey
+        AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+
+-- Simpler EXISTS test without aggregation
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+
+SELECT o_orderkey, o_orderpriority FROM orders
+WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
+ORDER BY o_orderkey;
+
+-- Cleanup
+SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
+DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
+DROP SERVER subquery_loopback CASCADE;

--- a/test/sql/where_sub.sql
+++ b/test/sql/where_sub.sql
@@ -1,0 +1,43 @@
+CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
+SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.orders  (
+        id     Int32,
+        date   Date,
+        class  String
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE where_sub_test.lines (
+        order_id    Int32,
+        num         Int32,
+        created_at  Date,
+        updated_at  Date
+    ) ENGINE = MergeTree ORDER BY (order_id, num);
+$$);
+
+CREATE SCHEMA where_sub;
+IMPORT FOREIGN SCHEMA "where_sub_test" FROM SERVER where_sub_loopback INTO where_sub;
+
+-- \d where_sub.orders
+-- \d where_sub.lines
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT class, COUNT(*) AS order_count
+  FROM where_sub.orders
+ WHERE date >= date '2025-07-01'
+   AND date < date(date '2025-07-01' + interval '3month')
+   AND EXISTS (
+       SELECT * FROM where_sub.lines
+        WHERE order_id = id AND created_at < updated_at
+   )
+ GROUP BY class
+ ORDER BY class;
+
+SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
+DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
+DROP SERVER where_sub_loopback CASCADE;


### PR DESCRIPTION
Push down `EXISTS`` subqueries to ClickHouse using its native `LEFT SEMI JOIN` syntax. This change enables all but one TPC-H query to execute efficiently and 12 to fully push down.

Key changes:
- Add `JOIN_SEMI` case in `chfdw_get_jointype_name()`, returning "LEFT SEMI"
- Handle SEMI joins without the `ALL` modifier in `deparseFromExprForRel()`
- Add `semijoin_target_ok()` to validate that a target doesn't reference columns from the outer relation
- Add JOIN_SEMI support to `foreign_join_ok()` with proper condition routing
- Adjust cost estimates to make join pushdown more attractive to planner

Add `test/sql/where_sub.sql` a test for the basic pushdown behavior of `WHERE EXISTS()` and `test/sql/subquery_pushdown.sql` to test pushdown for TPC-H query 4.

Example query against pg_clickhouse tables:

    SELECT * FROM orders WHERE EXISTS (SELECT 1 FROM lineitem ...)

Resolves to ClickHouse query:

    SELECT ... FROM orders r1 LEFT SEMI JOIN lineitem r2 ON (...)

Note that this change improves the plans for existing queries in the `binary_queries.sql` and `http.sql`, pushing sorts down to ClickHouse that previously ran in PostgreSQL.

Other changes:

- Add `Makefile` targets to build `compile_commands.json` for IDE/clangd support
- Add the `tempcheck` target to the `Makefile` to run tests against a temporary PostgreSQL cluster
- Add additional files and directories to `.gitignore`