### PR TITLE
Document `IMPORT FOREIGN SCHEMA` case preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.1.2] — Unreleased
+
+### 📚 Documentation
+
+*   Added a note to the `IMPORT FOREIGN SCHEMA` documentation explaining how
+    table and column names imported from ClickHouse will have their letter
+    casing and blank spaces preserved if they have uppercase characters or
+    blank spaces.
+
+  [v0.1.2]: https://github.com/clickhouse/pg_clickhouse/compare/v0.1.1...v0.1.2
+
 ## [v0.1.1] — 2025-12-17
 
 This release makes binary-only changes. Once installed, any existing use of

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -235,6 +235,47 @@ the foreign tables. Columns will be defined using the [supported data
 types](#data-types) and, were detectible, the options supported by [CREATE
 FOREIGN TABLE](#create-foreign-table).
 
+> **⚠️ Imported Identifier Case Preservation**
+>
+> `IMPORT FOREIGN SCHEMA` runs `quote_identifier()` on the table and column
+> names it imports, which double-quotes identifiers with uppercase characters
+> or blank spaces. Such table and column names thus must be double-quoted in
+> PostgreSQL queries. Names with all lowercase and no blank space characters
+> do not need to be quoted.
+>
+> For example, given this ClickHouse table:
+>
+> ```sql
+> CREATE OR REPLACE TABLE test
+> (
+>     id UInt64,
+>     Name TEXT,
+>     updatedAt DateTime DEFAULT now()
+> )
+> ENGINE = MergeTree
+> ORDER BY id;
+> ```
+>
+> `IMPORT FOREIGN SCHEMA` creates this foreign table:
+>
+> ```sql
+> CREATE TABLE test
+> (
+>     id          BIGINT      NOT NULL,
+>     "Name"      TEXT        NOT NULL,
+>     "updatedAt" TIMESTAMPTZ NOT NULL
+> );
+> ```
+>
+> Queries therefore must quote appropriately, e.g.,
+>
+> ```sql
+> SELECT id, "Name", "updatedAt" FROM test;
+> ```
+>
+> To create objects with different names or all lowercase (and therefore
+> case-insensitive) names, use [CREATE FOREIGN TABLE](#create-foreign-table).
+
 ### CREATE FOREIGN TABLE
 
 Use [IMPORT FOREIGN SCHEMA] to create a foreign table that can query data from
@@ -247,7 +288,7 @@ CREATE FOREIGN TABLE uact (
     duration   smallint,
     sign       smallint
 ) SERVER taxi_srv OPTIONS(
-    table_name 'uact'
+    table_name 'uact',
     engine 'CollapsingMergeTree'
 );
 ```


### PR DESCRIPTION
Add a note to the `IMPORT FOREIGN SCHEMA` documentation explaining how table and column names imported from ClickHouse will have their letter casing and blank spaces preserved if they have uppercase characters or blank spaces, and otherwise retains them as case-insensitive (lowercase in Postgres).

Also add a missing comma to the `CREATE FOREIGN TABLE` example.