### PR TITLE
Remove the custom code for Adjust extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,25 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.2] — Unreleased
 
+### 📔 Notes
+
+*   Removed unused code designed to support custom PostgreSQL extensions:
+    [ajbool], ajtime, [country], and [istore].
+
 ### 📚 Documentation
 
 *   Added a note to the `IMPORT FOREIGN SCHEMA` documentation explaining how
     table and column names imported from ClickHouse will have their letter
     casing and blank spaces preserved if they have uppercase characters or
     blank spaces.
+*   Fixed the commands to start and connect to the pg_clickhouse Docker image
+    in the [tutorial].
 
   [v0.1.2]: https://github.com/clickhouse/pg_clickhouse/compare/v0.1.1...v0.1.2
+  [ajbool]: https://pgxn.org/dist/ajbool/ "ajbool on PGXN"
+  [country]: https://pgxn.org/dist/country/ "country on PGXN"
+  [istore]: https://pgxn.org/dist/istore/ "istore on PGXN"
+  [tutorial]: ./doc/tutorial.md
 
 ## [v0.1.1] — 2025-12-17
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -289,80 +289,7 @@ chfdw_check_for_custom_function(Oid funcid)
 			procform = (Form_pg_proc) GETSTRUCT(proctup);
 			proname = NameStr(procform->proname);
 
