### PR TITLE
Proper param conversion to CH string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. It uses the
 *   Added support for parameterized execution, including `PREPARE` and
     `EXECUTE`, by converting PostgreSQL `$1`-style parameters to ClickHouse
     `{param:type}`-style parameters.
+*   Added support for inserting arrays to the http engine.
 
 ### 📚 Documentation
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -463,7 +463,7 @@ ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc)
 }
 
 void
-ch_binary_do_output_convertion(ch_binary_insert_state * insert_state,
+ch_binary_do_output_conversion(ch_binary_insert_state * insert_state,
 							   TupleTableSlot * slot)
 {
 	Datum	   *out_values = insert_state->values;

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2085,6 +2085,21 @@ deparseArray(Datum arr, deparse_expr_cxt * context)
 }
 
 /*
+ * Exported function to convert an array to a ClickHouse string literal array.
+ */
+char	   *
+chfdw_array_to_ch_literal(Datum arr)
+{
+
+	deparse_expr_cxt context;
+
+	context.array_as_tuple = false;
+	context.buf = makeStringInfo();
+	deparseArray(arr, &context);
+	return context.buf->data;
+}
+
+/*
  * Deparse given constant value into context->buf.
  *
  * This function has to be kept in sync with ruleutils.c's get_const_expr.

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -114,7 +114,7 @@ typedef struct ChFdwScanState
 	/* for remote query execution */
 	ch_connection conn;			/* connection for the scan */
 	int			numParams;		/* number of parameters passed to query */
-	FmgrInfo   *param_flinfo;	/* output conversion functions for them */
+	Oid		   *param_oids;		/* output parameter type OIDs them */
 	List	   *param_exprs;	/* executable expressions for param values */
 	const char **param_values;	/* textual values of query parameters */
 	ch_cursor  *ch_cursor;		/* result of query from clickhouse */
@@ -253,11 +253,11 @@ static void finish_foreign_modify(CHFdwModifyState * fmstate);
 static void prepare_query_params(PlanState * node,
 								 List * fdw_exprs,
 								 int numParams,
-								 FmgrInfo * *param_flinfo,
+								 Oid * *param_oids,
 								 List * *param_exprs,
 								 const char ***param_values);
 static void process_query_params(ExprContext * econtext,
-								 FmgrInfo * param_flinfo,
+								 Oid * param_oids,
 								 List * param_exprs,
 								 const char **param_values);
 static bool foreign_join_ok(PlannerInfo * root, RelOptInfo * joinrel,
@@ -834,7 +834,7 @@ clickhouseBeginForeignScan(ForeignScanState * node, int eflags)
 		prepare_query_params((PlanState *) node,
 							 fsplan->fdw_exprs,
 							 numParams,
-							 &fsstate->param_flinfo,
+							 &fsstate->param_oids,
 							 &fsstate->param_exprs,
 							 &fsstate->param_values);
 }
@@ -998,7 +998,7 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 		if (numParams > 0)
 		{
 			process_query_params(econtext,
-								 fsstate->param_flinfo,
+								 fsstate->param_oids,
 								 fsstate->param_exprs,
 								 values);
 		}
@@ -1459,7 +1459,7 @@ static void
 prepare_query_params(PlanState * node,
 					 List * fdw_exprs,
 					 int numParams,
-					 FmgrInfo * *param_flinfo,
+					 Oid * *param_oids,
 					 List * *param_exprs,
 					 const char ***param_values)
 {
@@ -1469,17 +1469,14 @@ prepare_query_params(PlanState * node,
 	Assert(numParams > 0);
 
 	/* Prepare for output conversion of parameters used in remote query. */
-	*param_flinfo = (FmgrInfo *) palloc0(sizeof(FmgrInfo) * numParams);
+	*param_oids = (Oid *) palloc0(sizeof(Oid) * numParams);
 
 	i = 0;
 	foreach(lc, fdw_exprs)
 	{
 		Node	   *param_expr = (Node *) lfirst(lc);
-		Oid			typefnoid;
-		bool		isvarlena;
 
-		getTypeOutputInfo(exprType(param_expr), &typefnoid, &isvarlena);
-		fmgr_info(typefnoid, &(*param_flinfo)[i]);
+		(*param_oids)[i] = exprType(param_expr);
 		i++;
 	}
 
@@ -1502,7 +1499,7 @@ prepare_query_params(PlanState * node,
  */
 static void
 process_query_params(ExprContext * econtext,
-					 FmgrInfo * param_flinfo,
+					 Oid * param_oids,
 					 List * param_exprs,
 					 const char **param_values)
 {
@@ -1524,13 +1521,9 @@ process_query_params(ExprContext * econtext,
 		 * type-specific output function, unless the value is null.
 		 */
 		if (isNull)
-		{
 			param_values[i] = NULL;
-		}
 		else
-		{
-			param_values[i] = OutputFunctionCall(&param_flinfo[i], expr_value);
-		}
+			param_values[i] = chfdw_datum_to_ch_literal(expr_value, param_oids[i]);
 
 		i++;
 	}

--- a/src/include/binary.hh
+++ b/src/include/binary.hh
@@ -89,7 +89,7 @@ extern "C"
 	void		ch_binary_column_append_data(ch_binary_insert_state * state, size_t colidx);
 	void	   *ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc);
 	void		ch_binary_insert_state_free(void *c);
-	void		ch_binary_do_output_convertion(ch_binary_insert_state * insert_state,
+	void		ch_binary_do_output_conversion(ch_binary_insert_state * insert_state,
 											   TupleTableSlot * slot);
 
 #ifdef __cplusplus

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -78,6 +78,7 @@ ch_connection chfdw_binary_connect(ch_connection_details * details);
 text	   *chfdw_http_fetch_raw_data(ch_cursor * cursor);
 List	   *chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * server);
 char *ch_quote_literal(const char *rawstr);
+char	   *chfdw_datum_to_ch_literal(Datum value, Oid type);
 
 typedef enum
 {
@@ -228,6 +229,7 @@ extern void chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo * root
 											  bool has_final_sort, bool has_limit, bool is_subquery,
 											  List * *retrieved_attrs, List * *params_list);
 extern const char *chfdw_get_jointype_name(JoinType jointype);
+char * chfdw_array_to_ch_literal(Datum arr);
 
 /* in shippable.c */
 extern bool chfdw_is_builtin(Oid objectId);

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -340,6 +340,75 @@ chfdw_http_fetch_raw_data(ch_cursor * cursor)
 }
 
 /*
+ * Convert a Datum to a ClickHouse literal string. Returns NULL if the value
+ * cannot be converted to a literal.
+ */
+extern char *
+chfdw_datum_to_ch_literal(Datum value, Oid type)
+{
+	if (type_is_array(type))
+		return chfdw_array_to_ch_literal(value);
+
+	switch (type)
+	{
+		case BOOLOID:
+		case INT2OID:
+		case INT4OID:
+			return psprintf("%d", DatumGetInt32(value));
+		case INT8OID:
+			return psprintf(INT64_FORMAT, DatumGetInt64(value));
+		case FLOAT4OID:
+			return psprintf("%f", DatumGetFloat4(value));
+		case FLOAT8OID:
+			return psprintf("%f", DatumGetFloat8(value));
+		case NUMERICOID:
+			return DatumGetCString(DirectFunctionCall1(numeric_out, value));
+		case BPCHAROID:
+		case VARCHAROID:
+		case TEXTOID:
+		case JSONOID:
+		case JSONBOID:
+		case NAMEOID:
+		case BITOID:
+		case BYTEAOID:
+			{
+				char	   *text,
+						   *result;
+				size_t		len;
+				bool		tl = false;
+				Oid			typoutput = InvalidOid;
+
+				getTypeOutputInfo(type, &typoutput, &tl);
+				text = OidOutputFunctionCall(typoutput, value);
+				len = strlen(text);
+				result = palloc(len * 2 + 1);
+				ch_escape_string(result, text, len+1);
+				return result;
+			}
+		case DATEOID:
+			/* we expect Date on other side */
+			return DatumGetCString(DirectFunctionCall1(ch_date_out, value));
+		case TIMEOID:
+			{
+				/* we expect DateTime on other side */
+				char	   *extval = DatumGetCString(DirectFunctionCall1(ch_time_out, value));
+				char	   *retval = psprintf("1970-01-01 %s", extval);
+
+				pfree(extval);
+				return retval;
+			}
+		case TIMESTAMPOID:
+		case TIMESTAMPTZOID:
+			/* we expect DateTime on other side */
+			return DatumGetCString(DirectFunctionCall1(ch_timestamp_out, value));
+		default:
+			ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+							errmsg("cannot convert value to clickhouse value"),
+							errhint("Value data type: %u", type)));
+	}
+}
+
+/*
  * extend_insert_query
  *		Construct values part of INSERT query
  */
@@ -365,6 +434,7 @@ extend_insert_query(ch_http_insert_state * state, TupleTableSlot * slot)
 			Datum		value;
 			Oid			type;
 			bool		isnull;
+			char	   *string;
 
 			value = slot_getattr(slot, attnum, &isnull);
 			type = TupleDescAttr(slot->tts_tupleDescriptor, attnum - 1)->atttypid;
@@ -382,87 +452,9 @@ extend_insert_query(ch_http_insert_state * state, TupleTableSlot * slot)
 				continue;
 			}
 
