### PR TITLE
Add support for parameterized execution

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -184,6 +184,20 @@ static QuerySettings ch_binary_settings(const ch_query *query)
 	return res;
 }
 
+/*
+ * Converts query->param_values to QueryParams.
+ */
+static QueryParams ch_binary_params(const ch_query *query)
+{
+	int i;
+	auto res = QueryParams{};
+
+	for (i = 0; i < query->num_params; i++)
+		res.insert_or_assign(psprintf("p%d", i+1), QueryParamValue(query->param_values[i]));
+
+	return res;
+}
+
 static void set_state_error(ch_binary_read_state_t * state, const char * str)
 {
 	assert(state->error == NULL);
@@ -205,6 +219,8 @@ ch_binary_response_t * ch_binary_simple_query(
 		client->Select(
 			clickhouse::Query(query->sql).SetQuerySettings(
 				ch_binary_settings(query)
+			).SetParams(
+				ch_binary_params(query)
 			).OnDataCancelable([&resp, &values, &check_cancel](const Block & block) {
 				if (check_cancel && check_cancel())
 				{
@@ -342,6 +358,8 @@ void ch_binary_prepare_insert(void * conn, const ch_query * query, ch_binary_ins
 		block = new Block(client->BeginInsert(
 			clickhouse::Query(std::string(query->sql)+ " VALUES").SetQuerySettings(
 				ch_binary_settings(query)
+			).SetParams(
+				ch_binary_params(query)
 			)
 		));
 		*/

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -132,6 +132,7 @@ static void deparseRelation(StringInfo buf, Relation rel);
 static void deparseExpr(Expr * expr, deparse_expr_cxt * context);
 static void deparseVar(Var * node, deparse_expr_cxt * context);
 static void deparseConst(Const * node, deparse_expr_cxt * context, int showtype);
+static void deparseParam(Param * node, deparse_expr_cxt * context);
 static void deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context);
 static void deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context);
 static void deparseOpExpr(OpExpr * node, deparse_expr_cxt * context);
@@ -146,6 +147,10 @@ static void deparseBoolExpr(BoolExpr * node, deparse_expr_cxt * context);
 static void deparseNullTest(NullTest * node, deparse_expr_cxt * context);
 static void deparseArrayExpr(ArrayExpr * node, deparse_expr_cxt * context);
 static void deparseArrayList(ArrayExpr * node, deparse_expr_cxt * context);
+static void printRemoteParam(int paramindex, Oid paramtype, int32 paramtypmod,
+							 deparse_expr_cxt * context);
+static void printRemotePlaceholder(Oid paramtype, int32 paramtypmod,
+								   deparse_expr_cxt * context);
 static void deparseSelectSql(List * tlist, bool is_subquery, List * *retrieved_attrs,
 							 deparse_expr_cxt * context);
 static void appendOrderByClause(List * pathkeys, bool has_final_sort,
@@ -343,8 +348,23 @@ foreign_expr_walker(Node * node,
 			break;
 		case T_Param:
 			{
-				/* We are not supporting param push down */
-				return false;
+				Param	   *p = (Param *) node;
+
+				/*
+				 * If it's a MULTIEXPR Param, punt.  We can't tell from here
+				 * whether the referenced sublink/subplan contains any remote
+				 * Vars; if it does, handling that is too complicated to
+				 * consider supporting at present.  Fortunately, MULTIEXPR
+				 * Params are not reduced to plain PARAM_EXEC until the end of
+				 * planning, so we can easily detect this case.  (Normal
+				 * PARAM_EXEC Params are safe to ship because their values
+				 * come from somewhere else in the plan tree; but a MULTIEXPR
+				 * references a sub-select elsewhere in the same targetlist,
+				 * so we'd be on the hook to evaluate it somehow if we wanted
+				 * to handle such cases as direct foreign updates.)
+				 */
+				if (p->paramkind == PARAM_MULTIEXPR)
+					return false;
 			}
 			break;
 		case T_SubscriptingRef:
@@ -653,6 +673,55 @@ foreign_expr_walker(Node * node,
 	if (inner_cxt.found_AggregateFunction)
 		outer_cxt->found_AggregateFunction = true;
 	return true;
+}
+
+/*
+ * Returns true if given expr is something we'd have to send the value of
+ * to the foreign server.
+ *
+ * This should return true when the expression is a shippable node that
+ * deparseExpr would add to context->params_list.  Note that we don't care
+ * if the expression *contains* such a node, only whether one appears at top
+ * level.  We need this to detect cases where setrefs.c would recognize a
+ * false match between an fdw_exprs item (which came from the params_list)
+ * and an entry in fdw_scan_tlist (which we're considering putting the given
+ * expression into).
+ */
+bool
+is_foreign_param(PlannerInfo * root,
+				 RelOptInfo * baserel,
+				 Expr * expr)
+{
+	if (expr == NULL)
+		return false;
+
+	switch (nodeTag(expr))
+	{
+		case T_Var:
+			{
+				/* It would have to be sent unless it's a foreign Var */
+				Var		   *var = (Var *) expr;
+				CHFdwRelationInfo *fpinfo = (CHFdwRelationInfo *) (baserel->fdw_private);
+				Relids		relids;
+
+				if (IS_UPPER_REL(baserel))
+					relids = fpinfo->outerrel->relids;
+				else
+					relids = baserel->relids;
+
+				if (bms_is_member(var->varno, relids) && var->varlevelsup == 0)
+					return false;	/* foreign Var, so not a param */
+				else
+					return true;	/* it'd have to be a param */
+				break;
+			}
+		case T_Param:
+			/* Params always have to be sent to the foreign server */
+			return true;
+		default:
+			break;
+	}
+	return false;
 }
 
 /*
@@ -1713,6 +1782,9 @@ deparseExpr(Expr * node, deparse_expr_cxt * context)
 		case T_Const:
 			deparseConst((Const *) node, context, 0);
 			break;
+		case T_Param:
+			deparseParam((Param *) node, context);
+			break;
 		case T_SubscriptingRef:
 			deparseSubscriptingRef((SubscriptingRef *) node, context);
 			break;
@@ -1812,7 +1884,34 @@ deparseVar(Var * node, deparse_expr_cxt * context)
 						 planner_rt_fetch(node->varno, context->root),
 						 qualify_col);
 	else
-		elog(ERROR, "pg_clickhouse does not support params");
+	{
+		/* Treat like a Param */
+		if (context->params_list)
+		{
+			int			pindex = 0;
+			ListCell   *lc;
+
+			/* find its index in params_list */
+			foreach(lc, *context->params_list)
+			{
+				pindex++;
+				if (equal(node, (Node *) lfirst(lc)))
+					break;
+			}
+			if (lc == NULL)
+			{
+				/* not in list, so add it */
+				pindex++;
+				*context->params_list = lappend(*context->params_list, node);
+			}
+
+			printRemoteParam(pindex, node->vartype, node->vartypmod, context);
+		}
+		else
+		{
+			printRemotePlaceholder(node->vartype, node->vartypmod, context);
+		}
+	}
 }
 
 #define USE_ISO_DATES			1
@@ -2103,6 +2202,81 @@ cleanup:
 	if (extval)
 		pfree(extval);
 
+}
+
+/*
+ * Deparse given Param node.
+ *
+ * If we're generating the query "for real", add the Param to
+ * context->params_list if it's not already present, and then use its index
+ * in that list as the remote parameter number.  During EXPLAIN, there's
+ * no need to identify a parameter number.
+ */
+static void
+deparseParam(Param * node, deparse_expr_cxt * context)
+{
+	if (context->params_list)
+	{
+		int			pindex = 0;
+		ListCell   *lc;
+
+		/* find its index in params_list */
+		foreach(lc, *context->params_list)
+		{
+			pindex++;
+			if (equal(node, (Node *) lfirst(lc)))
+				break;
+		}
+		if (lc == NULL)
+		{
+			/* not in list, so add it */
+			pindex++;
+			*context->params_list = lappend(*context->params_list, node);
+		}
+
+		printRemoteParam(pindex, node->paramtype, node->paramtypmod, context);
+	}
+	else
+	{
+		printRemotePlaceholder(node->paramtype, node->paramtypmod, context);
+	}
+}
+
+/*
+ * Print the representation of a parameter to be sent to the remote side
+ * by param number and remote data type.
+ */
+static void
+printRemoteParam(int paramindex, Oid paramtype, int32 paramtypmod,
+				 deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	char	   *ptypename = deparse_type_name(paramtype, paramtypmod);
+
+	appendStringInfo(buf, "{p%d:%s}", paramindex, ptypename);
+}
+
+/*
+ * Print the representation of a placeholder for a parameter that will be
+ * sent to the remote side at execution time.
+ *
+ * This is used when we're just trying to EXPLAIN the remote query. We don't
+ * have the actual value of the runtime parameter yet, and we don't want the
+ * remote planner to generate a plan that depends on such a value anyway.
+ * Thus, we can't do something simple like "CAST($1 AS paramtype)". Instead,
+ * we emit "SELECT CAST(NULL AS Nullable(paramtype))", which ClickHouse's
+ * planner should see as an unknown constant value, which is what we want.
+ * This might need adjustment if we ever make the planner flatten scalar
+ * subqueries.
+ */
+static void
+printRemotePlaceholder(Oid paramtype, int32 paramtypmod,
+					   deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	char	   *ptypename = deparse_type_name(paramtype, paramtypmod);
+
+	appendStringInfo(buf, "((SELECT CAST(null AS Nullable(%s))", ptypename);
 }
 
 /*

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -256,6 +256,10 @@ static void prepare_query_params(PlanState * node,
 								 FmgrInfo * *param_flinfo,
 								 List * *param_exprs,
 								 const char ***param_values);
+static void process_query_params(ExprContext * econtext,
+								 FmgrInfo * param_flinfo,
+								 List * param_exprs,
+								 const char **param_values);
 static bool foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel,
 							JoinType jointype, RelOptInfo * outerrel, RelOptInfo * innerrel,
 							JoinPathExtraData * extra);
@@ -285,7 +289,7 @@ Datum
 clickhouse_raw_query(PG_FUNCTION_ARGS)
 {
 	char	   *connstring = text_to_cstring(PG_GETARG_TEXT_P(1));
-	ch_query	query = new_query(text_to_cstring(PG_GETARG_TEXT_P(0)));
+	ch_query	query = new_query(text_to_cstring(PG_GETARG_TEXT_P(0)), 0, NULL);
 
 	ch_connection_details *details = connstring_parse(connstring);
 	ch_connection conn = chfdw_http_connect(details);
@@ -972,16 +976,32 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 {
 	HeapTuple	tup;
 	ChFdwScanState *fsstate = (ChFdwScanState *) node->fdw_state;
+	ExprContext *econtext = node->ss.ps.ps_ExprContext;
+	int			numParams = fsstate->numParams;
+	const char **values = fsstate->param_values;
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
 	struct timeval time1,
 				time2;
 	TupleDesc	tupdesc;
-	ch_query	query = new_query(fsstate->query);
+	ch_query	query = new_query(fsstate->query, fsstate->numParams, fsstate->param_values);
 
 	/* make query if needed */
 	if (fsstate->ch_cursor == NULL)
 	{
 		MemoryContext old = MemoryContextSwitchTo(fsstate->batch_cxt);
+
+		/*
+		 * Construct array of query parameter values in text format.  We do
+		 * the conversions in the short-lived per-tuple context, so as not to
+		 * cause a memory leak over repeated scans.
+		 */
+		if (numParams > 0)
+		{
+			process_query_params(econtext,
+								 fsstate->param_flinfo,
+								 fsstate->param_exprs,
+								 values);
+		}
 
 		fsstate->ch_cursor = fsstate->conn.methods->simple_query(fsstate->conn.conn,
 																 &query);
@@ -1383,7 +1403,7 @@ create_foreign_modify(EState * estate,
 	UserMapping *user;
 	MemoryContext old_mcxt;
 	Relation	rel = rri->ri_RelationDesc;
-	ch_query	q = new_query(query);
+	ch_query	q = new_query(query, 0, NULL);
 
 	/* Begin constructing CHFdwModifyState. */
 	fmstate = (CHFdwModifyState *) palloc0(sizeof(CHFdwModifyState));
@@ -1475,6 +1495,45 @@ prepare_query_params(PlanState * node,
 
 	/* Allocate buffer for text form of query parameters. */
 	*param_values = (const char **) palloc0(numParams * sizeof(char *));
+}
+
+/*
+ * Construct array of query parameter values in text format.
+ */
+static void
+process_query_params(ExprContext * econtext,
+					 FmgrInfo * param_flinfo,
+					 List * param_exprs,
+					 const char **param_values)
+{
+	int			i;
+	ListCell   *lc;
+
+	i = 0;
+	foreach(lc, param_exprs)
+	{
+		ExprState  *expr_state = (ExprState *) lfirst(lc);
+		Datum		expr_value;
+		bool		isNull;
+
+		/* Evaluate the parameter expression */
+		expr_value = ExecEvalExpr(expr_state, econtext, &isNull);
+
+		/*
+		 * Get string representation of each parameter value by invoking
+		 * type-specific output function, unless the value is null.
+		 */
+		if (isNull)
+		{
+			param_values[i] = NULL;
+		}
+		else
+		{
+			param_values[i] = OutputFunctionCall(&param_flinfo[i], expr_value);
+		}
+
+		i++;
+	}
 }
 
 /*
@@ -2178,6 +2237,15 @@ foreign_grouping_ok(PlannerInfo * root, RelOptInfo * grouped_rel,
 	 * server. All GROUP BY expressions will be part of the grouping target
 	 * and thus there is no need to search for them separately. Add grouping
 	 * expressions into target list which will be passed to foreign server.
+	 *
+	 * A tricky fine point is that we must not put any expression into the
+	 * target list that is just a foreign param (that is, something that
+	 * deparse.c would conclude has to be sent to the foreign server).  If we
+	 * do, the expression will also appear in the fdw_exprs list of the plan
+	 * node, and setrefs.c will get confused and decide that the fdw_exprs
+	 * entry is actually a reference to the fdw_scan_tlist entry, resulting in
+	 * a broken plan.  Somewhat oddly, it's OK if the expression contains such
+	 * a node, as long as it's not at top level; then no match is possible.
 	 */
 	i = 0;
 	foreach(lc, grouping_target->exprs)
@@ -2196,6 +2264,13 @@ foreign_grouping_ok(PlannerInfo * root, RelOptInfo * grouped_rel,
 			 * push down aggregation to the foreign server.
 			 */
 			if (!chfdw_is_foreign_expr(root, grouped_rel, expr))
+				return false;
+
+			/*
+			 * If it would be a foreign param, we can't put it into the tlist,
+			 * so we have to fail.
+			 */
+			if (is_foreign_param(root, grouped_rel, expr))
 				return false;
 
 			/*

--- a/src/http.c
+++ b/src/http.c
@@ -160,6 +160,9 @@ ch_http_simple_query(ch_http_connection_t * conn, const ch_query * query)
 	CURLU	   *cu = curl_url();
 	kv_iter		iter;
 	char	   *buf = NULL;
+	curl_mime  *form;
+	curl_mimepart *part;
+	int			i;
 
 	ch_http_response_t *resp = calloc(sizeof(ch_http_response_t), 1);
 
@@ -197,7 +200,6 @@ ch_http_simple_query(ch_http_connection_t * conn, const ch_query * query)
 
 	/* variable */
 	curl_easy_setopt(conn->curl, CURLOPT_WRITEDATA, resp);
-	curl_easy_setopt(conn->curl, CURLOPT_POSTFIELDS, query->sql);
 	curl_easy_setopt(conn->curl, CURLOPT_VERBOSE, curl_verbose);
 	if (curl_progressfunc)
 	{
@@ -210,15 +212,44 @@ ch_http_simple_query(ch_http_connection_t * conn, const ch_query * query)
 	if (conn->dbname)
 	{
 		headers = curl_slist_append(headers, psprintf("%s: %s", DATABASE_HEADER, conn->dbname));
+		if (!headers)
+		{
+			curl_free(url);
+			resp->http_status = -1;
+			resp->data = "out of memory";
+			return resp;
+		}
 		curl_easy_setopt(conn->curl, CURLOPT_HTTPHEADER, headers);
 	}
+
+	/* Construct and add the the POST form data. */
+	form = curl_mime_init(conn->curl);
+	if (!form)
+	{
+		curl_free(url);
+		if (headers)
+			curl_slist_free_all(headers);
+		resp->http_status = -1;
+		resp->data = "out of memory";
+		return resp;
+	}
+	part = curl_mime_addpart(form);
+	curl_mime_name(part, "query");
+	curl_mime_data(part, query->sql, CURL_ZERO_TERMINATED);
+	for (i = 0; i < query->num_params; i++)
+	{
+		part = curl_mime_addpart(form);
+		curl_mime_name(part, psprintf("param_p%d", i + 1));
+		curl_mime_data(part, query->param_values[i], CURL_ZERO_TERMINATED);
+	}
+	curl_easy_setopt(conn->curl, CURLOPT_MIMEPOST, form);
 
 	curl_error_happened = false;
 	errcode = curl_easy_perform(conn->curl);
 	curl_free(url);
+	curl_mime_free(form);
 	if (headers)
 		curl_slist_free_all(headers);
-
 
 	if (errcode == CURLE_ABORTED_BY_CALLBACK)
 	{

--- a/src/include/engine.h
+++ b/src/include/engine.h
@@ -21,9 +21,11 @@ typedef struct
 typedef struct
 {
    const char     *sql;
+   const int num_params;
+   const char **param_values;
    const kv_list    *settings;
 }          ch_query;
 
-#define new_query(sql) {sql, chfdw_get_session_settings()}
+#define new_query(sql, num, vals) {sql, num, vals, chfdw_get_session_settings()}
 
 #endif							/* CLICKHOUSE_ENGINE_H */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -216,6 +216,9 @@ extern void chfdw_classify_conditions(PlannerInfo * root,
 extern bool chfdw_is_foreign_expr(PlannerInfo * root,
 								  RelOptInfo * baserel,
 								  Expr * expr);
+extern bool is_foreign_param(PlannerInfo *root,
+							 RelOptInfo *baserel,
+							 Expr *expr);
 extern char *chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry * rte,
 									  Index rtindex, Relation rel,
 									  List * targetAttrs);

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -156,7 +156,7 @@ kill_query(void *conn, const char *query_id)
 	ch_http_response_t *resp;
 	ch_query	query = new_query(psprintf(
 										   "kill query where query_id=%s",
-										   ch_quote_literal(query_id)));
+										   ch_quote_literal(query_id)), 0, NULL);
 
 	ch_http_set_progress_func(NULL);
 	resp = ch_http_simple_query(conn, &query);
@@ -498,7 +498,7 @@ http_insert_tuple(void *istate, TupleTableSlot * slot)
 	if ((slot == NULL && state->sql.len > 0)
 		|| state->sql.len > (MaxAllocSize / 2 /* 512MB */ ))
 	{
-		ch_query	query = new_query(state->sql.data);
+		ch_query	query = new_query(state->sql.data, 0, NULL);
 
 		http_simple_insert(state->conn, &query);
 		resetStringInfo(&state->sql);
@@ -934,7 +934,7 @@ chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * se
 	UserMapping *user = GetUserMapping(userid, server->serverid);
 	ch_connection conn = chfdw_get_connection(user);
 	ch_cursor  *cursor;
-	ch_query	query = new_query(NULL);
+	ch_query	query = new_query(NULL, 0, NULL);
 	List	   *result = NIL,
 			   *datts = NIL;
 	char	  **row_values;

--- a/test/expected/param.out
+++ b/test/expected/param.out
@@ -1,0 +1,667 @@
+SET datestyle = 'ISO';
+-- Create servers for each engine.
+CREATE SERVER param_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+-- Create the schema in ClickHouse.
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE param_test.ft1 (
+        c1 Int,
+        c2 Int,
+        c3 String,
+        c4 Date,
+        c5 Date,
+        c6 String,
+        c7 String,
+        c8 String
+    ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert some data.
+SELECT clickhouse_raw_query($$
+    INSERT INTO param_test.ft1
+    SELECT number,
+           number % 10,
+           toString(number),
+           addDays(toDate('1970-01-01'), number % 100),
+           addDays(toDate('1970-01-01'), number % 100),
+           number % 10,
+           number % 10,
+           'foo'
+    FROM numbers(1, 110)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- ===================================================================
+-- binary foreign tables
+-- ===================================================================
+CREATE SCHEMA bin_test;
+CREATE FOREIGN TABLE bin_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE bin_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- binary parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM bin_test.ft1 t1, bin_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- ===================================================================
+-- http foreign tables
+-- ===================================================================
+CREATE SCHEMA http_test;
+CREATE FOREIGN TABLE http_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE http_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- http parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM http_test.ft1 t1, http_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- Clean up.
+DROP USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+DROP SERVER param_bin_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table bin_test.ft1
+drop cascades to foreign table bin_test.ft2
+DROP USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+DROP SERVER param_http_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table http_test.ft1
+drop cascades to foreign table http_test.ft2

--- a/test/expected/param_1.out
+++ b/test/expected/param_1.out
@@ -1,0 +1,667 @@
+SET datestyle = 'ISO';
+-- Create servers for each engine.
+CREATE SERVER param_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+-- Create the schema in ClickHouse.
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE param_test.ft1 (
+        c1 Int,
+        c2 Int,
+        c3 String,
+        c4 Date,
+        c5 Date,
+        c6 String,
+        c7 String,
+        c8 String
+    ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert some data.
+SELECT clickhouse_raw_query($$
+    INSERT INTO param_test.ft1
+    SELECT number,
+           number % 10,
+           toString(number),
+           addDays(toDate('1970-01-01'), number % 100),
+           addDays(toDate('1970-01-01'), number % 100),
+           number % 10,
+           number % 10,
+           'foo'
+    FROM numbers(1, 110)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- ===================================================================
+-- binary foreign tables
+-- ===================================================================
+CREATE SCHEMA bin_test;
+CREATE FOREIGN TABLE bin_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE bin_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- binary parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM bin_test.ft1 t1, bin_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1 (returns $0)
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- ===================================================================
+-- http foreign tables
+-- ===================================================================
+CREATE SCHEMA http_test;
+CREATE FOREIGN TABLE http_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE http_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- http parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM http_test.ft1 t1, http_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1 (returns $0)
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- Clean up.
+DROP USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+DROP SERVER param_bin_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table bin_test.ft1
+drop cascades to foreign table bin_test.ft2
+DROP USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+DROP SERVER param_http_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table http_test.ft1
+drop cascades to foreign table http_test.ft2

--- a/test/expected/param_2.out
+++ b/test/expected/param_2.out
@@ -1,0 +1,667 @@
+SET datestyle = 'ISO';
+-- Create servers for each engine.
+CREATE SERVER param_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+-- Create the schema in ClickHouse.
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE param_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE param_test.ft1 (
+        c1 Int,
+        c2 Int,
+        c3 String,
+        c4 Date,
+        c5 Date,
+        c6 String,
+        c7 String,
+        c8 String
+    ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Insert some data.
+SELECT clickhouse_raw_query($$
+    INSERT INTO param_test.ft1
+    SELECT number,
+           number % 10,
+           toString(number),
+           addDays(toDate('1970-01-01'), number % 100),
+           addDays(toDate('1970-01-01'), number % 100),
+           number % 10,
+           number % 10,
+           'foo'
+    FROM numbers(1, 110)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- ===================================================================
+-- binary foreign tables
+-- ===================================================================
+CREATE SCHEMA bin_test;
+CREATE FOREIGN TABLE bin_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE bin_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- binary parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM bin_test.ft1 t1, bin_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
+----+----+----+------------------------+---------------------+----+----+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on bin_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on bin_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1 (returns $0)
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- ===================================================================
+-- http foreign tables
+-- ===================================================================
+CREATE SCHEMA http_test;
+CREATE FOREIGN TABLE http_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+CREATE FOREIGN TABLE http_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+-- ===================================================================
+-- http parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM http_test.ft1 t1, http_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c3, t2.c3
+   Relations: (ft1 t1) INNER JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c3, r2.c3 FROM  param_test.ft1 r1 ALL INNER JOIN param_test.ft1 r2 ON (TRUE) WHERE ((r2.c1 = 2)) AND ((r1.c1 = 1))
+(4 rows)
+
+EXECUTE st1(1, 1);
+ c3 | c3 
+----+----
+ 1  | 1
+(1 row)
+
+EXECUTE st1(101, 101);
+ c3  | c3  
+-----+-----
+ 101 | 101
+(1 row)
+
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c4) = '1970-01-17')) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st2(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st2(101, 121);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+RESET enable_hashjoin;
+RESET enable_sort;
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+                                                                                                                                     QUERY PLAN                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: t1.c1, t1.c2, t1.c3, t1.c4, t1.c5, t1.c6, t1.c7, t1.c8
+   Relations: (ft1 t1) LEFT SEMI JOIN (ft2 t2)
+   Remote SQL: SELECT r1.c1, r1.c2, r1.c3, r1.c4, r1.c5, r1.c6, r1.c7, r1.c8 FROM  param_test.ft1 r1 LEFT SEMI JOIN param_test.ft1 r3 ON (((r3.c1 > 10)) AND ((date(r3.c5) = date('1970-01-17 08:00:00'))) AND ((r1.c3 = r3.c3))) WHERE ((r1.c1 < 20)) ORDER BY r1.c1 ASC NULLS LAST
+(4 rows)
+
+EXECUTE st3(10, 20);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+(1 row)
+
+EXECUTE st3(20, 30);
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = 1))
+(3 rows)
+
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+(3 rows)
+
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+(3 rows)
+
+EXECUTE st5('foo', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+(1 row)
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.t1 WHERE ((c1 = c2)) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+EXECUTE st6;
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
+----+----+----+------------------------+---------------------+----+------------+-----
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+(9 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+                                                                                 QUERY PLAN                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on http_test.ft1
+   ->  Result
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+(3 rows)
+
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on http_test.ft1
+   Output: ft1.c1, ft1.c2
+   Remote SQL: SELECT c1, c2 FROM param_test.ft1 WHERE ((c1 = {p1:Int32}))
+   InitPlan 1 (returns $0)
+     ->  Result
+           Output: 4
+(6 rows)
+
+SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+ c1 | c2 
+----+----
+  4 |  4
+(1 row)
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+-- Clean up.
+DROP USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+DROP SERVER param_bin_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table bin_test.ft1
+drop cascades to foreign table bin_test.ft2
+DROP USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+DROP SERVER param_http_svr CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table http_test.ft1
+drop cascades to foreign table http_test.ft2

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -115,6 +115,19 @@ json.sql
  24.8-25.3  | json_1.out
  22-24.3    | json_2.out
 
+param.sql
+---------
+
+ Postgres | File
+----------|-------------
+ 14-18    | param.out
+ 14-16    | param_1.out
+ 13       | param_2.out
+
+ ClickHouse | File
+------------|-----------
+ 23-25      | param.out
+
 subquery_pushdown.sql
 ---------------------
 

--- a/test/sql/param.sql
+++ b/test/sql/param.sql
@@ -1,0 +1,251 @@
+SET datestyle = 'ISO';
+-- Create servers for each engine.
+CREATE SERVER param_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+
+CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+
+-- Create the schema in ClickHouse.
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
+SELECT clickhouse_raw_query('CREATE DATABASE param_test');
+SELECT clickhouse_raw_query($$
+    CREATE TABLE param_test.ft1 (
+        c1 Int,
+        c2 Int,
+        c3 String,
+        c4 Date,
+        c5 Date,
+        c6 String,
+        c7 String,
+        c8 String
+    ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
+$$);
+
+-- Insert some data.
+SELECT clickhouse_raw_query($$
+    INSERT INTO param_test.ft1
+    SELECT number,
+           number % 10,
+           toString(number),
+           addDays(toDate('1970-01-01'), number % 100),
+           addDays(toDate('1970-01-01'), number % 100),
+           number % 10,
+           number % 10,
+           'foo'
+    FROM numbers(1, 110)
+$$);
+
+-- ===================================================================
+-- binary foreign tables
+-- ===================================================================
+CREATE SCHEMA bin_test;
+
+CREATE FOREIGN TABLE bin_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+
+CREATE FOREIGN TABLE bin_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_bin_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+
+-- ===================================================================
+-- binary parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM bin_test.ft1 t1, bin_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+
+EXECUTE st1(1, 1);
+EXECUTE st1(101, 101);
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+EXECUTE st2(10, 20);
+EXECUTE st2(101, 121);
+RESET enable_hashjoin;
+RESET enable_sort;
+
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM bin_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+EXECUTE st3(10, 20);
+EXECUTE st3(20, 30);
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXECUTE st5('foo', 1);
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+EXECUTE st6;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
+
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+
+-- ===================================================================
+-- http foreign tables
+-- ===================================================================
+CREATE SCHEMA http_test;
+
+CREATE FOREIGN TABLE http_test.ft1 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'ft1',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+
+CREATE FOREIGN TABLE http_test.ft2 (
+	c1 int NOT NULL,
+	c2 int NOT NULL,
+	c3 text,
+	c4 timestamptz,
+	c5 timestamp,
+	c6 varchar(10),
+	c7 char(10) default 'f21',
+	c8 text
+) SERVER param_http_svr OPTIONS(
+    database 'param_test',
+    table_name 'ft1'
+);
+
+-- ===================================================================
+-- http parameterized queries
+-- ===================================================================
+-- simple join
+PREPARE st1(int, int) AS SELECT t1.c3, t2.c3 FROM http_test.ft1 t1, http_test.ft2 t2 WHERE t1.c1 = $1 AND t2.c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
+
+EXECUTE st1(1, 1);
+EXECUTE st1(101, 101);
+SET enable_hashjoin TO off;
+SET enable_sort TO off;
+-- subquery using stable function (can't be sent to remote, but is?)
+PREPARE st2(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c4) = date('1970-01-17')) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
+EXECUTE st2(10, 20);
+EXECUTE st2(101, 121);
+RESET enable_hashjoin;
+RESET enable_sort;
+
+-- subquery using immutable function (can be sent to remote)
+PREPARE st3(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 < $2 AND t1.c3 IN (SELECT c3 FROM http_test.ft2 t2 WHERE c1 > $1 AND date(c5) = date('1970-01-17'::timestamptz)) ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
+EXECUTE st3(10, 20);
+EXECUTE st3(20, 30);
+
+-- custom plan should be chosen initially
+PREPARE st4(int) AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = $1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+-- once we try it enough times, should switch to generic plan
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
+-- value of $1 should not be sent to remote
+PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
+EXECUTE st5('foo', 1);
+
+-- altering FDW options requires replanning
+PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
+EXECUTE st6;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
+SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
+
+-- implicit parameter
+EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);
+
+-- cleanup
+DEALLOCATE st1;
+DEALLOCATE st2;
+DEALLOCATE st3;
+DEALLOCATE st4;
+DEALLOCATE st5;
+DEALLOCATE st6;
+DEALLOCATE st7;
+
+-- Clean up.
+DROP USER MAPPING FOR CURRENT_USER SERVER param_bin_svr;
+DROP SERVER param_bin_svr CASCADE;
+DROP USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
+DROP SERVER param_http_svr CASCADE;


### PR DESCRIPTION
The `PREPARE` command requires parameterized execution, as do some SQL queries. For example, PostgreSQL converts this query:

    SELECT * FROM foo
     WHERE id = (SELECT 2);

To this parameterized query:

    SELECT * FROM foo
     WHERE id = $1

postgres_fdw has supported parameterized execution for a long time, and there are vestiges of that feature from the original clickhouse_fdw code included here. Perhaps ClickHouse didn't support parameterized queries back then, but it does now.

Add the functions necessary to build on the existing `params_list`, `numParams`, and `param_values` values to support parameterized execution. Use the ClickHouse parameter format, `{param_name:data_type}`, for parameters in queries, and pass the values via both the binary and http engines.

When using `PREPARE`, the first five executions will send the literal values rather than the parameter placeholders. The sixth and subsequent calls will have the parameter placeholders and pass the parameters separately. Postgres itself decides on this division between a custom plan (with literals) or a generic plan (with placeholders) as described in [PREPARE Notes].

Most of this code comes right from postgres_fdw, mainly to handle cases of `T_Param` nodes. IN addition:

*   Pass the number of params and the params to `new_query()` to be included in a `ch_query`, so that the engines can send them
*   Use `Query.SetParams()` to send params with the binary engine
*   Use a `POST` request with form data to send the query and params with the http engine
*   `process_query_params()` currently converts parameters to text using PostgreSQL's output functions; will need to be updated to consistently use ClickHouse formats (#110)
*   Add the `param.sql` tests ported from postgres_fdw tests

  [PREPARE Notes]: https://www.postgresql.org/docs/current/sql-prepare.html#SQL-PREPARE-NOTES