-			if (STR_EQUAL(extname, "istore"))
-			{
-				if (STR_EQUAL(proname, "sum"))
-				{
-					entry->cf_type = CF_ISTORE_SUM;
-					strcpy(entry->custom_name, "sumMap");
-				}
-				if (STR_EQUAL(proname, "sum_up"))
-				{
-					entry->cf_type = CF_ISTORE_SUM_UP;
-					strcpy(entry->custom_name, "arraySum");
-				}
-				else if (STR_EQUAL(proname, "istore_seed"))
-				{
-					entry->cf_type = CF_ISTORE_SEED;
-					entry->custom_name[0] = '\1';	/* complex */
-				}
-				else if (STR_EQUAL(proname, "accumulate"))
-				{
-					entry->cf_type = CF_ISTORE_ACCUMULATE;
-					entry->custom_name[0] = '\1';	/* complex */
-				}
-				else if (STR_EQUAL(proname, "slice"))
-				{
-					entry->cf_type = CF_UNSHIPPABLE;
-					entry->custom_name[0] = '\0';	/* complex */
-				}
-			}
-			else if (STR_EQUAL(extname, "country"))
-			{
-				if (STR_EQUAL(proname, "country_common_name"))
-				{
-					entry->cf_type = CF_UNSHIPPABLE;
-					entry->custom_name[0] = '\0';	/* complex */
-				}
-			}
-			else if (STR_EQUAL(extname, "ajtime"))
-			{
-				if (STR_EQUAL(proname, "ajtime_to_timestamp"))
-				{
-					entry->cf_type = CF_AJTIME_TO_TIMESTAMP;
-					strcpy(entry->custom_name, "");
-				}
-				else if (STR_EQUAL(proname, "ajtime_pl_interval"))
-				{
-					entry->cf_type = CF_AJTIME_PL_INTERVAL;
-					strcpy(entry->custom_name, "addSeconds");
-				}
-				else if (STR_EQUAL(proname, "ajtime_mi_interval"))
-				{
-					entry->cf_type = CF_AJTIME_MI_INTERVAL;
-					strcpy(entry->custom_name, "subtractSeconds");
-				}
-				else if (STR_EQUAL(proname, "day_diff"))
-				{
-					entry->cf_type = CF_AJTIME_DAY_DIFF;
-					strcpy(entry->custom_name, "toInt32");
-				}
-				else if (STR_EQUAL(proname, "ajdate"))
-				{
-					entry->cf_type = CF_AJTIME_AJDATE;
-					strcpy(entry->custom_name, "toDate");
-				}
-				else if (STR_EQUAL(proname, "ajtime_out"))
-				{
-					entry->cf_type = CF_AJTIME_OUT;
-				}
-			}
-			else if (STR_EQUAL(extname, "ajbool"))
-			{
-				if (STR_EQUAL(proname, "ajbool_out"))
-					entry->cf_type = CF_AJBOOL_OUT;
-			}
-			else if (STR_EQUAL(extname, "intarray"))
+			if (STR_EQUAL(extname, "intarray"))
 			{
 				if (STR_EQUAL(proname, "idx"))
 				{
@@ -384,32 +311,6 @@ chfdw_check_for_custom_function(Oid funcid)
 	return entry;
 }
 
-static Oid
-find_rowfunc(char *procname, Oid rettype)
-{
-	Oid			argtypes[1] = {RECORDOID};
-	Oid			procOid;
-	List	   *funcname = NIL;
-
-	funcname = list_make1(makeString(procname));
-	procOid = LookupFuncName(funcname, 1, argtypes, false);
-	if (!OidIsValid(procOid))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_FUNCTION),
-				 errmsg("function %s does not exist",
-						func_signature_string(funcname, 1, NIL, argtypes))));
-
-
-	if (get_func_rettype(procOid) != rettype)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-				 errmsg("typmod_in function %s must return type %s",
-						procname, format_type_be(rettype))));
-
-	list_free_deep(funcname);
-	return procOid;
-}
-
 CustomObjectDef *
 chfdw_check_for_custom_type(Oid typeoid)
 {
@@ -424,41 +325,8 @@ chfdw_check_for_custom_type(Oid typeoid)
 	entry = hash_search(custom_objects_cache, (void *) &typeoid, HASH_FIND, NULL);
 	if (!entry)
 	{
-		HeapTuple	tp;
-
 		entry = hash_search(custom_objects_cache, (void *) &typeoid, HASH_ENTER, NULL);
 		init_custom_entry(entry);
-
-		tp = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typeoid));
-		if (HeapTupleIsValid(tp))
-		{
-			Form_pg_type typtup = (Form_pg_type) GETSTRUCT(tp);
-			char	   *name = NameStr(typtup->typname);
-
-			if (STR_EQUAL(name, "istore"))
-			{
-				entry->cf_type = CF_ISTORE_TYPE;	/* bigistore or istore */
-				strcpy(entry->custom_name, "Tuple(Array(Int32), Array(Int64))");
-				entry->rowfunc = find_rowfunc("row_to_istore", typeoid);
-			}
-			else if (STR_EQUAL(name, "bigistore"))
-			{
-				entry->cf_type = CF_ISTORE_TYPE;	/* bigistore or istore */
-				strcpy(entry->custom_name, "Tuple(Array(Int32), Array(Int64))");
-				entry->rowfunc = find_rowfunc("row_to_bigistore", typeoid);
-			}
-			else if (STR_EQUAL(name, "ajtime"))
-			{
-				entry->cf_type = CF_AJTIME_TYPE;	/* ajtime */
-				strcpy(entry->custom_name, "timestamp");
-			}
-			else if (STR_EQUAL(name, "country"))
-			{
-				entry->cf_type = CF_COUNTRY_TYPE;	/* country type */
-				strcpy(entry->custom_name, "text");
-			}
-			ReleaseSysCache(tp);
-		}
 	}
 
 	return entry;
