### PR TITLE
Update ClickHouse version test matrix

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -12,9 +12,9 @@ jobs:
         # Test latest version and all LTS releases.
         # .github/ubuntu/ch-versions --lts --latest-stable --earliest 22  --prefix '          - ' | pbcopy
         ch:
-          - 25.9.3.48-stable
-          - 25.8.10.7-lts
-          - 25.3.6.56-lts
+          - 25.11.2.24-stable
+          - 25.8.12.129-lts
+          - 25.3.9.72-lts
           - 24.8.14.39-lts
           - 24.3.18.7-lts
           - 23.8.16.40-lts

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ OBJS = $(sort \
 
 # clickhouse-cpp source and build directories.
 CH_CPP_DIR = vendor/clickhouse-cpp
-CH_CPP_BUILD_DIR = vendor/_build
+MACHINE = $(shell echo "$$(uname -s)-$$(uname -m)" | tr '[:upper:]' '[:lower:]')
+CH_CPP_BUILD_DIR = vendor/_build/$(MACHINE)
 
 # List the clickhouse-cpp libraries we require.
 CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)


### PR DESCRIPTION
Also use the machine OS and architecture for the vendor build directory, to avoid rebuilds of the `clickhouse-cpp` library across between machines and Docker containers.
