### PR TITLE
Add ClickHouse 25.12 to CI and fix issues

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         # Test latest version and all LTS releases.
         # Keep in sync with dev/docker-compose.yml.
-        # .github/ubuntu/ch-versions --lts --latest-stable --earliest 22  --prefix '          - ' | pbcopy
+        # .github/ubuntu/ch-versions --lts --latest-stable --earliest 23  --prefix '          - ' | pbcopy
         ch:
-          - 25.11.2.24-stable
+          - 25.12.1.649-stable
           - 25.8.12.129-lts
-          - 25.3.9.72-lts
+          - 25.3.10.19-lts
           - 24.8.14.39-lts
           - 24.3.18.7-lts
           - 23.8.16.40-lts

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -13,15 +13,15 @@ volumes:
   config:
 
 services:
-  ch_25_11:
+  ch_25_12:
     image: pgxn/pgxn-tools
-    container_name: ch_25_11
+    container_name: ch_25_12
     platform: linux/amd64
     stdin_open: true
     stop_grace_period: 10ms
     environment:
       PGUSER: postgres
-      CH_RELEASE: 25.11.2.24-stable
+      CH_RELEASE: 25.12.1.649-stable
     working_dir: /work
     volumes:
       - ..:/work
@@ -60,7 +60,7 @@ services:
     stop_grace_period: 10ms
     environment:
       PGUSER: postgres
-      CH_RELEASE: 25.3.9.72-lts
+      CH_RELEASE: 25.3.10.19-lts
     working_dir: /work
     volumes:
       - ..:/work

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -422,7 +422,7 @@ clickhouseGetForeignRelSize(PlannerInfo * root,
 	{
 		appendStringInfoChar(fpinfo->relation_name, ' ');
 		appendStringInfoString(fpinfo->relation_name,
-						 quote_identifier(rte->eref->aliasname));
+							   quote_identifier(rte->eref->aliasname));
 	}
 
 	/* No outer and inner relations. */

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -132,13 +132,20 @@ http_disconnect(void *conn)
 static char *
 format_error(char *errstring)
 {
-	int			n = strlen(errstring);
+	size_t		n = strlen(errstring);
 
 	for (int i = 0; i < n; i++)
 	{
 		if (strncmp(errstring + i, "version", 7) == 0)
 			return pnstrdup(errstring, i - 2);
 	}
+
+	/*
+	 * For some reason ClickHouse 25.12 added a newline to an auth failure
+	 * error. Strip it out.
+	 */
+	if (n > 0 && errstring[n - 1] == '\n')
+		errstring[--n] = '\0';
 
 	return errstring;
 }
@@ -936,10 +943,10 @@ chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * se
 	char	  **row_values;
 
 	query.sql = psprintf("SELECT name, engine, engine_full "
-				   "FROM system.tables "
-				   "WHERE name NOT LIKE '.inner%%' "
-				   "AND database = %s",
-				   ch_quote_literal(stmt->remote_schema));
+						 "FROM system.tables "
+						 "WHERE name NOT LIKE '.inner%%' "
+						 "AND database = %s",
+						 ch_quote_literal(stmt->remote_schema));
 
 	cursor = conn.methods->simple_query(conn.conn, &query);
 


### PR DESCRIPTION
Replace 25.11 with 25.12 and replace 25.3.9 with 25.3.10. The pattern here is to run the latest release plus all previous lts releases.

Oddly, 25.12 returns an error string with a trailing newline on auth failure. So strip it out.

Also, run `make indent` and let it change the indentation of a query in `chfdw_construct_create_tables()`.