@@ -509,14 +377,7 @@ chfdw_check_for_custom_operator(Oid opoid, Form_pg_operator form)
 
 			if (extname)
 			{
-				if (STR_EQUAL(extname, "ajtime"))
-					entry->cf_type = CF_AJTIME_OPERATOR;
-				else if (STR_EQUAL(extname, "istore"))
-				{
-					if (form && strcmp(NameStr(form->oprname), "->") == 0)
-						entry->cf_type = CF_ISTORE_FETCHVAL;
-				}
-				else if (STR_EQUAL(extname, "hstore"))
+				if (STR_EQUAL(extname, "hstore"))
 				{
 					if (form && strcmp(NameStr(form->oprname), "->") == 0)
 						entry->cf_type = CF_HSTORE_FETCHVAL;
@@ -591,11 +452,8 @@ chfdw_apply_custom_table_options(CHFdwRelationInfo * fpinfo, Oid relid)
 	for (attnum = 1; attnum <= tupdesc->natts; attnum++)
 	{
 		bool		found;
-		CustomObjectDef *cdef;
 		CustomColumnInfo entry_key,
 				   *entry;
-		custom_object_type cf_type = CF_ISTORE_ARR;
-
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
 		entry_key.relid = relid;
@@ -628,20 +486,12 @@ chfdw_apply_custom_table_options(CHFdwRelationInfo * fpinfo, Oid relid)
 			else if (STR_EQUAL(def->defname, "aggregatefunction"))
 			{
 				entry->is_AggregateFunction = CF_AGGR_FUNC;
-				cf_type = CF_ISTORE_COL;
 			}
 			else if (STR_EQUAL(def->defname, "simpleaggregatefunction"))
 			{
 				entry->is_AggregateFunction = CF_AGGR_SIMPLE;
-				cf_type = CF_ISTORE_COL;
 			}
-			else if (STR_EQUAL(def->defname, "arrays"))
-				cf_type = CF_ISTORE_ARR;
 		}
-
-		cdef = chfdw_check_for_custom_type(attr->atttypid);
-		if (cdef && cdef->cf_type == CF_ISTORE_TYPE)
-			entry->coltype = cf_type;
 	}
 	table_close_compat(rel, NoLock);
 }

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -179,13 +179,6 @@ static bool is_subquery_var(Var * node, RelOptInfo * foreignrel,
 static void get_relation_column_alias_ids(Var * node, RelOptInfo * foreignrel,
 										  int *relno, int *colno);
 
-static char *
-get_alias_name()
-{
-	var_counter++;
-	return psprintf("_tmp%d", var_counter++);
-}
-
 /*
  * Examine each qual clause in input_conds, and classify them into two groups,
  * which are returned as two lists:
@@ -395,10 +388,6 @@ foreign_expr_walker(Node * node,
 				 * semantics on remote side.
 				 */
 				if (!chfdw_is_shippable(fe->funcid, ProcedureRelationId, fpinfo, &cdef))
-					return false;
-
-				/* only simple Var as first argument for accumulate */
-				if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE && (!IsA(linitial(fe->args), Var)))
 					return false;
 
 				/*
@@ -1637,134 +1626,9 @@ deparseColumnRef(StringInfo buf, CustomObjectDef * cdef,
 	if (colname == NULL)
 		colname = get_attname(rte->relid, varattno, false);
 
-	if (cinfo && cinfo->coltype == CF_ISTORE_ARR)
-	{
-		char	   *colkey = psprintf("%s_keys", colname);
-		char	   *colval = psprintf("%s_values", colname);
-
-		if (cdef && cdef->cf_type == CF_ISTORE_SUM)
-		{
-			/* SUM context */
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colkey));
-			appendStringInfoChar(buf, ',');
-
-			if (cinfo->table_engine == CH_COLLAPSING_MERGE_TREE)
-			{
-				appendStringInfoString(buf, "arrayMap(x -> x * ");
-				appendStringInfoString(buf, cinfo->signfield);
-				appendStringInfoChar(buf, ',');
-				if (qualify_col)
-					ADD_REL_QUALIFIER(buf, varno);
-				appendStringInfoString(buf, quote_identifier(colval));
-				appendStringInfoChar(buf, ')');
-			}
-			else
-			{
-				if (qualify_col)
-					ADD_REL_QUALIFIER(buf, varno);
-				appendStringInfoString(buf, quote_identifier(colval));
-			}
-		}
-		else if (cdef && cdef->cf_type == CF_ISTORE_FETCHVAL)
-		{
-			/* values[indexOf(ids, */
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colval));
-			appendStringInfoString(buf, "[nullif(indexOf(");
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colkey));
-			appendStringInfoChar(buf, ',');
-		}
-		else if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
-		{
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colval));
-
-			if (cdef->cf_context && list_length(cdef->cf_context) == 2)
-			{
-				appendStringInfoChar(buf, ',');
-				if (qualify_col)
-					ADD_REL_QUALIFIER(buf, varno);
-				appendStringInfoString(buf, quote_identifier(colkey));
-			}
-		}
-		else
-		{
-			appendStringInfoChar(buf, '(');
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colkey));
-			appendStringInfoChar(buf, ',');
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colval));
-			appendStringInfoChar(buf, ')');
-		}
-
-		pfree(colkey);
-		pfree(colval);
-	}
-	else if (cinfo && cinfo->coltype == CF_ISTORE_COL)
-	{
-		char	   *alias_name = get_alias_name();
-
-		if (cdef && cdef->cf_type == CF_ISTORE_FETCHVAL)
-		{
-			/*
-			 * ((finalizeAggregation(colname) as _tmp).2)[indexOf(_tmp.1, - we
-			 * fill this part <key>)] - should be filled later
-			 */
-
-			appendStringInfoString(buf, "((");
-
-			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
-				appendStringInfoString(buf, "finalizeAggregation(");
-			else
-				appendStringInfoChar(buf, '(');
-
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-
-			appendStringInfoString(buf, quote_identifier(colname));
-			appendStringInfo(buf, ") as %s).2)[nullif(indexOf(%s.1, ", alias_name, alias_name);
-		}
-		else if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
-		{
-			appendStringInfoChar(buf, '(');
-
-			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
-				appendStringInfoString(buf, "finalizeAggregation(");
-			else
-				appendStringInfoChar(buf, '(');
-
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colname));
-			appendStringInfo(buf, ") as %s).2", alias_name);
-
-			if (cdef->cf_context && list_length(cdef->cf_context) == 2)
-				appendStringInfo(buf, ", %s.1", alias_name);
-		}
-		else
-		{
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, varno);
-			appendStringInfoString(buf, quote_identifier(colname));
-		}
-
-		pfree(alias_name);
-	}
-	else
-	{
-		if (qualify_col)
-			ADD_REL_QUALIFIER(buf, varno);
-		appendStringInfoString(buf, quote_identifier(colname));
-	}
+	if (qualify_col)
+		ADD_REL_QUALIFIER(buf, varno);
+	appendStringInfoString(buf, quote_identifier(colname));
 }
 
 /*
@@ -2185,30 +2049,7 @@ deparseConst(Const * node, deparse_expr_cxt * context, int showtype)
 	}
 	else
 	{
-		CustomObjectDef *cdef = chfdw_check_for_custom_function(typoutput);
-
 		extval = OidOutputFunctionCall(typoutput, node->constvalue);
-		if (cdef && cdef->cf_type == CF_AJBOOL_OUT)
-		{
-			/*
-			 * ajbool: 'f' => 0 't' => 1 'u' => -1
-			 */
-			if (extval[0] == 'f')
-				appendStringInfoChar(buf, '0');
-			else if (extval[0] == 't')
-				appendStringInfoChar(buf, '1');
-			else if (extval[0] == 'u')
-				appendStringInfoString(buf, "-1");
-			else
-				elog(ERROR, "unexpected output of ajbool");
-
-			goto cleanup;
-		}
-		else if (cdef && cdef->cf_type == CF_AJTIME_OUT)
-		{
-			closebr = true;
-			appendStringInfoString(buf, "toDateTime(");
-		}
 	}
 
 	switch (node->consttype)
