### PR TITLE
fix: prevent postgres-client crash when COPY 0 rows

### DIFF
--- a/src/pglink.c
+++ b/src/pglink.c
@@ -739,7 +739,7 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 {
 	ch_binary_insert_state *state = istate;
 
-	if (state->conversion_states == NULL)
+	if (state->conversion_states == NULL && slot)
 	{
 		MemoryContext old_mcxt;
 


### PR DESCRIPTION
Problem:
 Executing `COPY public.employees (id, name, salary, department, hire_date)
 FROM stdin;` followed immediately by `\.` (i.e., zero rows) would crash
 the client due to unhandled empty input in the COPY loop.

Test:
  psql testdb -c "\COPY public.employees (id, name, salary, department, hire_date) FROM stdin;" <<EOF
  \.
  EOF
  Verified that client does not crash.

Example:
ClickHouse table schema:

```sql
CREATE TABLE employees (
    id         Int32,
    name       String,
    salary     Decimal(10, 2),
    department String,
    hire_date  Date
)
ENGINE = MergeTree()
ORDER BY id;
```

postgres command:

```sql
COPY public.employees (id, name, salary, department, hire_date) FROM stdin;
\.
```