### PR TITLE
Add docker-compose for testing ClickHouse versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 .gitattributes export-ignore
 .github export-ignore
 .gitmodules export-ignore
+dev export-ignore

--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test latest version and all LTS releases.
+        # Keep in sync with dev/docker-compose.yml.
         # .github/ubuntu/ch-versions --lts --latest-stable --earliest 22  --prefix '          - ' | pbcopy
         ch:
           - 25.11.2.24-stable

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ regression.out
 /pg_clickhouse-*
 .vscode/
 _build/
-/latest-changes.md
+/release-notes.md
 /src/fdw.c
 /sql/*--*.sql
 !/sql/*--*--*.sql

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)
 CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
 
 # Build static on Darwin by default.
-ifndef ($(CH_BUILD))
+ifndef CH_BUILD
 # ifeq ($(OS),darwin)
 	CH_BUILD = static
 # endif
@@ -71,7 +71,10 @@ ifneq ($(OS),darwin)
 endif
 
 # Clean up the clickhouse-cpp build directory and generated files.
-EXTRA_CLEAN = $(CH_CPP_BUILD_DIR) sql/$(EXTENSION)--$(EXTVERSION).sql src/fdw.c compile_commands.json
+EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql src/fdw.c compile_commands.json $(EXTENSION)-$(DISTVERSION).zip
+ifndef NO_VENDOR_CLEAN
+	EXTRA_CLEAN += $(CH_CPP_BUILD_DIR)
+endif
 
 # Import PGXS.
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,5 @@
+start:
+	docker compose up -d --remove-orphans
+
+stop:
+	docker compose down --remove-orphans --volumes

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,24 @@
+ClickHouse Version Testing Containers
+=====================================
+
+This directory's [docker-compose.yml](docker-compose.yml) starts images for
+each supported major version of ClickHouse. Each container also runs
+PostgreSQL 18. Both ClickHouse and PostgreSQL run on their default ports
+(unexported) and trust all local connections. The containers are based on
+[pgxn-tools].
+
+Example usage:
+
+```sh
+make start
+docker logs -f ch_25_11
+# Wait a few minutes for the services to start (log output will stop)
+docker exec -it ch_25_11 bash
+make clean NO_VENDOR_CLEAN=1 # Option to prevent clickhouse-cpp rebuild
+pg-build-test # or make && make install && make installcheck
+```
+
+The containers should remain until you `make stop`; if you restart Docker (or
+your system), they may need to be started again, e.g., `docker start ch_25_11`.
+
+  [pgxn-tools]: https://github.com/pgxn/docker-pgxn-tools/

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,153 @@
+# Run containers for each supported major version of ClickHouse. Each is based
+# on [pgxn-tools] to simplify testing and has PostgreSQL 18 running. Both
+# databases servers are on their usual ports and trust local connections
+# without passwords.
+#
+# Keep in sync with .github/workflows/clickhouse.yml
+
+networks:
+  default:
+    name: pgch
+
+volumes:
+  config:
+
+services:
+  ch_25_11:
+    image: pgxn/pgxn-tools
+    container_name: ch_25_11
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 25.11.2.24-stable
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+  ch_25_8:
+    image: pgxn/pgxn-tools
+    container_name: ch_25_8
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 25.8.12.129-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+
+  ch_25_3:
+    image: pgxn/pgxn-tools
+    container_name: ch_25_3
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 25.3.9.72-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+
+  ch_24_8:
+    image: pgxn/pgxn-tools
+    container_name: ch_24_8
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 25.3.9.72-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+
+  ch_24_3:
+    image: pgxn/pgxn-tools
+    container_name: ch_24_3
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 24.3.18.7-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+
+  ch_23_8:
+    image: pgxn/pgxn-tools
+    container_name: ch_23_8
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 23.8.16.40-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '
+
+  ch_23_3:
+    image: pgxn/pgxn-tools
+    container_name: ch_23_3
+    platform: linux/amd64
+    stdin_open: true
+    stop_grace_period: 10ms
+    environment:
+      PGUSER: postgres
+      CH_RELEASE: 23.3.22.3-lts
+    working_dir: /work
+    volumes:
+      - ..:/work
+    command: >
+      /bin/sh -c '
+        .github/ubuntu/clickhouse.sh
+        pg-start 18 libcurl4-openssl-dev uuid-dev
+        printf "ClickHouse $$CH_RELEASE and Postgres 18 started"
+        tail -f /dev/null
+      '


### PR DESCRIPTION
Add `dev/docker-compose.yml` along with a README and `Makefile` to easily spin up containers running Postgres 18 and each major release of ClickHouse (copied from `.github/workflows/clickhouse.yml`).

Ignore `dev` when exporting the repo (no need to include it in a release zip file), while at it, fix the release notes file to ignore (changed in b8d6b54).

While at it, add the `NO_VENDOR_CLEAN` option to the `Makefile` to prevent `make clean` from deleting the vendor build directory; handy to keep it between ClickHouse versions in the different containers. Also fix the incorrect checking of `CH_BUILD`, and add the `dist` artifact to `EXTRA_CLEAN`.