-			switch (type)
-			{
-				case BOOLOID:
-				case INT2OID:
-				case INT4OID:
-					appendStringInfo(&state->sql, "%d", DatumGetInt32(value));
-					break;
-				case INT8OID:
-					appendStringInfo(&state->sql, INT64_FORMAT, DatumGetInt64(value));
-					break;
-				case FLOAT4OID:
-					appendStringInfo(&state->sql, "%f", DatumGetFloat4(value));
-					break;
-				case FLOAT8OID:
-					appendStringInfo(&state->sql, "%f", DatumGetFloat8(value));
-					break;
-				case NUMERICOID:
-					{
-						char	   *extval = DatumGetCString(DirectFunctionCall1(numeric_out, value));
-
-						appendStringInfoString(&state->sql, extval);
-						pfree(extval);
-					}
-					break;
-				case BPCHAROID:
-				case VARCHAROID:
-				case TEXTOID:
-				case JSONOID:
-				case JSONBOID:
-				case NAMEOID:
-				case BITOID:
-				case BYTEAOID:
-					{
-						char	   *text,
-								   *result;
-						size_t		len;
-						bool		tl = false;
-						Oid			typoutput = InvalidOid;
-
-						getTypeOutputInfo(type, &typoutput, &tl);
-						text = OidOutputFunctionCall(typoutput, value);
-						len = strlen(text) + 1;
-						result = palloc(len * 2 + 1);
-						ch_escape_string(result, text, len);
-						appendStringInfoString(&state->sql, result);
-						pfree(result);
-					}
-					break;
-				case DATEOID:
-					{
-						/* we expect Date on other side */
-						char	   *extval = DatumGetCString(DirectFunctionCall1(ch_date_out, value));
-
-						appendStringInfoString(&state->sql, extval);
-						pfree(extval);
-						break;
-					}
-				case TIMEOID:
-					{
-						/* we expect DateTime on other side */
-						char	   *extval = DatumGetCString(DirectFunctionCall1(ch_time_out, value));
-
-						appendStringInfo(&state->sql, "1970-01-01 %s", extval);
-						pfree(extval);
-						break;
-					}
-				case TIMESTAMPOID:
-				case TIMESTAMPTZOID:
-					{
-						/* we expect DateTime on other side */
-						char	   *extval = DatumGetCString(DirectFunctionCall1(ch_timestamp_out, value));
-
-						appendStringInfoString(&state->sql, extval);
-						pfree(extval);
-						break;
-					}
-				default:
-					ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-									errmsg("cannot convert constant value to clickhouse value"),
-									errhint("Constant value data type: %u", type)));
-			}
+			string = chfdw_datum_to_ch_literal(value, type);
+			appendStringInfoString(&state->sql, string);
+			pfree(string);
 #ifdef USE_ASSERT_CHECKING
 			pindex++;
 #endif
