### PR TITLE
Use `ColumnDecimal->GetString`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "clickhouse-cpp"]
 	path = vendor/clickhouse-cpp
-	url = https://github.com/ClickHouse/clickhouse-cpp.git
+	url = https://github.com/theory/clickhouse-cpp.git

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
 
 # Build static on Darwin by default.
 ifndef CH_BUILD
-# ifeq ($(OS),darwin)
+ifeq ($(OS),darwin)
 	CH_BUILD = static
-# endif
+endif
 endif
 
 # Are we statically compiling clickhouse-cpp into the extension or no?

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -792,50 +792,9 @@ nested_col:
 		case Type::Code::Decimal32:
 		case Type::Code::Decimal:
 		{
-			auto decCol = col->As<ColumnDecimal>();
-			auto val = decCol->At(row);
-
-			/* Convert the Int128 to a string. */
-			std::stringstream ss;
-			ss << val;
-			std::string str = ss.str();
-
-			/* Start a destination string. */
-			std::stringstream res;
-			auto scale = decCol->GetScale();
-
-			/* Output a dash for negative values */
-			if (val < 0)
-			{
-				res << '-';
-				str.erase(0, 1);
-			}
-
-			if (scale == 0)
-			{
-				/* No decimal point, just output the entire value. */
-				res << str;
-			}
-			else if (str.length() <= scale)
-			{
-				/* Append the entire value prepended with zeros after the decimal. */
-				res << "0." << std::string(scale-str.length(), '0') << str;
-			}
-			else
-			{
-				/* There are digits before the decimal. */
-				auto decAt = str.length() - scale;
-				res << str.substr(0, decAt);
-
-				/* Append any digits after the decimal. */
-				if (decAt < str.length())
-				{
-					res << '.' << str.substr(decAt);
-				}
-			}
-
+			auto val = col->As<ColumnDecimal>()->GetString(row);
 			ret = DirectFunctionCall3(numeric_in,
-										CStringGetDatum(res.str().c_str()),
+										CStringGetDatum(val.c_str()),
 										ObjectIdGetDatum(0),
 										Int32GetDatum(-1));
 			*valtype = NUMERICOID;


### PR DESCRIPTION
Instead of converting the Int128 value from `clickhouse-cpp`, use the new `ColumnDecimal->GetString()` function to get the stringification of a decimal value fetched from ClickHouse. This greatly simplifies the code and restores the ability to use the `clickhouse-cpp` shared library, re-enabled in the `Makefile` for all OSes other than Darwin.

Draft pull request pending ClickHouse/clickhouse-cpp#451. Resolves #90.