### PR TITLE
Tweak cost estimation, avoid min/max optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Removed unused code designed to support custom PostgreSQL extensions:
     [ajbool], ajtime, [country], and [istore].
+*   Tweaked cost estimation to encourage pushdown of `min()` and `max()`.
 
 ### 📚 Documentation
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -920,6 +920,8 @@ These PostgreSQL aggregate functions pushdown to ClickHouse.
 *   [array_agg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/grouparray)
 *   [avg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/avg)
 *   [count](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count)
+*   [min](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/min)
+*   [max](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/max)
 
 ### Custom Aggregates
 

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -1382,7 +1382,7 @@ estimate_path_cost_size(double *p_rows, int *p_width,
 	*p_rows = 1000;
 	*p_width = 32;
 	*p_startup_cost = 1.0;
-	*p_total_cost = 5.0 + coef;
+	*p_total_cost = 0.1 + coef;
 }
 
 /*

--- a/test/expected/aggregates.out
+++ b/test/expected/aggregates.out
@@ -575,5 +575,641 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
  {5.1,1.99,8.14,8.53,3.57,2.47,8.24,4.79,6.75,7.69}
 (1 row)
 
+-- min(UInt64)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan
+   Output: (min(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(id) FROM agg_test.hits
+(4 rows)
+
+   min    
+----------
+ 41607833
+(1 row)
+
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan
+   Output: (min(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(id) FROM agg_test.hits
+(4 rows)
+
+   min    
+----------
+ 41607833
+(1 row)
+
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(id) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+   min    
+----------
+ 41607833
+(1 row)
+
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(id) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+   min    
+----------
+ 41607833
+(1 row)
+
+-- min(DateTime64)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (min("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min("timestamp") FROM agg_test.hits
+(4 rows)
+
+            min             
+----------------------------
+ 2025-12-05 11:51:04.390884
+(1 row)
+
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (min("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min("timestamp") FROM agg_test.hits
+(4 rows)
+
+            min             
+----------------------------
+ 2025-12-05 11:51:04.390884
+(1 row)
+
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min("timestamp") FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+            min             
+----------------------------
+ 2025-12-10 16:24:16.877779
+(1 row)
+
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min("timestamp") FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+            min             
+----------------------------
+ 2025-12-10 16:24:16.877779
+(1 row)
+
+-- min(Date)
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Foreign Scan
+   Output: (min(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(datestamp) FROM agg_test.hits
+(4 rows)
+
+    min     
+------------
+ 2025-12-05
+(1 row)
+
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Foreign Scan
+   Output: (min(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(datestamp) FROM agg_test.hits
+(4 rows)
+
+    min     
+------------
+ 2025-12-05
+(1 row)
+
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(datestamp) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    min     
+------------
+ 2025-12-10
+(1 row)
+
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(datestamp) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    min     
+------------
+ 2025-12-10
+(1 row)
+
+-- min(String)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (min(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(path) FROM agg_test.hits
+(4 rows)
+
+   min    
+----------
+ /profile
+(1 row)
+
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (min(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(path) FROM agg_test.hits
+(4 rows)
+
+   min    
+----------
+ /profile
+(1 row)
+
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(path) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+   min   
+---------
+ /search
+(1 row)
+
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(path) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+   min   
+---------
+ /search
+(1 row)
+
+-- min(UInt32)
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan
+   Output: (min(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(duration) FROM agg_test.hits
+(4 rows)
+
+ min 
+-----
+   2
+(1 row)
+
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan
+   Output: (min(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(duration) FROM agg_test.hits
+(4 rows)
+
+ min 
+-----
+   2
+(1 row)
+
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(duration) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+ min 
+-----
+  15
+(1 row)
+
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(duration) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+ min 
+-----
+  15
+(1 row)
+
+-- min(Decimal)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (min(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(cost) FROM agg_test.hits
+(4 rows)
+
+ min  
+------
+ 1.20
+(1 row)
+
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (min(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(cost) FROM agg_test.hits
+(4 rows)
+
+ min 
+-----
+ 1.2
+(1 row)
+
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(cost) FROM agg_test.hits WHERE ((cost < 1000000000))
+(4 rows)
+
+ min  
+------
+ 1.99
+(1 row)
+
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (min(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT min(cost) FROM agg_test.hits WHERE ((cost < 1000000000))
+(4 rows)
+
+ min  
+------
+ 1.99
+(1 row)
+
+-- max(UInt64)
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan
+   Output: (max(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(id) FROM agg_test.hits
+(4 rows)
+
+    max     
+------------
+ 4264738908
+(1 row)
+
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan
+   Output: (max(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(id) FROM agg_test.hits
+(4 rows)
+
+    max     
+------------
+ 4264738908
+(1 row)
+
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(id) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    max    
+-----------
+ 914876110
+(1 row)
+
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(id))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(id) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    max    
+-----------
+ 914876110
+(1 row)
+
+-- max(DateTime64)
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (max("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max("timestamp") FROM agg_test.hits
+(4 rows)
+
+            max             
+----------------------------
+ 2025-12-19 07:24:50.960198
+(1 row)
+
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Foreign Scan
+   Output: (max("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max("timestamp") FROM agg_test.hits
+(4 rows)
+
+            max             
+----------------------------
+ 2025-12-19 07:24:50.960198
+(1 row)
+
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max("timestamp") FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+            max            
+---------------------------
+ 2025-12-18 16:36:18.43735
+(1 row)
+
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max("timestamp"))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max("timestamp") FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+            max            
+---------------------------
+ 2025-12-18 16:36:18.43735
+(1 row)
+
+-- max(Date)
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Foreign Scan
+   Output: (max(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(datestamp) FROM agg_test.hits
+(4 rows)
+
+    max     
+------------
+ 2025-12-19
+(1 row)
+
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Foreign Scan
+   Output: (max(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(datestamp) FROM agg_test.hits
+(4 rows)
+
+    max     
+------------
+ 2025-12-19
+(1 row)
+
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(datestamp) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    max     
+------------
+ 2025-12-18
+(1 row)
+
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(datestamp))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(datestamp) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+    max     
+------------
+ 2025-12-18
+(1 row)
+
+-- max(String)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (max(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(path) FROM agg_test.hits
+(4 rows)
+
+         max         
+---------------------
+ /widgets/voluptatem
+(1 row)
+
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (max(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(path) FROM agg_test.hits
+(4 rows)
+
+         max         
+---------------------
+ /widgets/voluptatem
+(1 row)
+
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(path) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+         max         
+---------------------
+ /widgets/voluptatem
+(1 row)
+
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(path))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(path) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+         max         
+---------------------
+ /widgets/voluptatem
+(1 row)
+
+-- max(UInt32)
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan
+   Output: (max(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(duration) FROM agg_test.hits
+(4 rows)
+
+ max  
+------
+ 7672
+(1 row)
+
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan
+   Output: (max(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(duration) FROM agg_test.hits
+(4 rows)
+
+ max  
+------
+ 7672
+(1 row)
+
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(duration) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+ max  
+------
+ 7672
+(1 row)
+
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(duration))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(duration) FROM agg_test.hits WHERE ((duration < 1000000000))
+(4 rows)
+
+ max  
+------
+ 7672
+(1 row)
+
+-- max(Decimal)
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (max(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(cost) FROM agg_test.hits
+(4 rows)
+
+ max  
+------
+ 8.90
+(1 row)
+
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan
+   Output: (max(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(cost) FROM agg_test.hits
+(4 rows)
+
+ max 
+-----
+ 8.9
+(1 row)
+
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(cost) FROM agg_test.hits WHERE ((cost < 1000000000))
+(4 rows)
+
+ max  
+------
+ 8.53
+(1 row)
+
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (max(cost))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT max(cost) FROM agg_test.hits WHERE ((cost < 1000000000))
+(4 rows)
+
+ max  
+------
+ 8.53
+(1 row)
+
 NOTICE:  drop cascades to foreign table agg_bin.hits
 NOTICE:  drop cascades to foreign table agg_http.hits

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -296,9 +296,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -164,7 +164,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..0.60 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -164,7 +164,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..0.60 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -164,7 +164,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..0.60 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -164,7 +164,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..0.60 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=8)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=8)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=8)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=8)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -164,7 +164,7 @@ INSERT INTO ftcopy VALUES
 EXPLAIN (VERBOSE) SELECT * FROM ftcopy ORDER BY c1;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Foreign Scan on public.ftcopy  (cost=1.00..5.50 rows=1000 width=64)
+ Foreign Scan on public.ftcopy  (cost=1.00..0.60 rows=1000 width=64)
    Output: c1, c2, c3, c4, c5, c6
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6 FROM http_test.tcopy ORDER BY c1 ASC NULLS LAST
 (3 rows)
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -363,9 +363,9 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON
 EXPLAIN SELECT DISTINCT t1.c1, t2.c1 FROM ft2 t1 LEFT JOIN ft1 t2 ON (t1.c1 = t2.c1) order by t1.c1 LIMIT 10;
                            QUERY PLAN                           
 ----------------------------------------------------------------
- Limit  (cost=1.00..1.09 rows=10 width=32)
-   ->  Unique  (cost=1.00..10.50 rows=1000 width=32)
-         ->  Foreign Scan  (cost=1.00..5.50 rows=1000 width=32)
+ Limit  (cost=1.00..1.05 rows=10 width=32)
+   ->  Unique  (cost=1.00..5.60 rows=1000 width=32)
+         ->  Foreign Scan  (cost=1.00..0.60 rows=1000 width=32)
                Relations: (ft2 t1) LEFT JOIN (ft1 t2)
 (4 rows)
 

--- a/test/sql/aggregates.sql
+++ b/test/sql/aggregates.sql
@@ -112,6 +112,7 @@ IMPORT FOREIGN SCHEMA "agg_test" FROM SERVER agg_http_svr INTO agg_http;
 
 \set id_limit 1000000000
 
+-- avg()
 \echo -- AVG(UInt64)
 EXPLAIN (VERBOSE, COSTS OFF) SELECT avg(id) FROM agg_bin.hits;
 SELECT avg(id) FROM agg_bin.hits;
@@ -145,6 +146,7 @@ SELECT avg(cost) FROM agg_bin.hits WHERE cost < :id_limit;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT avg(cost) FROM agg_http.hits WHERE cost < :id_limit;
 SELECT avg(cost) FROM agg_http.hits WHERE cost < :id_limit;
 
+-- array_agg()
 \echo -- array_agg(UInt64)
 EXPLAIN (VERBOSE, COSTS OFF) SELECT array_agg(id) FROM agg_bin.hits;
 SELECT array_agg(id) FROM agg_bin.hits;
@@ -222,11 +224,139 @@ SELECT array_agg(cost) FROM agg_bin.hits WHERE id < :id_limit;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT array_agg(cost) FROM agg_http.hits WHERE cost < :id_limit;
 SELECT array_agg(cost) FROM agg_http.hits WHERE id < :id_limit;
 
--- \echo -- min(UInt64)
--- EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_bin.hits;
--- SELECT min(id) FROM agg_bin.hits;
--- EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_http.hits;
--- SELECT min(id) FROM agg_http.hits;
+-- min()
+\echo -- min(UInt64)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_bin.hits;
+SELECT min(id) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_http.hits;
+SELECT min(id) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT min(id) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(id) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT min(id) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- min(DateTime64)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(timestamp) FROM agg_bin.hits;
+SELECT min(timestamp) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(timestamp) FROM agg_http.hits;
+SELECT min(timestamp) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(timestamp) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT min(timestamp) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(timestamp) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT min(timestamp) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- min(Date)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(datestamp) FROM agg_bin.hits;
+SELECT min(datestamp) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(datestamp) FROM agg_http.hits;
+SELECT min(datestamp) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(datestamp) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT min(datestamp) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(datestamp) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT min(datestamp) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- min(String)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(path) FROM agg_bin.hits;
+SELECT min(path) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(path) FROM agg_http.hits;
+SELECT min(path) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(path) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT min(path) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(path) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT min(path) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- min(UInt32)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(duration) FROM agg_bin.hits;
+SELECT min(duration) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(duration) FROM agg_http.hits;
+SELECT min(duration) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(duration) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT min(duration) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(duration) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT min(duration) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- min(Decimal)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(cost) FROM agg_bin.hits;
+SELECT min(cost) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(cost) FROM agg_http.hits;
+SELECT min(cost) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(cost) FROM agg_bin.hits WHERE cost < :id_limit;
+SELECT min(cost) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT min(cost) FROM agg_http.hits WHERE cost < :id_limit;
+SELECT min(cost) FROM agg_http.hits WHERE id < :id_limit;
+
+-- max()
+\echo -- max(UInt64)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(id) FROM agg_bin.hits;
+SELECT max(id) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(id) FROM agg_http.hits;
+SELECT max(id) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(id) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT max(id) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(id) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT max(id) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- max(DateTime64)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(timestamp) FROM agg_bin.hits;
+SELECT max(timestamp) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(timestamp) FROM agg_http.hits;
+SELECT max(timestamp) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(timestamp) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT max(timestamp) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(timestamp) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT max(timestamp) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- max(Date)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(datestamp) FROM agg_bin.hits;
+SELECT max(datestamp) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(datestamp) FROM agg_http.hits;
+SELECT max(datestamp) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(datestamp) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT max(datestamp) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(datestamp) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT max(datestamp) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- max(String)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(path) FROM agg_bin.hits;
+SELECT max(path) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(path) FROM agg_http.hits;
+SELECT max(path) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(path) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT max(path) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(path) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT max(path) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- max(UInt32)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(duration) FROM agg_bin.hits;
+SELECT max(duration) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(duration) FROM agg_http.hits;
+SELECT max(duration) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(duration) FROM agg_bin.hits WHERE duration < :id_limit;
+SELECT max(duration) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(duration) FROM agg_http.hits WHERE duration < :id_limit;
+SELECT max(duration) FROM agg_http.hits WHERE id < :id_limit;
+
+\echo -- max(Decimal)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(cost) FROM agg_bin.hits;
+SELECT max(cost) FROM agg_bin.hits;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(cost) FROM agg_http.hits;
+SELECT max(cost) FROM agg_http.hits;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(cost) FROM agg_bin.hits WHERE cost < :id_limit;
+SELECT max(cost) FROM agg_bin.hits WHERE id < :id_limit;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT max(cost) FROM agg_http.hits WHERE cost < :id_limit;
+SELECT max(cost) FROM agg_http.hits WHERE id < :id_limit;
 
 -- Clean up.
 DROP USER MAPPING FOR CURRENT_USER SERVER agg_bin_svr;


### PR DESCRIPTION
The Postgres planner examines simple `min()` and `max()` queries, such as:

    SELECT min(x) FROM y;

And rewrites them as:

    SELECT x FROM y ORDER BY x LIMIT 1;

This works great for Postgres queries, but less so for foreign queries, not least because `LIMIT` is missing from the FDW's visibility, so `LIMIT 1` isn't pushed down, resulting in a table, index, or column scan in the foreign table that returns all thr records to Postgres. Not optimal.

We prefer pg_clickhouse to push down the original `min()` or `max()` query and let ClickHouse do its own optimization. This goes with our general desire to pushdown damn near everything. Experiments with postgres_fdw revealed that the optimization could be skipped through cost estimation; the same is true here.

Reduce the total cost created by `estimate_path_cost_size()` from `5.0 + coef` to `0.1 + coef` (`coef` is passed to the function and so far is 0, 0.1, or 0.5). This change reduces the total cost such that Postgres elects to skip its optimization and pushdown simple `min()` and `max()` queries. New aggregate tests demonstrate this pattern.

This change reduces the total estimated cost for *all* queries, not just simple `min()` and `max()` queries, but we consider this acceptable since in general we want all queries to be pushed down.

Update expected test results for a couple of queries that have their costs changed as a result of this adjustment. Also document `min` and `max` pushdown now that it's properly tested