@@ -2323,8 +2164,6 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 	ListCell   *arg;
 	CustomObjectDef *cdef,
 			   *old_cdef;
-	CustomObjectDef funcdef;
-	CHFdwRelationInfo *fpinfo = context->scanrel->fdw_private;
 
 	/*
 	 * If the function call came from an implicit coercion, then just show the
@@ -2460,189 +2299,9 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 		appendStringInfoChar(buf, ')');
 		return;
 	}
-	else if (cdef && cdef->cf_type == CF_ISTORE_SEED)
-	{
-		if (!context->func)
-		{
-			/* not aggregation */
-			appendStringInfoChar(buf, '(');
-		}
-
-		appendStringInfoString(buf, "range(toUInt16(");
-		deparseExpr(list_nth(node->args, 1), context);
-		appendStringInfoString(buf, ") + 1), arrayResize(emptyArrayInt64(),toUInt16(");
-		deparseExpr(list_nth(node->args, 1), context);
-		appendStringInfoString(buf, ") + 1, coalesce(");
-		deparseExpr(list_nth(node->args, 2), context);
-		appendStringInfoString(buf, ", 0)");
-
-		if (context->func && context->func->cf_type == CF_ISTORE_SUM
-			&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
-			appendStringInfo(buf, " * %s", fpinfo->ch_table_sign_field);
-
-		appendStringInfoChar(buf, ')');
-
-		if (!context->func)
-			appendStringInfoChar(buf, ')');
-
-		return;
-	}
-	else if (cdef && cdef->cf_type == CF_ISTORE_ACCUMULATE)
-	{
-		Relids		relids = context->scanrel->relids;
-		Var		   *var = linitial(node->args);
-		bool		qualify_col = (bms_num_members(relids) > 1);
-		char	   *colname = NULL;
-		RangeTblEntry *rte;
-		CustomColumnInfo *cinfo;
-
-		if (!IsA(linitial(node->args), Var))
-			elog(ERROR, "pg_clickhouse supports simple accumulate with column as first parameter");
-
-		if (bms_is_member(var->varno, relids) && var->varlevelsup == 0)
-			rte = planner_rt_fetch(var->varno, context->root);
-		else
-			elog(ERROR, "unidentified first parameter in accumulate");
-
-		/* Get FDW specific options for this column */
-		cinfo = chfdw_get_custom_column_info(rte->relid, var->varattno);
-		if (!cinfo)
-			elog(ERROR, "unidentified first parameter in accumulate");
-
-		if (!context->func)
-		{
-			/* not aggregation */
-			appendStringInfoChar(buf, '(');
-		}
-
-		colname = cinfo->colname;
-		if (cinfo->coltype == CF_ISTORE_ARR)
-		{
-			char	   *max_key_alias = get_alias_name();
-			char	   *colkey = psprintf("%s_keys", colname);
-			char	   *colval = psprintf("%s_values", colname);
-
-			if (list_length(node->args) == 1)
-				elog(ERROR, "pg_clickhouse supports accumulate only with max_key parameter");
-
-			/*
-			 * first block if(a_keys[1] <= max_key, arrayMap(x -> a_keys[1] +
-			 * x - 1, arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key)
-			 * - a_keys[1] + 1))), []),
-			 */
-			appendStringInfoString(buf, "if(");
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-
-			appendStringInfoString(buf, colkey);
-			appendStringInfoString(buf, "[1] <= (coalesce(");
-			deparseExpr((Expr *) list_nth(node->args, 1), context);
-			appendStringInfo(buf, ", 0) as %s), arrayMap(x -> ", max_key_alias);
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colkey);
-			appendStringInfoString(buf, "[1] + x - 1, arrayEnumerate(arrayResize(emptyArrayInt32(), (");
-			appendStringInfo(buf, "%s) - ", max_key_alias);
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colkey);
-			appendStringInfoString(buf, "[1] + 1))), []),");
-
-			/*
-			 * second block: if(a_keys[1] <= max_key, arrayCumSum(arrayMap(x
-			 * -> sign * (a_values[indexOf(a_keys, a_keys[1] + x - 1)]),
-			 * arrayEnumerate(arrayResize(emptyArrayInt32(), (max_key)
-			 * -a_keys[1] + 1)))), [])
-			 */
-			appendStringInfoString(buf, "if(");
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colkey);
-			appendStringInfo(buf, "[1] <= (%s", max_key_alias);
-			appendStringInfoString(buf, "), arrayCumSum(arrayMap(x ->");
-
-			if (context->func && context->func->cf_type == CF_ISTORE_SUM
-				&& fpinfo->ch_table_engine == CH_COLLAPSING_MERGE_TREE)
-				appendStringInfo(buf, "%s * ", fpinfo->ch_table_sign_field);
-
-			appendStringInfoChar(buf, '(');
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colval);
-			appendStringInfoString(buf, "[indexOf(");
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colkey);
-			appendStringInfoChar(buf, ',');
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, colkey);
-			appendStringInfoString(buf, "[1] + x - 1)]), arrayEnumerate(arrayResize(emptyArrayInt32(), (");
-			appendStringInfo(buf, "%s) - ", max_key_alias);
-			appendStringInfoString(buf, colkey);
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-			appendStringInfoString(buf, "[1] + 1)))), [])");
-
-			pfree(colkey);
-			pfree(colval);
-
-			return;
-		}
-		else if (cinfo->coltype == CF_ISTORE_COL)
-		{
-			/*
-			 * (mapFill((finalizeAggregation(col) as t1).1, t1.2, <max_key>)
-			 * as t2).1, arrayCumSum(t2.2)
-			 *
-			 * simple: (mapFill((col as t1).1, t1.2, <max_key>) as t2).1,
-			 * arrayCumSum(t2.2)
-			 */
-
-			char	   *alias1 = get_alias_name();
-			char	   *alias2 = get_alias_name();
-
-			appendStringInfoString(buf, "(mapFill((");
-			if (cinfo->is_AggregateFunction == CF_AGGR_FUNC)
-				appendStringInfoString(buf, "finalizeAggregation(");
-			else
-				appendStringInfoChar(buf, '(');
-
-			if (qualify_col)
-				ADD_REL_QUALIFIER(buf, var->varno);
-
-			appendStringInfoString(buf, colname);
-			appendStringInfo(buf, ") as %s).1, %s.2", alias1, alias1);
-
-			if (list_length(node->args) > 1)
-			{
-				/* max key, for now just assume it keys are always int32 */
-				appendStringInfoString(buf, ", toInt32(assumeNotNull(");
-				deparseExpr((Expr *) list_nth(node->args, 1), context);
-				appendStringInfoString(buf, "))");
-			}
-			appendStringInfo(buf, ") as %s).1, arrayCumSum(%s.2)", alias2, alias2);
-
-			return;
-		}
-		else
-			elog(ERROR, "accumulate for this kind of istore not implemented");
-
-		if (!context->func)
-			appendStringInfoChar(buf, ')');
-	}
 
 	appendStringInfoChar(buf, '(');