@@ -761,7 +753,7 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 			MemoryContextSwitchTo(old_mcxt);
 		}
 
-		ch_binary_do_output_convertion(state, slot);
+		ch_binary_do_output_conversion(state, slot);
 
 		for (size_t i = 0; i < state->outdesc->natts; i++)
 			ch_binary_column_append_data(state, i);

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -1,0 +1,236 @@
+SET datestyle = 'ISO';
+CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('create database http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+    c1 Int8, c2 Int16, c3 Int32, c4 Int64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+    c1 Float32, c2 Float64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+    c1 Int8, c2 Nullable(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+    c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 DateTime64(3)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+    c1 Int32, c2 Array(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+/* ints */
+INSERT INTO ints
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+SELECT * FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+(3 rows)
+
+INSERT INTO ints (c1, c4, c3, c2)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(4, 6) i;
+SELECT * FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+  4 |  7 |  6 |  5
+  5 |  8 |  7 |  6
+  6 |  9 |  8 |  7
+(6 rows)
+
+/* check dropping columns (that will change attnums) */
+ALTER TABLE ints DROP COLUMN c1;
+ALTER TABLE ints ADD COLUMN c1 SMALLINT;
+INSERT INTO ints (c1, c2, c3, c4)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(7, 8) i;
+SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+  4 |  7 |  6 |  5
+  5 |  8 |  7 |  6
+  6 |  9 |  8 |  7
+  7 |  8 |  9 | 10
+  8 |  9 | 10 | 11
+(8 rows)
+
+/* check other number types */
+INSERT INTO uints
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
+SELECT * FROM uints ORDER BY c1;
+ c1 | c2 | c3 | c4 | c5 
+----+----+----+----+----
+  1 |  2 |  3 |  4 | t
+  2 |  3 |  4 |  5 | f
+  3 |  4 |  5 |  6 | t
+(3 rows)
+
+INSERT INTO floats
+	SELECT i * 1.1, i + 2.1 FROM generate_series(1, 3) i;
+SELECT * FROM floats ORDER BY c1;
+ c1  | c2  
+-----+-----
+ 1.1 | 3.1
+ 2.2 | 4.1
+ 3.3 | 5.1
+(3 rows)
+
+/* check nullable */
+INSERT INTO null_ints SELECT i, case WHEN i % 2 = 0 THEN NULL ELSE i END FROM generate_series(1, 10) i;
+INSERT INTO null_ints(c1) SELECT i FROM generate_series(11, 13) i;
+SELECT * FROM null_ints ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |   
+  3 |  3
+  4 |   
+  5 |  5
+  6 |   
+  7 |  7
+  8 |   
+  9 |  9
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+(13 rows)
+
+SELECT * FROM null_ints ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |   
+  3 |  3
+  4 |   
+  5 |  5
+  6 |   
+  7 |  7
+  8 |   
+  9 |  9
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+(13 rows)
+
+/* check dates and strings */
+ALTER TABLE complex ALTER COLUMN c7 SET DATA TYPE timestamp(3);
+\d+ complex
+                                                 Foreign table "public.complex"
+ Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
+--------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
+ c1     | integer                        |           | not null |         |             | plain    |              | 
+ c2     | date                           |           | not null |         |             | plain    |              | 
+ c3     | timestamp without time zone    |           | not null |         |             | plain    |              | 
+ c4     | text                           |           | not null |         |             | extended |              | 
+ c5     | character varying(10)          |           | not null |         |             | extended |              | 
+ c6     | text                           |           | not null |         |             | extended |              | 
+ c7     | timestamp(3) without time zone |           | not null |         |             | plain    |              | 
+Not-null constraints:
+    "complex_c1_not_null" NOT NULL "c1"
+    "complex_c2_not_null" NOT NULL "c2"
+    "complex_c3_not_null" NOT NULL "c3"
+    "complex_c4_not_null" NOT NULL "c4"
+    "complex_c5_not_null" NOT NULL "c5"
+    "complex_c6_not_null" NOT NULL "c6"
+    "complex_c7_not_null" NOT NULL "c7"
+Server: http_inserts_loopback
+FDW options: (database 'http_inserts_test', table_name 'complex', engine 'MergeTree')
+
+INSERT INTO complex VALUES
+	(1, '2020-06-01', '2020-06-02 10:01:02', 't1', 'fix_t1', 'low1', '2020-06-02 10:01:02.123'),
+	(2, '2020-06-02', '2020-06-03 10:01:02', 5, 'fix_t2', 'low2', '2020-06-03 11:01:02.234'),
+	(3, '2020-06-03', '2020-06-04 10:01:02', 5, 'fix_t3', 'low3', '2020-06-04 12:01:02');
+SELECT * FROM complex ORDER BY c1;
+ c1 |     c2     |         c3          | c4 |   c5   |  c6  |         c7          
+----+------------+---------------------+----+--------+------+---------------------
+  1 | 2020-06-01 | 2020-06-02 10:01:02 | t1 | fix_t1 | low1 | 2020-06-02 10:01:02
+  2 | 2020-06-02 | 2020-06-03 10:01:02 | 5  | fix_t2 | low2 | 2020-06-03 11:01:02
+  3 | 2020-06-03 | 2020-06-04 10:01:02 | 5  | fix_t3 | low3 | 2020-06-04 12:01:02
+(3 rows)
+
+/* check arrays */
+INSERT INTO arrays VALUES
+	(1, ARRAY[1,2]),
+	(2, ARRAY[3,4,5]),
+	(3, ARRAY[6,4]);
+SELECT * FROM arrays ORDER BY c1;
+ c1 |   c2    
+----+---------
+  1 | {1,2}
+  2 | {3,4,5}
+  3 | {6,4}
+(3 rows)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP SERVER http_inserts_loopback CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to foreign table arrays
+drop cascades to foreign table complex
+drop cascades to foreign table floats
+drop cascades to foreign table ints
+drop cascades to foreign table null_ints
+drop cascades to foreign table uints

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -1,0 +1,228 @@
+SET datestyle = 'ISO';
+CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('create database http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+    c1 Int8, c2 Int16, c3 Int32, c4 Int64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+    c1 Float32, c2 Float64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+    c1 Int8, c2 Nullable(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+    c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 DateTime64(3)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+    c1 Int32, c2 Array(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+/* ints */
+INSERT INTO ints
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+SELECT * FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+(3 rows)
+
+INSERT INTO ints (c1, c4, c3, c2)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(4, 6) i;
+SELECT * FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+  4 |  7 |  6 |  5
+  5 |  8 |  7 |  6
+  6 |  9 |  8 |  7
+(6 rows)
+
+/* check dropping columns (that will change attnums) */
+ALTER TABLE ints DROP COLUMN c1;
+ALTER TABLE ints ADD COLUMN c1 SMALLINT;
+INSERT INTO ints (c1, c2, c3, c4)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(7, 8) i;
+SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 |  2 |  3 |  4
+  2 |  3 |  4 |  5
+  3 |  4 |  5 |  6
+  4 |  7 |  6 |  5
+  5 |  8 |  7 |  6
+  6 |  9 |  8 |  7
+  7 |  8 |  9 | 10
+  8 |  9 | 10 | 11
+(8 rows)
+
+/* check other number types */
+INSERT INTO uints
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
+SELECT * FROM uints ORDER BY c1;
+ c1 | c2 | c3 | c4 | c5 
+----+----+----+----+----
+  1 |  2 |  3 |  4 | t
+  2 |  3 |  4 |  5 | f
+  3 |  4 |  5 |  6 | t
+(3 rows)
+
+INSERT INTO floats
+	SELECT i * 1.1, i + 2.1 FROM generate_series(1, 3) i;
+SELECT * FROM floats ORDER BY c1;
+ c1  | c2  
+-----+-----
+ 1.1 | 3.1
+ 2.2 | 4.1
+ 3.3 | 5.1
+(3 rows)
+
+/* check nullable */
+INSERT INTO null_ints SELECT i, case WHEN i % 2 = 0 THEN NULL ELSE i END FROM generate_series(1, 10) i;
+INSERT INTO null_ints(c1) SELECT i FROM generate_series(11, 13) i;
+SELECT * FROM null_ints ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |   
+  3 |  3
+  4 |   
+  5 |  5
+  6 |   
+  7 |  7
+  8 |   
+  9 |  9
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+(13 rows)
+
+SELECT * FROM null_ints ORDER BY c1;
+ c1 | c2 
+----+----
+  1 |  1
+  2 |   
+  3 |  3
+  4 |   
+  5 |  5
+  6 |   
+  7 |  7
+  8 |   
+  9 |  9
+ 10 |   
+ 11 |   
+ 12 |   
+ 13 |   
+(13 rows)
+
+/* check dates and strings */
+ALTER TABLE complex ALTER COLUMN c7 SET DATA TYPE timestamp(3);
+\d+ complex
+                                                 Foreign table "public.complex"
+ Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
+--------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
+ c1     | integer                        |           | not null |         |             | plain    |              | 
+ c2     | date                           |           | not null |         |             | plain    |              | 
+ c3     | timestamp without time zone    |           | not null |         |             | plain    |              | 
+ c4     | text                           |           | not null |         |             | extended |              | 
+ c5     | character varying(10)          |           | not null |         |             | extended |              | 
+ c6     | text                           |           | not null |         |             | extended |              | 
+ c7     | timestamp(3) without time zone |           | not null |         |             | plain    |              | 
+Server: http_inserts_loopback
+FDW options: (database 'http_inserts_test', table_name 'complex', engine 'MergeTree')
+
+INSERT INTO complex VALUES
+	(1, '2020-06-01', '2020-06-02 10:01:02', 't1', 'fix_t1', 'low1', '2020-06-02 10:01:02.123'),
+	(2, '2020-06-02', '2020-06-03 10:01:02', 5, 'fix_t2', 'low2', '2020-06-03 11:01:02.234'),
+	(3, '2020-06-03', '2020-06-04 10:01:02', 5, 'fix_t3', 'low3', '2020-06-04 12:01:02');
+SELECT * FROM complex ORDER BY c1;
+ c1 |     c2     |         c3          | c4 |   c5   |  c6  |         c7          
+----+------------+---------------------+----+--------+------+---------------------
+  1 | 2020-06-01 | 2020-06-02 10:01:02 | t1 | fix_t1 | low1 | 2020-06-02 10:01:02
+  2 | 2020-06-02 | 2020-06-03 10:01:02 | 5  | fix_t2 | low2 | 2020-06-03 11:01:02
+  3 | 2020-06-03 | 2020-06-04 10:01:02 | 5  | fix_t3 | low3 | 2020-06-04 12:01:02
+(3 rows)
+
+/* check arrays */
+INSERT INTO arrays VALUES
+	(1, ARRAY[1,2]),
+	(2, ARRAY[3,4,5]),
+	(3, ARRAY[6,4]);
+SELECT * FROM arrays ORDER BY c1;
+ c1 |   c2    
+----+---------
+  1 | {1,2}
+  2 | {3,4,5}
+  3 | {6,4}
+(3 rows)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP SERVER http_inserts_loopback CASCADE;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to foreign table arrays
+drop cascades to foreign table complex
+drop cascades to foreign table floats
+drop cascades to foreign table ints
+drop cascades to foreign table null_ints
+drop cascades to foreign table uints

--- a/test/expected/param.out
+++ b/test/expected/param.out
@@ -28,7 +28,7 @@ SELECT clickhouse_raw_query($$
         c5 Date,
         c6 String,
         c7 String,
-        c8 String
+        c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
  clickhouse_raw_query 
@@ -46,7 +46,7 @@ SELECT clickhouse_raw_query($$
            addDays(toDate('1970-01-01'), number % 100),
            number % 10,
            number % 10,
-           'foo'
+           ['foo']
     FROM numbers(1, 110)
 $$);
  clickhouse_raw_query 
@@ -66,7 +66,7 @@ CREATE FOREIGN TABLE bin_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -79,7 +79,7 @@ CREATE FOREIGN TABLE bin_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -124,9 +124,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -148,9 +148,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -210,59 +210,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -277,11 +277,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -300,25 +300,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | {foo}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | {foo}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | {foo}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | {foo}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | {foo}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | {foo}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | {foo}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | {foo}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
@@ -366,7 +366,7 @@ CREATE FOREIGN TABLE http_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -379,7 +379,7 @@ CREATE FOREIGN TABLE http_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -424,9 +424,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -448,9 +448,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -510,59 +510,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -577,11 +577,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -600,25 +600,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | {'foo'}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | {'foo'}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | {'foo'}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | {'foo'}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | {'foo'}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | {'foo'}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | {'foo'}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | {'foo'}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');

--- a/test/expected/param_1.out
+++ b/test/expected/param_1.out
@@ -28,7 +28,7 @@ SELECT clickhouse_raw_query($$
         c5 Date,
         c6 String,
         c7 String,
-        c8 String
+        c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
  clickhouse_raw_query 
@@ -46,7 +46,7 @@ SELECT clickhouse_raw_query($$
            addDays(toDate('1970-01-01'), number % 100),
            number % 10,
            number % 10,
-           'foo'
+           ['foo']
     FROM numbers(1, 110)
 $$);
  clickhouse_raw_query 
@@ -66,7 +66,7 @@ CREATE FOREIGN TABLE bin_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -79,7 +79,7 @@ CREATE FOREIGN TABLE bin_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -124,9 +124,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -148,9 +148,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -210,59 +210,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -277,11 +277,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -300,25 +300,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | {foo}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | {foo}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | {foo}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | {foo}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | {foo}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | {foo}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | {foo}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | {foo}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
@@ -366,7 +366,7 @@ CREATE FOREIGN TABLE http_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -379,7 +379,7 @@ CREATE FOREIGN TABLE http_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -424,9 +424,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -448,9 +448,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -510,59 +510,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -577,11 +577,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -600,25 +600,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | {'foo'}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | {'foo'}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | {'foo'}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | {'foo'}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | {'foo'}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | {'foo'}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | {'foo'}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | {'foo'}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');

--- a/test/expected/param_2.out
+++ b/test/expected/param_2.out
@@ -28,7 +28,7 @@ SELECT clickhouse_raw_query($$
         c5 Date,
         c6 String,
         c7 String,
-        c8 String
+        c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
  clickhouse_raw_query 
@@ -46,7 +46,7 @@ SELECT clickhouse_raw_query($$
            addDays(toDate('1970-01-01'), number % 100),
            number % 10,
            number % 10,
-           'foo'
+           ['foo']
     FROM numbers(1, 110)
 $$);
  clickhouse_raw_query 
@@ -66,7 +66,7 @@ CREATE FOREIGN TABLE bin_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -79,7 +79,7 @@ CREATE FOREIGN TABLE bin_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -124,9 +124,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -148,9 +148,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6  | {foo}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -210,59 +210,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on bin_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -277,11 +277,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -300,25 +300,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 | c7 | c8  
-----+----+----+------------------------+---------------------+----+----+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 | c7 |  c8   
+----+----+----+------------------------+---------------------+----+----+-------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1  | {foo}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2  | {foo}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3  | {foo}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4  | {foo}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5  | {foo}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6  | {foo}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7  | {foo}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8  | {foo}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9  | {foo}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on bin_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
@@ -366,7 +366,7 @@ CREATE FOREIGN TABLE http_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -379,7 +379,7 @@ CREATE FOREIGN TABLE http_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -424,9 +424,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st2(10, 20);
 (4 rows)
 
 EXECUTE st2(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st2(101, 121);
@@ -448,9 +448,9 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st3(10, 20);
 (4 rows)
 
 EXECUTE st3(10, 20);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
- 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+ 16 |  6 | 16 | 1970-01-17 00:00:00-08 | 1970-01-17 00:00:00 | 6  | 6          | {'foo'}
 (1 row)
 
 EXECUTE st3(20, 30);
@@ -510,59 +510,59 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 (3 rows)
 
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+PREPARE st5(text[], int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = 'foo')) AND ((c1 = 1))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = ['foo'])) AND ((c1 = 1))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on http_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
-   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:String})) AND ((c1 = {p2:Int32}))
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM param_test.ft1 WHERE ((c8 = {p1:Array(String)})) AND ((c1 = {p2:Int32}))
 (3 rows)
 
