### PR TITLE
Switch to option-style parse for session_settings

### DIFF
--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -477,29 +477,29 @@ Set the `pg_clickhouse.session_settings` runtime parameter to configure
 [ClickHouse settings] to be set on subsequent queries. Example:
 
 ```sql
-SET pg_clickhouse.session_settings = 'join_use_nulls=1, final=1';
+SET pg_clickhouse.session_settings = 'join_use_nulls 1, final 1';
 ```
 
-The default is `join_use_nulls=1`. Set it to an empty string to fall back on
+The default is `join_use_nulls 1`. Set it to an empty string to fall back on
 the ClickHouse server's settings.
 
 ```sql
 SET pg_clickhouse.session_settings = '';
 ```
 
-The syntax is a comma-delimited list of key/value pairs separated by an equal
-sign. Keys must correspond to [ClickHouse settings]. Escape spaces, commas,
-and backslashes in values with a backslash:
+The syntax is a comma-delimited list of key/value pairs separated by one or
+more spaces. Keys must correspond to [ClickHouse settings]. Escape spaces,
+commas, and backslashes in values with a backslash:
 
 ```sql
-SET pg_clickhouse.session_settings = 'join_algorithm = grace_hash\,hash';
+SET pg_clickhouse.session_settings = 'join_algorithm grace_hash\,hash';
 ```
 
 Or use single quoted values to avoid escaping spaces and commas; consider
 using [dollar quoting] to avoid the need to double-quote:
 
 ```sql
-SET pg_clickhouse.session_settings = $$join_algorithm = 'grace_hash,hash'$$;
+SET pg_clickhouse.session_settings = $$join_algorithm 'grace_hash,hash'$$;
 ```
 
 If you care about legibility and need to set many settings, use multiple
@@ -507,19 +507,20 @@ lines, for example:
 
 ```sql
 SET pg_clickhouse.session_settings TO $$
-    connect_timeout = 2,
-    count_distinct_implementation = uniq,
-    groupby_use_nulls = 0,
-    join_algorithm = 'prefer_partial_merge',
-    join_use_nulls = 1,
-    log_queries_min_type = QUERY_FINISH,
-    max_block_size = 32768,
-    max_execution_time = 45,
-    max_result_rows = 1024,
-    metrics_perf_events_list = 'this,that',
-    network_compression_method = ZSTD,
-    poll_interval = 5,
-    totals_mode = after_having_auto
+    connect_timeout 2,
+    count_distinct_implementation uniq,
+    final 1,
+    group_by_use_nulls 1,
+    join_algorithm 'prefer_partial_merge',
+    join_use_nulls 1,
+    log_queries_min_type QUERY_FINISH,
+    max_block_size 32768,
+    max_execution_time 45,
+    max_result_rows 1024,
+    metrics_perf_events_list 'this,that',
+    network_compression_method ZSTD,
+    poll_interval 5,
+    totals_mode after_having_auto
 $$;
 ```
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -202,7 +202,7 @@ ch_connection_details *
 connstring_parse(const char *connstring)
 {
 	ListCell   *lc;
-	List	   *options = chfdw_parse_options(connstring, false);
+	List	   *options = chfdw_parse_options(connstring, false, true);
 	ch_connection_details *details = palloc0(sizeof(ch_connection_details));
 
 	if (options == NIL)

--- a/src/include/engine.h
+++ b/src/include/engine.h
@@ -24,6 +24,6 @@ typedef struct
 	const List	   *settings;
 }			ch_query;
 
-#define new_query(sql) {sql, chfdw_parse_options(ch_session_settings, true)}
+#define new_query(sql) {sql, chfdw_parse_options(ch_session_settings, true, false)}
 
 #endif							/* CLICKHOUSE_ENGINE_H */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -203,7 +203,7 @@ extern char *ch_session_settings;
 extern void
 			chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
 								  char **dbname, char **username, char **password);
