### PR TITLE
Increment to and timestamp v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.1.2] — Unreleased
+## [v0.1.2] — 2026-01-07
+
+This release makes binary-only changes. Once installed, any existing use of
+pg_clickhouse v0.1 will get its benefits on reload without needing to
+`ALTER EXTENSION UPDATE`.
 
 ### ⚡ Improvements
 
@@ -19,7 +23,7 @@ All notable changes to this project will be documented in this file. It uses the
 ### 📚 Documentation
 
 *   Documented `IMPORT FOREIGN SCHEMA` identifier case preservation behavior.
-*   Fixed the Postgres DOcker start and connect info in the
+*   Fixed the Postgres Docker start and connect info in the
     [tutorial](doc/tutorial.md).
 *   Added complete DML documentation to the [reference
     docs](doc/pg_clickhouse.md), including the new `PREPARE`/`EXECUTE` support
@@ -38,7 +42,8 @@ All notable changes to this project will be documented in this file. It uses the
 *   Fixed conversion of `array_agg()` to support ClickHouse versions prior to
     23.8.
 *   Fixed the precision of fractional seconds in the binary engine's
-    conversion of ClickHouse DateTime64 values to Postgres TIMESTAMP (#114).
+    conversion of ClickHouse `DateTime64` values to Postgres `TIMESTAMP`
+    (#114).
 
 ### 📔 Notes
 
@@ -54,6 +59,8 @@ All notable changes to this project will be documented in this file. It uses the
     blank spaces.
 *   Fixed the commands to start and connect to the pg_clickhouse Docker image
     in the [tutorial].
+*   Documented the Postgres aggregate functions known (via new tests) to push
+    down to ClickHouse.
 
   [v0.1.2]: https://github.com/clickhouse/pg_clickhouse/compare/v0.1.1...v0.1.2
   [ajbool]: https://pgxn.org/dist/ajbool/ "ajbool on PGXN"
@@ -64,8 +71,8 @@ All notable changes to this project will be documented in this file. It uses the
 ## [v0.1.1] — 2025-12-17
 
 This release makes binary-only changes. Once installed, any existing use of
-pg_clickhouse v0.1 will get its benefits on reload without needing to `ALTER
-EXTENSION UPDATE`.
+pg_clickhouse v0.1 will get its benefits on reload without needing to
+`ALTER EXTENSION UPDATE`.
 
 ### ⚡ Improvements
 

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_clickhouse",
    "abstract": "Query ClickHouse databases from PostgreSQL",
    "description": "Provides a Foreign Data Wrapper and other interfaces for easy and efficient access to ClickHouse databases, including pushdown of WHERE, JOIN, and aggregates expressions as well as comprehensive EXPLAIN and ANALYZE support.",
-   "version": "0.1.1",
+   "version": "0.1.2",
    "maintainer": "David E. Wheeler <david@justatheory.com>",
    "license": "apache_2_0",
    "provides": {
@@ -10,7 +10,7 @@
          "abstract": "Interfaces to query ClickHouse databases from Postgres",
          "file": "pg_clickhouse.control",
          "docfile": "doc/pg_clickhouse.md",
-         "version": "0.1.1"
+         "version": "0.1.2"
       }
    },
    "prereqs": {

--- a/Makefile
+++ b/Makefile
@@ -195,3 +195,10 @@ lsp: compile_commands.json
 compile_commands.json:
 	$(MAKE) clean
 	bear -- $(MAKE) all
+
+# ClickHouse Docker Containers
+start-containers:
+	docker compose -f dev/docker-compose.yml up -d --remove-orphans
+
+stop-containers:
+	docker compose -f dev/docker-compose.yml down --remove-orphans --volumes

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ memory.
 
 The PostgreSQL and curl development packages include `pg_config` and
 `curl-config` in the path, so you should be able to just run `make` (or
-`gmake`), then `make install`, then in your database `CREATE EXTENSION http`.
+`gmake`), then `make install`, then in your database
+`CREATE EXTENSION pg_clickhouse`.
 
 #### Debian / Ubuntu / APT
 


### PR DESCRIPTION
Also fix a few typos/formatting issues (closes #112) and add targets to the `Makefile` to simplify starting Docker containers for the supported ClickHouse versions.