### PR TITLE
Set PG_MODULE_MAGIC_EXT version to full `x.y.z`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 
 # Versioned source file.
 src/fdw.c: src/fdw.c.in
-	sed -e 's,__VERSION__,$(EXTVERSION),g' $< > $@
+	sed -e 's,__VERSION__,$(DISTVERSION),g' $< > $@
 
 # Configure the installation of the clickhouse-cpp library.
 ifeq ($(CH_BUILD), static)

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -41,7 +41,7 @@
 
 /* Extension metadata for the server. */
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "pg_clickhouse",.version = "__VERSION__");
+PG_MODULE_MAGIC_EXT(.name = "pg_clickhouse", .version = "__VERSION__");
 #else
 PG_MODULE_MAGIC;
 #endif


### PR DESCRIPTION
The plan is to make `x.y.0` releases that increment `.y` only when there are SQL changes, and to release `x.y.1+` for library-only changes. This will allow everyone to get all the library-only bug fixes without having to run `ALTER EXTENSION UPDATE`.

But while the version listed in the catalog will be `x.y`, it makes sense to properly version the library with `x.y.z`. So change the value assigned to `PG_MODULE_MAGIC_EXT.version` to the full release `x.y.z`, so that users can find the full version, at least on Postgres 18 and higher.