-extern List * chfdw_parse_options(const char *options, bool with_comma);
+extern List * chfdw_parse_options(const char *options, bool with_comma, bool with_equal);
 
 /* in deparse.c */
 extern void chfdw_classify_conditions(PlannerInfo * root,

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -1,17 +1,12 @@
 \unset ECHO
- ch_noop_bigint 
-----------------
-               
-(1 row)
-
 NOTICE:  OK ``
-NOTICE:  OK `join_use_nulls=1`
-NOTICE:  OK `join_use_nulls=1, xyz=true`
-NOTICE:  OK ` additional_result_filter = 'x != 2' `
-NOTICE:  OK ` additional_result_filter = 'x != 2' ,join_use_nulls = 1 `
-NOTICE:  OK ` xxx = DEFAULT, yyy = foo\,bar, zzz = 'He said, \'Hello\'', aaa = hi\ there `
-NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in options string
-NOTICE:  ERR 42601 - pg_clickhouse: missing "=" after "join_use_nulls" in options string
+NOTICE:  OK `join_use_nulls 1`
+NOTICE:  OK `join_use_nulls 1, xyz true`
+NOTICE:  OK ` additional_result_filter 'x != 2' `
+NOTICE:  OK ` additional_result_filter 'x != 2' ,join_use_nulls 1 `
+NOTICE:  OK ` xxx DEFAULT, yyy foo\,bar, zzz    'He said, \'Hello\'', aaa  hi\ there `
+NOTICE:  ERR 42601 - pg_clickhouse: missing value for parameter "join_use_nulls" in options string
+NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value in options string
 NOTICE:  ERR 42601 - pg_clickhouse: unterminated quoted string in options string
 NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value in options string
         name        | value 
@@ -28,22 +23,22 @@ NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value i
  join_use_nulls     | 1
 (3 rows)
 
-        pg_clickhouse.session_settings        
-----------------------------------------------
-                                             +
-     connect_timeout = 2,                    +
-     count_distinct_implementation = uniq,   +
-     join_algorithm = 'prefer_partial_merge',+
-     join_use_nulls = 0,                     +
-     join_use_nulls = 1,                     +
-     log_queries_min_type = QUERY_FINISH,    +
-     max_block_size = 32768,                 +
-     max_execution_time = 45,                +
-     max_result_rows = 1024,                 +
-     metrics_perf_events_list = 'this,that', +
-     network_compression_method = ZSTD,      +
-     poll_interval = 5,                      +
-     totals_mode = after_having_auto         +
+       pg_clickhouse.session_settings       
+--------------------------------------------
+                                           +
+     connect_timeout 2,                    +
+     count_distinct_implementation uniq,   +
+     join_algorithm 'prefer_partial_merge',+
+     join_use_nulls 0,                     +
+     join_use_nulls 1,                     +
+     log_queries_min_type QUERY_FINISH,    +
+     max_block_size 32768,                 +
+     max_execution_time 45,                +
+     max_result_rows 1024,                 +
+     metrics_perf_events_list 'this,that', +
+     network_compression_method ZSTD,      +
+     poll_interval 5,                      +
+     totals_mode after_having_auto         +
  
 (1 row)
 

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -1,8 +1,8 @@
 \unset ECHO
 SET client_min_messages = notice;
 
--- Load pg_clickhouse by calling one of its functions.
-SELECT ch_noop_bigint('');
+-- Load pg_clickhouse;
+LOAD 'pg_clickhouse';
 
 -- Test parsing.
 DO $do$
@@ -12,17 +12,17 @@ BEGIN
     FOREACH cfg IN ARRAY ARRAY[
         -- Success.
         '',
-        'join_use_nulls=1',
-        'join_use_nulls=1, xyz=true',
-        $$ additional_result_filter = 'x != 2' $$,
-        $$ additional_result_filter = 'x != 2' ,join_use_nulls = 1 $$,
-        $$ xxx = DEFAULT, yyy = foo\,bar, zzz = 'He said, \'Hello\'', aaa = hi\ there $$,
+        'join_use_nulls 1',
+        'join_use_nulls 1, xyz true',
+        $$ additional_result_filter 'x != 2' $$,
+        $$ additional_result_filter 'x != 2' ,join_use_nulls 1 $$,
+        $$ xxx DEFAULT, yyy foo\,bar, zzz    'He said, \'Hello\'', aaa  hi\ there $$,
 
         -- Failure.
         'join_use_nulls',
-        'join_use_nulls xyz',
-        $$ additional_result_filter = 'x != 2 $$,
-        'join_use_nulls  = xyz no_preceding_comma = 2'
+        'join_use_nulls = xyz',
+        $$ additional_result_filter 'x != 2 $$,
+        'join_use_nulls  xyz no_preceding_comma = 2'
    ] LOOP
         BEGIN
             RAISE NOTICE 'OK `%`', set_config('pg_clickhouse.session_settings', cfg, true);
@@ -93,19 +93,19 @@ SELECT name, value
 
 -- Customize all of the above settings.
 SET pg_clickhouse.session_settings TO $$
-    connect_timeout = 2,
-    count_distinct_implementation = uniq,
-    join_algorithm = 'prefer_partial_merge',
-    join_use_nulls = 0,
-    join_use_nulls = 1,
-    log_queries_min_type = QUERY_FINISH,
-    max_block_size = 32768,
-    max_execution_time = 45,
-    max_result_rows = 1024,
-    metrics_perf_events_list = 'this,that',
-    network_compression_method = ZSTD,
-    poll_interval = 5,
-    totals_mode = after_having_auto
+    connect_timeout 2,
+    count_distinct_implementation uniq,
+    join_algorithm 'prefer_partial_merge',
+    join_use_nulls 0,
+    join_use_nulls 1,
+    log_queries_min_type QUERY_FINISH,
+    max_block_size 32768,
+    max_execution_time 45,
+    max_result_rows 1024,
+    metrics_perf_events_list 'this,that',
+    network_compression_method ZSTD,
+    poll_interval 5,
+    totals_mode after_having_auto
 $$;
 
 SHOW pg_clickhouse.session_settings;


### PR DESCRIPTION
The format of the `pg_clickhouse.session_settings` GUC was

    key = val, key = 'val'...

But that doesn't match options passed to `CREATE SERVER` and the like, which requires space, not an equal sign, between option names and values:

    key val, key 'val'...

In the future we'll want to merge these options with the GUC, so it's better if they use the same format.

So add a new parameter to `chfdw_parse_options()`, `bool with_equal`, and only require an equal sign between the name and value when it't true. Then change calls to it to not require a comma for the GUC, but to still require them for the `clickhouse_raw_query()` connection string, to align with the libpq behavior.

Update the GUC tests and documentation to reflect this change.