### PR TITLE
Use recommended session settings

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -19,8 +19,6 @@ jobs:
           - 24.3.18.7-lts
           - 23.8.16.40-lts
           - 23.3.22.3-lts
-          - 22.8.21.38-lts
-          - 22.3.20.29-lts
     name: 🏠 ClickHouse ${{ matrix.ch }}
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ pg_clickhouse Postgres Extension
 [![PGXN]][⚙️] [![Postgres]][🐘] [![ClickHouse]][🏠] [![Docker]][🐳]
 
 This library contains the PostgreSQL extension `pg_clickhouse`, including a
-foreign data wrapper for ClickHouse databases. It supports ClickHouse v22 and
+foreign data wrapper for ClickHouse databases. It supports ClickHouse v23 and
 later.
 
 ## Getting Started
@@ -264,7 +264,7 @@ adding DML features. Our road map:
   [Postgres]:  https://github.com/clickhouse/pg_clickhouse/actions/workflows/postgres.yml/badge.svg
   [🐘]:        https://github.com/clickhouse/pg_clickhouse/actions/workflows/postgres.yml "Tested with PostgreSQL 13-18"
   [ClickHouse]: https://github.com/clickhouse/pg_clickhouse/actions/workflows/clickhouse.yml/badge.svg
-  [🏠]:          https://github.com/clickhouse/pg_clickhouse/actions/workflows/clickhouse.yml "Tested with ClickHouse v22–25"
+  [🏠]:          https://github.com/clickhouse/pg_clickhouse/actions/workflows/clickhouse.yml "Tested with ClickHouse v23–25"
   [Docker]:    https://ghcr-badge.egpl.dev/clickhouse/pg_clickhouse/latest_tag?color=%2344cc11&ignore=latest&label=Docker
   [🐳]:        https://github.com/ClickHouse/pg_clickhouse/pkgs/container/pg_clickhouse "Latest version on Docker Hub"
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -11,7 +11,7 @@ CREATE EXTENSION pg_clickhouse;
 
 This library contains PostgreSQL extension that enables remote query execution
 on ClickHouse databases, including a [foreign data wrapper]. It supports
-PostgreSQL 13 and higher and ClickHouse 22 and higher.
+PostgreSQL 13 and higher and ClickHouse 23 and higher.
 
 ## Getting Started
 

--- a/src/option.c
+++ b/src/option.c
@@ -505,7 +505,7 @@ _PG_init(void)
 							   "Sets the default ClickHouse session settings.",
 							   NULL,
 							   &ch_session_settings,
-							   "join_use_nulls=1",
+							   "join_use_nulls = 1, group_by_use_nulls = 1, final = 1",
 							   PGC_USERSET,
 							   0,
 							   check_settings_guc,

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -14,15 +14,19 @@ NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in option
 NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in options string
 NOTICE:  ERR 42601 - pg_clickhouse: unterminated quoted string in options string
 NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value in options string
-      name      | value 
-----------------+-------
- join_use_nulls | 1
-(1 row)
+        name        | value 
+--------------------+-------
+ final              | 1
+ group_by_use_nulls | 1
+ join_use_nulls     | 1
+(3 rows)
 
-      name      | value 
-----------------+-------
- join_use_nulls | 1
-(1 row)
+        name        | value 
+--------------------+-------
+ final              | 1
+ group_by_use_nulls | 1
+ join_use_nulls     | 1
+(3 rows)
 
         pg_clickhouse.session_settings        
 ----------------------------------------------

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -59,8 +59,13 @@ CREATE FOREIGN TABLE http_remote_settings (
 
 -- Reset to defaults.
 RESET pg_clickhouse.session_settings;
-SELECT name, value FROM bin_remote_settings WHERE name = 'join_use_nulls';
-SELECT name, value FROM http_remote_settings WHERE name = 'join_use_nulls';
+SELECT name, value FROM bin_remote_settings
+ WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final')
+ ORDER BY name;
+
+SELECT name, value FROM http_remote_settings
+ WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final')
+ ORDER BY name;
 
 -- List of seeings changed below.
 select '{


### PR DESCRIPTION
Per discussion with @rschu1ze, change the default session settings to:

```
join_use_nulls = 1, group_by_use_nulls = 1, final = 1
```

As v22 doesn't support `group_by_use_nulls`, drop support for it.