-	if (cdef && cdef->cf_type == CF_AJTIME_DAY_DIFF)
-	{
-		appendStringInfoString(buf, "(cast(");
-		deparseExpr((Expr *) list_nth(node->args, 1), context);
-		appendStringInfoString(buf, ", 'DateTime') - ");
-		deparseExpr((Expr *) linitial(node->args), context);
-		appendStringInfoString(buf, ") / 86400)");
-		return;
-	}
-	else if (cdef && (cdef->cf_type == CF_TIMEZONE || cdef->cf_type == CF_MATCH))
+	if (cdef && (cdef->cf_type == CF_TIMEZONE || cdef->cf_type == CF_MATCH))
 	{
 		deparseExpr((Expr *) list_nth(node->args, 1), context);
 		appendStringInfoString(buf, ", ");
@@ -2652,45 +2311,6 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 	}
 
 	old_cdef = context->func;
-
-	/* sup_up requires only values part of array */
-	if (cdef && cdef->cf_type == CF_ISTORE_SUM_UP)
-	{
-		/*
-		 * sum_up(daily_time_spent_cohort, 12) => arraySum(arrayFilter((v, k)
-		 * -> k <= 12, daily_time_spent_cohort_values,
-		 * daily_time_spent_cohort_keys))
-		 *
-		 * sum_up(daily_time_spent_cohort) =>
-		 * arraySum(daily_time_spent_cohort_values)
-		 *
-		 * !!!! or in case of AggregateFunction:
-		 * sum_up(daily_time_spent_cohort, 12) => arraySum(arrayFilter((v, k)
-		 * -> k <= 12, (finalizeAggregation(daily_time_spent_cohort) as
-		 * _tmp).2, _tmp.1))
-		 *
-		 * sum_up(daily_time_spent_cohort) =>
-		 * arraySum(finalizeAggregation(daily_time_spent_cohort).2)
-		 */
-		funcdef = *cdef;
-		funcdef.cf_context = node->args;
-		context->func = &funcdef;
-
-		if (list_length(node->args) == 2)
-		{
-			appendStringInfoString(buf, "arrayFilter((v, k) -> k <= ");
-			appendStringInfoChar(buf, '(');
-			deparseExpr((Expr *) list_nth(node->args, 1), context);
-			appendStringInfoChar(buf, ')');
-			appendStringInfoChar(buf, ',');
-			deparseExpr((Expr *) linitial(node->args), context);
-			appendStringInfoChar(buf, ')');
-		}
-		else
-			deparseExpr((Expr *) linitial(node->args), context);
-
-		goto end;
-	}
 
 	/* ... and all the arguments */
 	first = true;
