### PR TITLE
Add session_settings GUC and chfdw_parse_options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,8 @@ latest-changes.md: Changes
 tempcheck: install
 	$(pg_regress_installcheck) --temp-instance=/tmp/pg_clickhouse_test $(REGRESS_OPTS) $(REGRESS)
 
-# Run `make test` and copy all result files to test/expected/. Use for basic
-# test changes with the latest version of Postgres, but be aware that
+# Run `make installcheck` and copy all result files to test/expected/. Use for
+# basic test changes with the latest version of Postgres, but be aware that
 # alternate `_n.out` files will not be updated.
 #
 # DO NOT RUN UNLESS YOU'RE CERTAIN ALL YOUR TESTS ARE PASSING!

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -183,7 +183,6 @@ PG_FUNCTION_INFO_V1(clickhouse_raw_query);
 PG_FUNCTION_INFO_V1(clickhouse_op_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_noop);
-extern PGDLLEXPORT void _PG_init(void);
 static double time_used = 0;
 
 /*
@@ -279,11 +278,6 @@ static void merge_fdw_options(CHFdwRelationInfo * fpinfo,
 							  const CHFdwRelationInfo * fpinfo_o,
 							  const CHFdwRelationInfo * fpinfo_i);
 
-/* empty _PG_init_ function */
-void
-_PG_init(void)
-{
-}
 
 
 /* Make one query and close the connection */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -209,9 +209,11 @@ extern void chfdw_report_error(int elevel, ch_connection conn,
 							   bool clear, const char *sql);
 
 /* in option.c */
+extern char *ch_session_settings;
 extern void
 			chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
 								  char **dbname, char **username, char **password);
+extern List * chfdw_parse_options(const char *options, bool with_comma);
 
 /* in deparse.c */
 extern void chfdw_classify_conditions(PlannerInfo * root,

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -1,0 +1,12 @@
+\unset ECHO
+NOTICE:  OK ``
+NOTICE:  OK `join_use_nulls=1`
+NOTICE:  OK `join_use_nulls=1, xyz=true`
+NOTICE:  OK ` additional_result_filter = 'x != 2' `
+NOTICE:  OK ` additional_result_filter = 'x != 2' ,join_use_nulls = 1 `
+NOTICE:  OK ` xxx = DEFAULT, yyy = foo\,bar, zzz = 'He said, \'Hello\'', aaa = hi\ there `
+NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in options string
+NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in options string
+NOTICE:  ERR 42601 - pg_clickhouse: unterminated quoted string in options string
+NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value in options string
+NOTICE:  drop cascades to foreign table remote_settings

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -1,0 +1,46 @@
+\unset ECHO
+SET client_min_messages = notice;
+
+CREATE SERVER guc_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'system', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER guc_loopback;
+
+-- Test parsing.
+DO $do$
+DECLARE
+  cfg TEXT;
+BEGIN
+    FOREACH cfg IN ARRAY ARRAY[
+        -- Success.
+        '',
+        'join_use_nulls=1',
+        'join_use_nulls=1, xyz=true',
+        $$ additional_result_filter = 'x != 2' $$,
+        $$ additional_result_filter = 'x != 2' ,join_use_nulls = 1 $$,
+        $$ xxx = DEFAULT, yyy = foo\,bar, zzz = 'He said, \'Hello\'', aaa = hi\ there $$,
+
+        -- Failure.
+        'join_use_nulls',
+        'join_use_nulls xyz',
+        $$ additional_result_filter = 'x != 2 $$,
+        'join_use_nulls  = xyz no_preceding_comma = 2'
+   ] LOOP
+        BEGIN
+            RAISE NOTICE 'OK `%`', set_config('pg_clickhouse.session_settings', cfg, true);
+        EXCEPTION WHEN OTHERS OR ASSERT_FAILURE THEN
+            RAISE NOTICE 'ERR % - %', SQLSTATE, SQLERRM;
+        END;
+    END LOOP;
+END;
+$do$ LANGUAGE plpgsql;
+
+CREATE FOREIGN TABLE remote_settings (
+    name text,
+    value text
+)
+  SERVER guc_loopback
+  OPTIONS (table_name 'settings');
+
+-- Clean up.
+DROP USER MAPPING FOR CURRENT_USER SERVER guc_loopback;
+DROP SERVER guc_loopback CASCADE;


### PR DESCRIPTION
Port libpq's `conninfo_parse()` to `chfdw_parse_options()` with an argument to optionally require comma-delimited rather than space-delimited key/value pairs. This allows it to be used for connection string parsing and for parsing options akin to foreign server, foreign table, and user mapping comma-delimited options.

Refactor `connstring_parse()` to use `chfdw_parse_options()`.

Register a global configuration setting, not yet used, named `pg_clickhouse.session_settings`. Make its default value `join_use_nulls=1` and use `chfdw_parse_options()` to validate it.

Add a tests named `gucs` and use it for now to test the success and failure of option parsing. It contains foreign objects for future commits to use to test propagation of `pg_clickhouse.session_settings` to ClickHouse.

Other notes:

*   Move `_PG_init` to `option.c` to match the organization used by postgres_fdw
*   Only use `PGDLLEXPORT` on Postgres 15 and earlier, as it's no longer needed for later versions