-EXECUTE st5('foo', 1);
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
+EXECUTE st5('{foo}', 1);
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
 (1 row)
 
 -- altering FDW options requires replanning
@@ -577,11 +577,11 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 
 PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
@@ -600,25 +600,25 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 (3 rows)
 
 EXECUTE st6;
- c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     | c8  
-----+----+----+------------------------+---------------------+----+------------+-----
-  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | foo
-  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | foo
-  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | foo
-  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | foo
-  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | foo
-  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | foo
-  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | foo
-  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | foo
-  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | foo
+ c1 | c2 | c3 |           c4           |         c5          | c6 |     c7     |   c8    
+----+----+----+------------------------+---------------------+----+------------+---------
+  1 |  1 | 1  | 1970-01-02 00:00:00-08 | 1970-01-02 00:00:00 | 1  | 1          | {'foo'}
+  2 |  2 | 2  | 1970-01-03 00:00:00-08 | 1970-01-03 00:00:00 | 2  | 2          | {'foo'}
+  3 |  3 | 3  | 1970-01-04 00:00:00-08 | 1970-01-04 00:00:00 | 3  | 3          | {'foo'}
+  4 |  4 | 4  | 1970-01-05 00:00:00-08 | 1970-01-05 00:00:00 | 4  | 4          | {'foo'}
+  5 |  5 | 5  | 1970-01-06 00:00:00-08 | 1970-01-06 00:00:00 | 5  | 5          | {'foo'}
+  6 |  6 | 6  | 1970-01-07 00:00:00-08 | 1970-01-07 00:00:00 | 6  | 6          | {'foo'}
+  7 |  7 | 7  | 1970-01-08 00:00:00-08 | 1970-01-08 00:00:00 | 7  | 7          | {'foo'}
+  8 |  8 | 8  | 1970-01-09 00:00:00-08 | 1970-01-09 00:00:00 | 8  | 8          | {'foo'}
+  9 |  9 | 9  | 1970-01-10 00:00:00-08 | 1970-01-10 00:00:00 | 9  | 9          | {'foo'}
 (9 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-                                                                                 QUERY PLAN                                                                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Insert on http_test.ft1
    ->  Result
-         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text
+         Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
 SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -89,6 +89,18 @@ http.sql
  23         | http_4.out
  22         | http_5.out
 
+http_inserts.sql
+----------------
+
+ Postgres | File
+----------|--------------------
+ 18       | http_inserts.out
+ 13-17    | http_inserts_1.out
+
+ ClickHouse | File
+------------|------------------
+ 22-25      | http_inserts.out
+
 import_schema.sql
 -----------------
 
@@ -120,7 +132,7 @@ param.sql
 
  Postgres | File
 ----------|-------------
- 14-18    | param.out
+ 17-18    | param.out
  14-16    | param_1.out
  13       | param_2.out
 

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -1,0 +1,86 @@
+SET datestyle = 'ISO';
+CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+
+SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
+SELECT clickhouse_raw_query('create database http_inserts_test');
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+    c1 Int8, c2 Int16, c3 Int32, c4 Int64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+    c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+    c1 Float32, c2 Float64
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
+');
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+    c1 Int8, c2 Nullable(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+    c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 DateTime64(3)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+    c1 Int32, c2 Array(Int32)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+
+/* ints */
+INSERT INTO ints
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
+SELECT * FROM ints ORDER BY c1;
+INSERT INTO ints (c1, c4, c3, c2)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(4, 6) i;
+SELECT * FROM ints ORDER BY c1;
+
+/* check dropping columns (that will change attnums) */
+ALTER TABLE ints DROP COLUMN c1;
+ALTER TABLE ints ADD COLUMN c1 SMALLINT;
+INSERT INTO ints (c1, c2, c3, c4)
+	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(7, 8) i;
+SELECT c1, c2, c3, c4 FROM ints ORDER BY c1;
+
+/* check other number types */
+INSERT INTO uints
+	SELECT i, i + 1, i + 2, i+ 3, (i % 2)::bool FROM generate_series(1, 3) i;
+SELECT * FROM uints ORDER BY c1;
+INSERT INTO floats
+	SELECT i * 1.1, i + 2.1 FROM generate_series(1, 3) i;
+SELECT * FROM floats ORDER BY c1;
+
+/* check nullable */
+INSERT INTO null_ints SELECT i, case WHEN i % 2 = 0 THEN NULL ELSE i END FROM generate_series(1, 10) i;
+INSERT INTO null_ints(c1) SELECT i FROM generate_series(11, 13) i;
+SELECT * FROM null_ints ORDER BY c1;
+SELECT * FROM null_ints ORDER BY c1;
+
+/* check dates and strings */
+ALTER TABLE complex ALTER COLUMN c7 SET DATA TYPE timestamp(3);
+\d+ complex
+INSERT INTO complex VALUES
+	(1, '2020-06-01', '2020-06-02 10:01:02', 't1', 'fix_t1', 'low1', '2020-06-02 10:01:02.123'),
+	(2, '2020-06-02', '2020-06-03 10:01:02', 5, 'fix_t2', 'low2', '2020-06-03 11:01:02.234'),
+	(3, '2020-06-03', '2020-06-04 10:01:02', 5, 'fix_t3', 'low3', '2020-06-04 12:01:02');
+SELECT * FROM complex ORDER BY c1;
+
+/* check arrays */
+INSERT INTO arrays VALUES
+	(1, ARRAY[1,2]),
+	(2, ARRAY[3,4,5]),
+	(3, ARRAY[6,4]);
+SELECT * FROM arrays ORDER BY c1;
+
+DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
+DROP SERVER http_inserts_loopback CASCADE;

--- a/test/sql/param.sql
+++ b/test/sql/param.sql
@@ -20,7 +20,7 @@ SELECT clickhouse_raw_query($$
         c5 Date,
         c6 String,
         c7 String,
-        c8 String
+        c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
 
@@ -34,7 +34,7 @@ SELECT clickhouse_raw_query($$
            addDays(toDate('1970-01-01'), number % 100),
            number % 10,
            number % 10,
-           'foo'
+           ['foo']
     FROM numbers(1, 110)
 $$);
 
@@ -51,7 +51,7 @@ CREATE FOREIGN TABLE bin_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -65,7 +65,7 @@ CREATE FOREIGN TABLE bin_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_bin_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -106,14 +106,14 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 -- once we try it enough times, should switch to generic plan
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXECUTE st5('foo', 1);
+PREPARE st5(text[], int) AS SELECT * FROM bin_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXECUTE st5('{foo}', 1);
 
 -- altering FDW options requires replanning
 PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
@@ -154,7 +154,7 @@ CREATE FOREIGN TABLE http_test.ft1 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'ft1',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -168,7 +168,7 @@ CREATE FOREIGN TABLE http_test.ft2 (
 	c5 timestamp,
 	c6 varchar(10),
 	c7 char(10) default 'f21',
-	c8 text
+	c8 text[]
 ) SERVER param_http_svr OPTIONS(
     database 'param_test',
     table_name 'ft1'
@@ -209,14 +209,14 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 -- once we try it enough times, should switch to generic plan
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st4(1);
 -- value of $1 should not be sent to remote
-PREPARE st5(text,int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('foo', 1);
-EXECUTE st5('foo', 1);
+PREPARE st5(text[], int) AS SELECT * FROM http_test.ft1 t1 WHERE c8 = $1 and c1 = $2;
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st5('{foo}', 1);
+EXECUTE st5('{foo}', 1);
 
 -- altering FDW options requires replanning
 PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;


### PR DESCRIPTION
The code for passing parameters, originally copied from postgres_fdw, relied upon PostgreSQL's output functions to format string literals. Unfortunately this doesn't work for some ClickHouse string literals, including arrays.

Since the http engine already requires proper string literal generation, extract its code that does so from `extend_insert_query()` into the new, exported `chfdw_datum_to_ch_literal()` function. Simply pass a Datum and its Oid and it returns the appropriate `palloc'd string literal.

However, even that code did not properly handle arrays. `deparse.c` has a function that does it, `deparseArray()`. Export a wrapper around that function, `chfdw_array_to_ch_literal()`, that takes a single `Datum` and constructs the context required for `deparseArray()` to do its job. Then teach `chfdw_datum_to_ch_literal()` to call it for array `Datum`s.

Then replaces the `param_flinfo` variables in `fdw.c` with `param_oids` and store the OIDs for each parameter, rather than a pointer to a Postgres output function. Then change `process_query_params()` to use these OIDs to call `chfdw_datum_to_ch_literal()` to create the parameter string literals.

Add a new test script, `http_inserts.sql`, which duplicates `binary_inserts.sql` but for the http engine. It includes insertion of an array, testing the new functionality.

Also modify the `params.sql` test to convert one of its columns to an array and execute prepared statements with array parameters.

While at it:

*   Rename the mis-spelled `ch_binary_do_output_convertion`