@@ -2703,7 +2323,6 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 		first = false;
 	}
 
-end:
 	context->func = old_cdef;
 	appendStringInfoChar(buf, ')');
 }
@@ -2810,9 +2429,6 @@ findFunction(Oid typoid, char *name)
 	catlist = SearchSysCacheList1(PROCNAMEARGSNSP,
 								  CStringGetDatum(name));
 
-	if (catlist->n_members == 0)
-		elog(ERROR, "pg_clickhouse requires istore extension to parse istore values");
-
 	for (i = 0; i < catlist->n_members; i++)
 	{
 		proctup = &catlist->members[i]->tuple;
@@ -2862,25 +2478,6 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 	{
 		switch (cdef->cf_type)
 		{
-			case CF_AJTIME_OPERATOR:
-				{
-					/* intervals with ajtime */
-					CustomObjectDef *fdef = chfdw_check_for_custom_function(form->oprcode);
-
-					if (fdef && fdef->cf_type == CF_AJTIME_PL_INTERVAL)
-					{
-						deparseIntervalOp(linitial(node->args),
-										  list_nth(node->args, 1), context, true);
-						goto cleanup;
-					}
-					else if (fdef && fdef->cf_type == CF_AJTIME_MI_INTERVAL)
-					{
-						deparseIntervalOp(linitial(node->args),
-										  list_nth(node->args, 1), context, false);
-						goto cleanup;
-					}
-				}
-				break;
 			case CF_TIMESTAMPTZ_PL_INTERVAL:
 				{
 					deparseIntervalOp(linitial(node->args),
@@ -2911,48 +2508,6 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 					else
 						elog(ERROR, "pg_clickhouse supports hstore fetchval "
 							 "only for scalars");
-
-					goto cleanup;
-				}
-				break;
-			case CF_ISTORE_FETCHVAL:
-				{
-					Node	   *arg = linitial(node->args);
-
-					if (IsA(arg, Var))
-					{
-						CustomObjectDef *temp;
-
-						temp = context->func;
-						context->func = cdef;
-
-						/* values[nullif(indexOf(ids, ... in deparseColumnRef */
-						deparseExpr((Expr *) arg, context);
-						deparseExpr((Expr *) list_nth(node->args, 1), context);
-						/* ... 0)] */
-						appendStringInfoString(buf, "), 0)]");
-
-						context->func = temp;
-					}
-					else if (IsA(arg, Const))
-					{
-						Const	   *constval = (Const *) arg;
-						Oid			akeys = findFunction(constval->consttype, "akeys");
-						Oid			avalues = findFunction(constval->consttype, "avals");
-
-						/*
-						 * ([val1, val2][nullif(indexOf([k1, k2], arg), 0])
-						 */
-						appendStringInfoChar(buf, '(');
-						deparseArray(OidFunctionCall1(avalues, constval->constvalue), context);
-						appendStringInfoString(buf, "[nullif(indexOf(");
-						deparseArray(OidFunctionCall1(akeys, constval->constvalue), context);
-						appendStringInfoString(buf, ", ");
-						deparseExpr((Expr *) list_nth(node->args, 1), context);
-						appendStringInfoString(buf, "), 0)])");
-					}
-					else
-						elog(ERROR, "pg_clickhouse supports fetchval only for columns and consts");
 
 					goto cleanup;
 				}

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -256,28 +256,10 @@ typedef enum
 	CF_SIGN_SUM,				/* SUM aggregation */
 	CF_SIGN_AVG,				/* AVG aggregation */
 	CF_SIGN_COUNT,				/* COUNT aggregation */
-	CF_ISTORE_TYPE,				/* istore type */
-	CF_ISTORE_SUM,				/* SUM on istore column */
-	CF_ISTORE_SUM_UP,			/* SUM_UP on istore column */
-	CF_ISTORE_ARR,				/* COLUMN splitted to array */
-	CF_ISTORE_COL,				/* COLUMN splitted to columns by key */
-	CF_ISTORE_FETCHVAL,			/* -> operation on istore */
-	CF_ISTORE_SEED,				/* istore_seed */
-	CF_ISTORE_ACCUMULATE,		/* accumulate */
-	CF_AJTIME_OPERATOR,			/* ajtime operation */
-	CF_AJTIME_TO_TIMESTAMP,		/* ajtime to timestamp */
 	CF_DATE_TRUNC,				/* date_trunc function */
 	CF_DATE_PART,				/* date_part function */
 	CF_TIMESTAMPTZ_PL_INTERVAL, /* timestamptz + interval */
 	CF_TIMEZONE,				/* timezone */
-	CF_COUNTRY_TYPE,
-	CF_AJTIME_PL_INTERVAL,
-	CF_AJTIME_MI_INTERVAL,
-	CF_AJTIME_TYPE,				/* ajtime type */
-	CF_AJTIME_DAY_DIFF,
-	CF_AJTIME_AJDATE,
-	CF_AJTIME_OUT,
-	CF_AJBOOL_OUT,
 	CF_HSTORE_FETCHVAL,			/* -> operation on hstore */
 	CF_INTARRAY_IDX,
 	CF_CH_FUNCTION,				/* adapted clickhouse function */

--- a/src/option.c
+++ b/src/option.c
@@ -152,7 +152,6 @@ InitChFdwOptions(void)
 		{"aggregatefunction", AttributeRelationId, false},
 		{"simpleaggregatefunction", AttributeRelationId, false},
 		{"column_name", AttributeRelationId, false},
-		{"arrays", AttributeRelationId, false},
 		{NULL, InvalidOid, false}
 	};
 

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -906,9 +906,6 @@ parse_type(char *table_name, char *colname, char *typepart, bool *is_nullable, L
 				*options = lappend(*options, makeString(func));
 			}
 
-			if (strncmp(func, "sumMap", 6) == 0)
-				return "istore";
-
 			return parse_type(table_name, colname, pos2 + 2, is_nullable, options);
 		}
 


### PR DESCRIPTION
There was a whole lot of code to support a number of Ajust GmbH extensions inherited from the old clickhouse_fdw code: [ajbool], ajtime, [country], and [istore]. Presumably they would allow those extensions' custom data types and functions to work with ClickHouse.

pg_clickhouse takes a different approach, aiming to support all the data types in ClickHouse and PostgreSQL, but not non-core custom PostgreSQL data type extensions unless they prove essential to map to specific ClickHouse types.

So remove all the code for those extensions.

Leave, however, the code that supports the in-core intarray and hstore extensions. Expect future work to flesh out that support.

  [ajbool]: https://pgxn.org/dist/ajbool/ "ajbool on PGXN"
  [country]: https://pgxn.org/dist/country/ "country on PGXN"
  [istore]: https://pgxn.org/dist/istore/ "istore on PGXN"