### PR TITLE
Support the dbname option for http connections

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -326,6 +326,10 @@ connstring_parse(const char *connstring)
 		{
 			details->password = pstrdup(pval);
 		}
+		else if (strcmp(pname, "dbname") == 0)
+		{
+			details->dbname = pstrdup(pval);
+		}
 	}
 
 	pfree(buf);

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -44,7 +44,7 @@ typedef struct
 
 void		ch_http_init(int verbose, uint32_t query_id_prefix);
 void		ch_http_set_progress_func(void *progressfunc);
-ch_http_connection_t *ch_http_connection(char *, int, char *, char *);
+ch_http_connection_t *ch_http_connection(char *, int, char *, char *, char *);
 void		ch_http_close(ch_http_connection_t * conn);
 ch_http_response_t *ch_http_simple_query(ch_http_connection_t * conn, const char *query);
 char	   *ch_http_last_error(void);

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -6,6 +6,7 @@
 typedef struct ch_http_connection_t
 {
 	CURL	   *curl;
+	char	   *dbname;
 	char	   *base_url;
 	size_t		base_url_len;
 }			ch_http_connection_t;

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -90,7 +90,8 @@ chfdw_http_connect(ch_connection_details * details)
 {
 	ch_connection res;
 	ch_http_connection_t *conn = ch_http_connection(details->host, details->port,
-													details->username, details->password);
+													details->username, details->password,
+													details->dbname);
 
 	if (!initialized)
 	{
@@ -775,7 +776,6 @@ static char *str_types_map[][2] = {
 	{"Float32", "REAL"},
 	{"Float64", "DOUBLE PRECISION"},
 	{"Decimal", "NUMERIC"},
-	{"Boolean", "BOOLEAN"},
 	{"String", "TEXT"},
 	{"DateTime", "TIMESTAMP"},
 	{"Date", "DATE"},			/* must come after other Date types */

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -46,12 +46,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 Strin
 (1 row)
 
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
  clickhouse_raw_query 
 ----------------------
  

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -18,12 +18,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
 SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
 SELECT clickhouse_raw_query('
-	CREATE TABLE http_test.tcopy
+	CREATE TABLE tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-');
+', 'dbname=http_test');
 
 CREATE FOREIGN TABLE ft1 (
 	c0 int,


### PR DESCRIPTION
Previously, the HTTP engine never specified a database to connect to, instead schema-qualifying all tables in generated queries from `dbname` config for a foreign server. This works well for queries against foreign tables, but not when using `clickhouse_raw_query()`, which ignored the `dbname` param.

So add support for an explicit `dbname` when connecting via HTTP by parsing it into the connection details in `connstring_parse()`, adding it to the new `data` field in the `ch_http_connection_t` struct when "connecting" to ClickHouse, and then using that value to set the `X-ClickHouse-Database` header for all HTTP requests. Change one of the calls to `clickhouse_raw_query()` in the tests to use this option and not schema-qualify the query it executes.

While at it, remove the mapping for the `Boolean` type, which doesn't exist, but is covered by the `Bool` mapping.