### PR TITLE
Add pre-commit checks, including indentation

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -3,9 +3,10 @@ on:
   push:
   pull_request:
   schedule:
-    - cron:  '0 13 10 * *' # Monthly at 13:00 on the tenth
+    - cron: "0 13 10 * *" # Monthly at 13:00 on the tenth
 jobs:
   build:
+    env: { pg: 18 }
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +26,7 @@ jobs:
     container: pgxn/pgxn-tools
     steps:
       - name: Start Postgres
-        run: pg-start 18 libcurl4-openssl-dev uuid-dev
+        run: pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev
       - name: Checkout the Repository
         uses: actions/checkout@v4
         with: { submodules: true }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: 🔎 Lint
+on:
+  push:
+  pull_request:
+jobs:
+  lint:
+    name: 🔎 Lint Code
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    env: { pg: 18 }
+    steps:
+      - name: Install Postgres
+        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev
+      - name: Checkout the Repository
+        uses: actions/checkout@v4
+      - name: Install pre-commit
+        run: make debian-install-lint
+      - name: Add Postgres to Path
+        run: echo /usr/lib/postgresql/${{ env.pg }}/bin >> "$GITHUB_PATH"
+      - name: Lint the Code
+        run: make lint

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron:  '0 12 10 * *' # Monthly at noon on the tenth
+    - cron: "0 12 10 * *" # Monthly at noon on the tenth
 jobs:
   build:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-vcs-permalinks
+      - id: check-yaml
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ["--fix=auto"]
+      - id: trailing-whitespace
+        exclude: "[.](?:sql|out)$"
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+  - repo: local
+    hooks:
+      - id: indent
+        name: indent code
+        language: system
+        entry: ./dev/indent.sh
+        pass_filenames: false
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        name: JSON and YAML formatting
+        types_or: [json, yaml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,6 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
     `{param:type}`-style parameters.
 *   Added support for inserting arrays to the http engine.
 
-### 📚 Documentation
-
-*   Documented `IMPORT FOREIGN SCHEMA` identifier case preservation behavior.
-*   Fixed the Postgres Docker start and connect info in the
-    [tutorial](doc/tutorial.md).
-*   Added complete DML documentation to the [reference
-    docs](doc/pg_clickhouse.md), including the new `PREPARE`/`EXECUTE` support
-    and `INSERT`, `SET`, `COPY`, as well as shared library preloading.
-
 ### 🪲 Bug Fixes
 
 *   Fixed the http engine's parsing of UUID arrays selected from ClickHouse.
@@ -53,12 +44,14 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
 
 ### 📚 Documentation
 
-*   Added a note to the `IMPORT FOREIGN SCHEMA` documentation explaining how
-    table and column names imported from ClickHouse will have their letter
-    casing and blank spaces preserved if they have uppercase characters or
-    blank spaces.
+*   Documented `IMPORT FOREIGN SCHEMA` identifier case preservation behavior.
+*   Fixed the Postgres Docker start and connect info in the
+    [tutorial](doc/tutorial.md).
 *   Fixed the commands to start and connect to the pg_clickhouse Docker image
     in the [tutorial].
+*   Added complete DML documentation to the [reference
+    docs](doc/pg_clickhouse.md), including the new `PREPARE`/`EXECUTE` support
+    and `INSERT`, `SET`, `COPY`, as well as shared library preloading.
 *   Documented the Postgres aggregate functions known (via new tests) to push
     down to ClickHouse.
 
@@ -130,7 +123,7 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
 *   Mapped PostgreSQL `extract()` to push down to equivalent ClickHouse
     DateTime extraction functions (already mapped to `date_part()`)
 *   Mapped PostgreSQL `percentile_cont()` ordered set aggregate function to
-    push down to ClickHouse `quantile()` parametrized 
+    push down to ClickHouse `quantile()` parametrized
 *   Mapped the `COUNT()` return value to `bigint`
 *   Added the query text and, for the http engine, the status code to error
     messages

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Apache License
 ==============
 
-_Version 2.0, January 2004_  
+_Version 2.0, January 2004_
 _&lt;<http://www.apache.org/licenses/>&gt;_
 
 ### Terms and Conditions for use, reproduction, and distribution
@@ -184,13 +184,13 @@ the same “printed page” as the copyright notice for easier identification
 within third-party archives.
 
     Copyright [yyyy] [name of copyright owner]
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
       http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/META.json
+++ b/META.json
@@ -1,50 +1,50 @@
 {
-   "name": "pg_clickhouse",
-   "abstract": "Query ClickHouse databases from PostgreSQL",
-   "description": "Provides a Foreign Data Wrapper and other interfaces for easy and efficient access to ClickHouse databases, including pushdown of WHERE, JOIN, and aggregates expressions as well as comprehensive EXPLAIN and ANALYZE support.",
-   "version": "0.1.2",
-   "maintainer": "David E. Wheeler <david@justatheory.com>",
-   "license": "apache_2_0",
-   "provides": {
-      "pg_clickhouse": {
-         "abstract": "Interfaces to query ClickHouse databases from Postgres",
-         "file": "pg_clickhouse.control",
-         "docfile": "doc/pg_clickhouse.md",
-         "version": "0.1.2"
+  "abstract": "Query ClickHouse databases from PostgreSQL",
+  "description": "Provides a Foreign Data Wrapper and other interfaces for easy and efficient access to ClickHouse databases, including pushdown of WHERE, JOIN, and aggregates expressions as well as comprehensive EXPLAIN and ANALYZE support.",
+  "generated_by": "David E. Wheeler",
+  "license": "apache_2_0",
+  "maintainer": "David E. Wheeler <david@justatheory.com>",
+  "meta-spec": {
+    "url": "http://pgxn.org/meta/spec.txt",
+    "version": "1.0.0"
+  },
+  "name": "pg_clickhouse",
+  "no_index": {
+    "directory": ["vendor", "test"]
+  },
+  "prereqs": {
+    "runtime": {
+      "requires": {
+        "PostgreSQL": "13.0.0"
       }
-   },
-   "prereqs": {
-      "runtime": {
-         "requires": {
-            "PostgreSQL": "13.0.0"
-         }
-      }
-   },
-   "no_index": {
-      "directory": ["vendor", "test"]
-   },
-   "resources": {
-      "bugtracker": {
-         "web": "http://github.com/clickhouse/pg_clickhouse/issues/"
-      },
-      "repository": {
-        "url":  "git://github.com/clickhouse/pg_clickhouse.git",
-        "web":  "http://github.com/clickhouse/pg_clickhouse/",
-        "type": "git"
-      }
-   },
-   "generated_by": "David E. Wheeler",
-   "meta-spec": {
-      "version": "1.0.0",
-      "url": "http://pgxn.org/meta/spec.txt"
-   },
-   "tags": [
-      "foreign data wrapper",
-      "fdw",
-      "clickhouse",
-      "analytics",
-      "external data",
-      "pushdown",
-      "aggregate"
-   ]
+    }
+  },
+  "provides": {
+    "pg_clickhouse": {
+      "abstract": "Interfaces to query ClickHouse databases from Postgres",
+      "docfile": "doc/pg_clickhouse.md",
+      "file": "pg_clickhouse.control",
+      "version": "0.1.2"
+    }
+  },
+  "resources": {
+    "bugtracker": {
+      "web": "http://github.com/clickhouse/pg_clickhouse/issues/"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/clickhouse/pg_clickhouse.git",
+      "web": "http://github.com/clickhouse/pg_clickhouse/"
+    }
+  },
+  "tags": [
+    "foreign data wrapper",
+    "fdw",
+    "clickhouse",
+    "analytics",
+    "external data",
+    "pushdown",
+    "aggregate"
+  ],
+  "version": "0.1.2"
 }

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ include $(PGXS)
 # We'll need the clickhouse-cpp library and rpath so it can be found.
 SHLIB_LINK += -Wl,-rpath,$(pkglibdir)/
 
-# PostgresSQL 15 and earlier violate a C++ v17 storage specifier error.
+# PostgreSQL 15 and earlier violate a C++ v17 storage specifier error.
 ifeq ($(shell test $(MAJORVERSION) -lt 16; echo $$?),0)
 	PG_CXXFLAGS += -Wno-register
 endif
@@ -182,11 +182,25 @@ bake-vars:
 	@echo "revision=$(REVISION)"
 	@echo "pg_versions=$(PG_VERSIONS)"
 
-# Format the .c and .h files according to the PostgreSQL indentation standard.
-# Requires `pg_bsd_indent` to be in the path.
-indent:
-	@for fn in $(wildcard src/*.c.in src/*.c src/*/*.hh src/*/*.cpp); do printf "%s\n" "$$fn"; pg_bsd_indent -bad -bap -bbb -bc -bl -cli1 -cp33 -cdb -nce -d0 -di12 -nfc1 -i4 -l79 -lp -lpl -nip -npro -sac -tpg -ts4 "$$fn"; done
-	@rm *.BAK
+# Format the .c, .h, and .hh files according to the PostgreSQL indentation
+# standard. Requires `pg_bsd_indent` to be in the path.
+indent: dev/indent.sh
+	@$<
+
+# Linting.
+.PHONY: lint # Lint the project
+lint: .pre-commit-config.yaml
+	@pre-commit run --show-diff-on-failure --color=always --all-files
+
+## .git/hooks/pre-commit: Install the pre-commit hook
+.git/hooks/pre-commit:
+	@printf "#!/bin/sh\nmake lint\n" > $@
+	@chmod +x $@
+
+debian-install-lint:
+	@curl -SsLo /tmp/pre-commit.pyz https://github.com/pre-commit/pre-commit/releases/download/v4.5.1/pre-commit-4.5.1.pyz
+	@printf "#!/bin/sh\npython3 /tmp/pre-commit.pyz \"\$$@\"\n" > /usr/local/bin/pre-commit
+	@chmod +x /usr/local/bin/pre-commit
 
 .PHONY: lsp # Generate compile_commands.json for IDE/clangd support.
 lsp: compile_commands.json
@@ -197,8 +211,8 @@ compile_commands.json:
 	bear -- $(MAKE) all
 
 # ClickHouse Docker Containers
-start-containers:
-	docker compose -f dev/docker-compose.yml up -d --remove-orphans
+start-containers: dev/Makefile dev/docker-compose.yml
+	@$(MAKE) -C dev start
 
-stop-containers:
-	docker compose -f dev/docker-compose.yml down --remove-orphans --volumes
+stop-containers: dev/Makefile dev/docker-compose.yml
+	@$(MAKE) -C dev stop

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,5 +1,5 @@
 start:
-	docker compose up -d --remove-orphans
+	@docker compose up -d --remove-orphans
 
 stop:
-	docker compose down --remove-orphans --volumes
+	@docker compose down --remove-orphans --volumes

--- a/dev/indent.sh
+++ b/dev/indent.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+for fn in  src/**/*.h* src/*.c src/*.c.in; do
+    printf "%s\n" "$fn"
+    pg_bsd_indent -bad -bap -bbb -bc -bl -cli1 -cp33 -cdb -nce -d0 -di12 -nfc1 -i4 -l79 -lp -lpl -nip -npro -sac -tpg -ts4 "$fn"
+done
+rm -f ./*.BAK

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -67,7 +67,7 @@ from `v0.1.0` to `v0.1.1`, benefits all databases that have loaded `v0.1` and
 do not need to run `ALTER EXTENSION` to benefit from the upgrade.
 
 A release that increments the minor or major versions, on the other hand, will
-be accompanied by SQL upgrade scrips, and all existing database that contain
+be accompanied by SQL upgrade scripts, and all existing database that contain
 the extension must run `ALTER EXTENSION pg_clickhouse UPDATE` to benefit from
 the upgrade.
 
@@ -394,7 +394,7 @@ try=# EXPLAIN (VERBOSE)
        SELECT resource, avg(duration) AS average_duration
          FROM logs
         GROUP BY resource;
-                                     QUERY PLAN                                     
+                                     QUERY PLAN
 ------------------------------------------------------------------------------------
  Foreign Scan  (cost=1.00..5.10 rows=1000 width=64)
    Output: resource, (avg(duration))
@@ -413,7 +413,7 @@ like any other tables:
 
 ```pgsql
 try=# SELECT start_at, duration, resource FROM logs WHERE req_id = 4117909262;
-          start_at          | duration |    resource    
+          start_at          | duration |    resource
 ----------------------------+----------+----------------
  2025-12-05 15:07:32.944188 |      175 | /widgets/totam
 (1 row)
@@ -427,7 +427,7 @@ down to ClickHouse
 ```pgsql
 try=# EXPLAIN (VERBOSE, COSTS OFF)
        SELECT start_at, duration, resource FROM logs WHERE req_id = 4117909262;
-                                             QUERY PLAN                                              
+                                             QUERY PLAN
 -----------------------------------------------------------------------------------------------------
  Foreign Scan on public.logs
    Output: start_at, duration, resource
@@ -444,7 +444,7 @@ try=# EXPLAIN (ANALYZE, VERBOSE)
          FROM logs
          LEFT JOIN nodes on logs.node_id = nodes.node_id
         GROUP BY name;
-                                                                                  QUERY PLAN                                                                                   
+                                                                                  QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan  (cost=1.00..5.10 rows=1000 width=72) (actual time=3.201..3.221 rows=8.00 loops=1)
    Output: nodes.name, (count(*)), (round(avg(logs.duration), 0))
@@ -469,7 +469,7 @@ try=# EXPLAIN (ANALYZE, VERBOSE)
          FROM logs
          LEFT JOIN local_nodes on logs.node_id = local_nodes.node_id
         GROUP BY name;
-                                                             QUERY PLAN                                                              
+                                                             QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------------
  HashAggregate  (cost=147.65..150.65 rows=200 width=72) (actual time=6.215..6.235 rows=8.00 loops=1)
    Output: local_nodes.name, count(*), round(avg(logs.duration), 0)
@@ -513,7 +513,7 @@ try=# EXPLAIN (ANALYZE, VERBOSE)
          JOIN local_nodes
            ON remote.node_id = local_nodes.node_id
         ORDER BY name;
-                                                          QUERY PLAN                                                           
+                                                          QUERY PLAN
 -------------------------------------------------------------------------------------------------------------------------------
  Sort  (cost=65.68..66.91 rows=490 width=72) (actual time=4.480..4.484 rows=8.00 loops=1)
    Output: local_nodes.name, remote.count, remote.round
@@ -567,7 +567,7 @@ Use [EXECUTE] as usual to execute a prepared statement:
 
 ```pgsql
 try=# EXECUTE avg_durations_between_dates('2025-12-09', '2025-12-13');
-    date    | average_duration 
+    date    | average_duration
 ------------+------------------
  2025-12-09 |              190
  2025-12-10 |              194
@@ -582,7 +582,7 @@ pg_clickhouse pushes down the aggregations, as usual, as seen in the
 
 ```pgsql
 try=# EXPLAIN (VERBOSE) EXECUTE avg_durations_between_dates('2025-12-09', '2025-12-13');
-                                                                                                            QUERY PLAN                                                                                                             
+                                                                                                            QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan  (cost=1.00..5.10 rows=1000 width=36)
    Output: (date(start_at)), (round(avg(duration), 0))
@@ -598,7 +598,7 @@ This holds for the first five requests, as described in the PostgreSQL
 parameters:
 
 ```pgsql
-                                                                                                         QUERY PLAN                                                                                                          
+                                                                                                         QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan  (cost=1.00..5.10 rows=1000 width=36)
    Output: (date(start_at)), (round(avg(duration), 0))
@@ -784,28 +784,28 @@ pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
 types:
 
 ```
- ClickHouse |    PostgreSQL    |             Notes             
+ ClickHouse |    PostgreSQL    |             Notes
 ------------+------------------+-------------------------------
- Bool       | boolean          | 
- Date       | date             | 
- Date32     | date             | 
- DateTime   | timestamp        | 
- Decimal    | numeric          | 
- Float32    | real             | 
- Float64    | double precision | 
- IPv4       | inet             | 
- IPv6       | inet             | 
- Int16      | smallint         | 
- Int32      | integer          | 
- Int64      | bigint           | 
- Int8       | smallint         | 
+ Bool       | boolean          |
+ Date       | date             |
+ Date32     | date             |
+ DateTime   | timestamp        |
+ Decimal    | numeric          |
+ Float32    | real             |
+ Float64    | double precision |
+ IPv4       | inet             |
+ IPv6       | inet             |
+ Int16      | smallint         |
+ Int32      | integer          |
+ Int64      | bigint           |
+ Int8       | smallint         |
  JSON       | jsonb            | HTTP engine only
- String     | text             | 
- UInt16     | integer          | 
- UInt32     | bigint           | 
+ String     | text             |
+ UInt16     | integer          |
+ UInt32     | bigint           |
  UInt64     | bigint           | Errors on values > BIGINT max
- UInt8      | smallint         | 
- UUID       | uuid             | 
+ UInt8      | smallint         |
+ UUID       | uuid             |
 ```
 
 ### Functions
@@ -843,14 +843,14 @@ SELECT clickhouse_raw_query(
 );
 ```
 ```sql
-      clickhouse_raw_query       
+      clickhouse_raw_query
 ---------------------------------
  INFORMATION_SCHEMA      default+
  default default                +
  git     default                +
  information_schema      default+
  system  default                +
- 
+
 (1 row)
 ```
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -210,7 +210,7 @@ And now the table should be imported: In [psql], use `\det+` to see it:
 ```pgsql
 taxi=# \det+ taxi.*
                                        List of foreign tables
- Schema | Table |  Server  |                        FDW options                        | Description 
+ Schema | Table |  Server  |                        FDW options                        | Description
 --------+-------+----------+-----------------------------------------------------------+-------------
  taxi   | trips | taxi_srv | (database 'taxi', table_name 'trips', engine 'MergeTree') | [null]
 (1 row)
@@ -221,53 +221,53 @@ Success! Use `\d` to show all the columns:
 ```pgsql
 taxi=# \d taxi.trips
                                      Foreign table "taxi.trips"
-        Column         |            Type             | Collation | Nullable | Default | FDW options 
+        Column         |            Type             | Collation | Nullable | Default | FDW options
 -----------------------+-----------------------------+-----------+----------+---------+-------------
- trip_id               | bigint                      |           | not null |         | 
- vendor_id             | text                        |           | not null |         | 
- pickup_date           | date                        |           | not null |         | 
- pickup_datetime       | timestamp without time zone |           | not null |         | 
- dropoff_date          | date                        |           | not null |         | 
- dropoff_datetime      | timestamp without time zone |           | not null |         | 
- store_and_fwd_flag    | smallint                    |           | not null |         | 
- rate_code_id          | smallint                    |           | not null |         | 
- pickup_longitude      | double precision            |           | not null |         | 
- pickup_latitude       | double precision            |           | not null |         | 
- dropoff_longitude     | double precision            |           | not null |         | 
- dropoff_latitude      | double precision            |           | not null |         | 
- passenger_count       | smallint                    |           | not null |         | 
- trip_distance         | double precision            |           | not null |         | 
- fare_amount           | numeric(10,2)               |           | not null |         | 
- extra                 | numeric(10,2)               |           | not null |         | 
- mta_tax               | numeric(10,2)               |           | not null |         | 
- tip_amount            | numeric(10,2)               |           | not null |         | 
- tolls_amount          | numeric(10,2)               |           | not null |         | 
- ehail_fee             | numeric(10,2)               |           | not null |         | 
- improvement_surcharge | numeric(10,2)               |           | not null |         | 
- total_amount          | numeric(10,2)               |           | not null |         | 
- payment_type          | text                        |           | not null |         | 
- trip_type             | smallint                    |           | not null |         | 
- pickup                | character varying(25)       |           | not null |         | 
- dropoff               | character varying(25)       |           | not null |         | 
- cab_type              | text                        |           | not null |         | 
- pickup_nyct2010_gid   | smallint                    |           | not null |         | 
- pickup_ctlabel        | real                        |           | not null |         | 
- pickup_borocode       | smallint                    |           | not null |         | 
- pickup_ct2010         | text                        |           | not null |         | 
- pickup_boroct2010     | text                        |           | not null |         | 
- pickup_cdeligibil     | text                        |           | not null |         | 
- pickup_ntacode        | character varying(4)        |           | not null |         | 
- pickup_ntaname        | text                        |           | not null |         | 
- pickup_puma           | integer                     |           | not null |         | 
- dropoff_nyct2010_gid  | smallint                    |           | not null |         | 
- dropoff_ctlabel       | real                        |           | not null |         | 
- dropoff_borocode      | smallint                    |           | not null |         | 
- dropoff_ct2010        | text                        |           | not null |         | 
- dropoff_boroct2010    | text                        |           | not null |         | 
- dropoff_cdeligibil    | text                        |           | not null |         | 
- dropoff_ntacode       | character varying(4)        |           | not null |         | 
- dropoff_ntaname       | text                        |           | not null |         | 
- dropoff_puma          | integer                     |           | not null |         | 
+ trip_id               | bigint                      |           | not null |         |
+ vendor_id             | text                        |           | not null |         |
+ pickup_date           | date                        |           | not null |         |
+ pickup_datetime       | timestamp without time zone |           | not null |         |
+ dropoff_date          | date                        |           | not null |         |
+ dropoff_datetime      | timestamp without time zone |           | not null |         |
+ store_and_fwd_flag    | smallint                    |           | not null |         |
+ rate_code_id          | smallint                    |           | not null |         |
+ pickup_longitude      | double precision            |           | not null |         |
+ pickup_latitude       | double precision            |           | not null |         |
+ dropoff_longitude     | double precision            |           | not null |         |
+ dropoff_latitude      | double precision            |           | not null |         |
+ passenger_count       | smallint                    |           | not null |         |
+ trip_distance         | double precision            |           | not null |         |
+ fare_amount           | numeric(10,2)               |           | not null |         |
+ extra                 | numeric(10,2)               |           | not null |         |
+ mta_tax               | numeric(10,2)               |           | not null |         |
+ tip_amount            | numeric(10,2)               |           | not null |         |
+ tolls_amount          | numeric(10,2)               |           | not null |         |
+ ehail_fee             | numeric(10,2)               |           | not null |         |
+ improvement_surcharge | numeric(10,2)               |           | not null |         |
+ total_amount          | numeric(10,2)               |           | not null |         |
+ payment_type          | text                        |           | not null |         |
+ trip_type             | smallint                    |           | not null |         |
+ pickup                | character varying(25)       |           | not null |         |
+ dropoff               | character varying(25)       |           | not null |         |
+ cab_type              | text                        |           | not null |         |
+ pickup_nyct2010_gid   | smallint                    |           | not null |         |
+ pickup_ctlabel        | real                        |           | not null |         |
+ pickup_borocode       | smallint                    |           | not null |         |
+ pickup_ct2010         | text                        |           | not null |         |
+ pickup_boroct2010     | text                        |           | not null |         |
+ pickup_cdeligibil     | text                        |           | not null |         |
+ pickup_ntacode        | character varying(4)        |           | not null |         |
+ pickup_ntaname        | text                        |           | not null |         |
+ pickup_puma           | integer                     |           | not null |         |
+ dropoff_nyct2010_gid  | smallint                    |           | not null |         |
+ dropoff_ctlabel       | real                        |           | not null |         |
+ dropoff_borocode      | smallint                    |           | not null |         |
+ dropoff_ct2010        | text                        |           | not null |         |
+ dropoff_boroct2010    | text                        |           | not null |         |
+ dropoff_cdeligibil    | text                        |           | not null |         |
+ dropoff_ntacode       | character varying(4)        |           | not null |         |
+ dropoff_ntaname       | text                        |           | not null |         |
+ dropoff_puma          | integer                     |           | not null |         |
 Server: taxi_srv
 FDW options: (database 'taxi', table_name 'trips', engine 'MergeTree')
 ```
@@ -276,7 +276,7 @@ Now query the table:
 
  ```pgsql
  SELECT count(*) FROM taxi.trips;
-   count  
+   count
  ---------
   1999657
  (1 row)
@@ -285,16 +285,16 @@ Now query the table:
  Note how quickly the query executed. pg_clickhouse pushes down the entire
  query, including the `COUNT()` aggregate, so it runs on ClickHouse and only
  returns the single row to Postgres. Use [EXPLAIN] to see it:
- 
+
  ```pgsql
  EXPLAIN select count(*) from taxi.trips;
-                    QUERY PLAN                    
+                    QUERY PLAN
  -------------------------------------------------
   Foreign Scan  (cost=1.00..-0.90 rows=1 width=8)
     Relations: Aggregate on (trips)
  (2 rows)
  ```
- 
+
  Note that "Foreign Scan" appears at the root of the plan, meaning that the
  entire query was pushed down to ClickHouse.
 
@@ -309,7 +309,7 @@ your own SQL query.
     taxi=# \timing
     Timing is on.
     taxi=# SELECT round(avg(tip_amount), 2) FROM taxi.trips;
-     round 
+     round
     -------
       1.68
     (1 row)
@@ -325,7 +325,7 @@ your own SQL query.
             avg(total_amount)::NUMERIC(10, 2) AS average_total_amount
         FROM taxi.trips
         GROUP BY passenger_count;
-     passenger_count | average_total_amount 
+     passenger_count | average_total_amount
     -----------------+----------------------
                    0 |                22.68
                    1 |                15.96
@@ -338,7 +338,7 @@ your own SQL query.
                    8 |                36.40
                    9 |                 9.79
     (10 rows)
-    
+
     Time: 27.266 ms
     ```
 
@@ -352,7 +352,7 @@ your own SQL query.
     FROM taxi.trips
     GROUP BY pickup_date, pickup_ntaname
     ORDER BY pickup_date ASC LIMIT 10;
-     pickup_date |         pickup_ntaname         | number_of_trips 
+     pickup_date |         pickup_ntaname         | number_of_trips
     -------------+--------------------------------+-----------------
      2015-07-01  | Williamsburg                   |               1
      2015-07-01  | park-cemetery-etc-Queens       |               6
@@ -365,7 +365,7 @@ your own SQL query.
      2015-07-01  | Airport                        |             550
      2015-07-01  | East Harlem North              |              32
     (10 rows)
-    
+
     Time: 30.978 ms
     ```
 
@@ -384,7 +384,7 @@ your own SQL query.
     GROUP BY trip_minutes
     ORDER BY trip_minutes DESC
     LIMIT 5;
-          avg_tip      |     avg_fare     |  avg_passenger   | count | trip_minutes 
+          avg_tip      |     avg_fare     |  avg_passenger   | count | trip_minutes
     -------------------+------------------+------------------+-------+--------------
                   1.96 |                8 |                1 |     1 |        27512
                      0 |               12 |                2 |     1 |        27500
@@ -392,7 +392,7 @@ your own SQL query.
      0.716564885496183 | 14.2786259541985 | 1.94656488549618 |   131 |         1439
       1.00945205479452 | 12.8787671232877 | 1.98630136986301 |   146 |         1438
     (5 rows)
-    
+
     Time: 45.477 ms
     ```
 
@@ -408,7 +408,7 @@ your own SQL query.
     GROUP BY pickup_ntaname, pickup_hour
     ORDER BY pickup_ntaname, date_part('hour', pickup_datetime)
     LIMIT 5;
-     pickup_ntaname | pickup_hour | pickups 
+     pickup_ntaname | pickup_hour | pickups
     ----------------+-------------+---------
      Airport        |           0 |    3509
      Airport        |           1 |    1184
@@ -416,7 +416,7 @@ your own SQL query.
      Airport        |           3 |     152
      Airport        |           4 |     213
     (5 rows)
-    
+
     Time: 36.895 ms
     ```
 
@@ -440,7 +440,7 @@ your own SQL query.
     WHERE dropoff_nyct2010_gid IN (132, 138)
     ORDER BY pickup_datetime
     LIMIT 5;
-       pickup_datetime   |  dropoff_datetime   | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour 
+       pickup_datetime   |  dropoff_datetime   | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour
     ---------------------+---------------------+--------------+---------------------+----------------------+--------------+------+-----+------
      2015-07-01 00:04:14 | 2015-07-01 00:15:29 |        13.30 |                 -34 |                  132 | JFK          | 2015 |   1 |    0
      2015-07-01 00:09:42 | 2015-07-01 00:12:55 |         6.80 |                  50 |                  138 | LGA          | 2015 |   1 |    0
@@ -448,7 +448,7 @@ your own SQL query.
      2015-07-01 00:27:51 | 2015-07-01 00:39:02 |        14.72 |                -101 |                  138 | LGA          | 2015 |   1 |    0
      2015-07-01 00:32:03 | 2015-07-01 00:55:39 |        39.34 |                  48 |                  138 | LGA          | 2015 |   1 |    0
     (5 rows)
-    
+
     Time: 17.450 ms
     ```
 
@@ -492,7 +492,7 @@ Here's an excerpt from the CSV file you're using in table format. The
         LAYOUT(HASHED_ARRAY())
     $$, 'host=localhost dbname=taxi');
     ```
-    
+
     > [!NOTE]
     > Setting `LIFETIME` to 0 disables automatic updates to avoid unnecessary
     > traffic to our S3 bucket. In other cases, you might configure it
@@ -500,28 +500,28 @@ Here's an excerpt from the CSV file you're using in table format. The
     > LIFETIME](/sql-reference/dictionaries#refreshing-dictionary-data-using-lifetime).
 
     2.  Now import it:
-    
+
     ```sql
     IMPORT FOREIGN SCHEMA taxi LIMIT TO (taxi_zone_dictionary)
     FROM SERVER taxi_srv INTO taxi;
     ```
-    
+
     3.  Confirm we can query it:
-    
+
     ```pgsql
     taxi=# SELECT * FROM taxi.taxi_zone_dictionary limit 3;
-     LocationID |  Borough  |                     Zone                      | service_zone 
+     LocationID |  Borough  |                     Zone                      | service_zone
     ------------+-----------+-----------------------------------------------+--------------
              77 | Brooklyn  | East New York/Pennsylvania Avenue             | Boro Zone
             106 | Brooklyn  | Gowanus                                       | Boro Zone
             103 | Manhattan | Governor's Island/Ellis Island/Liberty Island | Yellow Zone
     (3 rows)
     ```
-    
+
     4.  Excellent. Now use the `dictGet` function unction to retrieve a
         borough's name in a query. For this query sums up the number of taxi
         rides per borough that end at either the LaGuardia or JFK airport:
-    
+
     ```pgsql
     taxi=# SELECT
             count(1) AS total,
@@ -533,7 +533,7 @@ Here's an excerpt from the CSV file you're using in table format. The
         WHERE dropoff_nyct2010_gid = 132 OR dropoff_nyct2010_gid = 138
         GROUP BY borough_name
         ORDER BY total DESC;
-     total | borough_name  
+     total | borough_name
     -------+---------------
      23683 | Unknown
       7053 | Manhattan
@@ -543,7 +543,7 @@ Here's an excerpt from the CSV file you're using in table format. The
        554 | Staten Island
         53 | EWR
     (7 rows)
-    
+
     Time: 66.245 ms
     ```
 
@@ -570,7 +570,7 @@ table.
       AND dropoff_nyct2010_gid IN (132, 138)
     GROUP BY "Borough"
     ORDER BY total DESC;
-     total | borough_name  
+     total | borough_name
     -------+---------------
       7053 | Manhattan
       6828 | Brooklyn
@@ -601,7 +601,7 @@ table.
           AND dropoff_nyct2010_gid IN (132, 138)
         GROUP BY "Borough"
         ORDER BY total DESC;
-                                  QUERY PLAN                               
+                                  QUERY PLAN
     -----------------------------------------------------------------------
      Foreign Scan  (cost=1.00..5.10 rows=1000 width=40)
        Relations: Aggregate on ((trips) INNER JOIN (taxi_zone_dictionary))

--- a/src/convert.c
+++ b/src/convert.c
@@ -91,7 +91,7 @@ convert_record(ch_convert_state * state, Datum val)
 
 		if (state->cdef && state->cdef->rowfunc != InvalidOid)
 		{
-			/* there is convertor from row to outtype */
+			/* there is converter from row to outtype */
 			val = OidFunctionCall1(state->cdef->rowfunc, val);
 		}
 		else if (state->outtype == TEXTOID)

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2139,7 +2139,7 @@ deparseConst(Const * node, deparse_expr_cxt * context, int showtype)
 	else if (typoutput == F_INTERVAL_OUT)
 	{
 		/*
-		 * basicly we can't convert month part since we should know about
+		 * basically we can't convert month part since we should know about
 		 * related timestamp first.
 		 *
 		 * for other types we just convert to seconds.
@@ -3205,7 +3205,7 @@ deparseAggref(Aggref * node, deparse_expr_cxt * context)
 
 		/* Close parameter args and start regular args. */
 		appendStringInfoString(buf, ")(");
-		/* Emit `WITHIN GROUP (ORDER BY ..)` args with no cloding paren. */
+		/* Emit `WITHIN GROUP (ORDER BY ..)` args with no closing paren. */
 		context->no_sort_parens = true;
 		appendAggOrderBy(node->aggorder, node->args, context);
 		context->no_sort_parens = false;
@@ -3222,7 +3222,7 @@ deparseAggref(Aggref * node, deparse_expr_cxt * context)
 			/*
 			 * Omit * for COUNT(*) but not COUNT(DISTINCT *)
 			 * https://github.com/ClickHouse/pg_clickhouse/issues/25 To be
-			 * fixed in ClickHouse 25.11, so can be omitted once relased.
+			 * fixed in ClickHouse 25.11, so can be omitted once released.
 			 * https://github.com/ClickHouse/ClickHouse/pull/89373
 			 *
 			 * XXX Once ClickHouse has made a release fixing this issue,

--- a/src/include/engine.h
+++ b/src/include/engine.h
@@ -20,11 +20,11 @@ typedef struct
  */
 typedef struct
 {
-   const char     *sql;
-   const int num_params;
-   const char **param_values;
-   const kv_list    *settings;
-}          ch_query;
+	const char *sql;
+	const int	num_params;
+	const char **param_values;
+	const		kv_list *settings;
+}			ch_query;
 
 #define new_query(sql, num, vals) {sql, num, vals, chfdw_get_session_settings()}
 

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -48,8 +48,8 @@ typedef struct ch_cursor
 
 typedef void (*disconnect_method) (void *conn);
 typedef void (*check_conn_method) (const char *password, UserMapping * user);
-typedef ch_cursor * (*simple_query_method) (void *conn, const ch_query *query);
-typedef void (*simple_insert_method) (void *conn, const ch_query *query);
+typedef ch_cursor * (*simple_query_method) (void *conn, const ch_query * query);
+typedef void (*simple_insert_method) (void *conn, const ch_query * query);
 typedef void **(*cursor_fetch_row_method) (ch_cursor * cursor, List * attrs,
 										   TupleDesc tupdesc, Datum * values, bool *nulls);
 typedef void *(*prepare_insert_method) (void *conn, ResultRelInfo *, List *,
@@ -77,7 +77,7 @@ ch_connection chfdw_http_connect(ch_connection_details * details);
 ch_connection chfdw_binary_connect(ch_connection_details * details);
 text	   *chfdw_http_fetch_raw_data(ch_cursor * cursor);
 List	   *chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * server);
-char *ch_quote_literal(const char *rawstr);
+char	   *ch_quote_literal(const char *rawstr);
 char	   *chfdw_datum_to_ch_literal(Datum value, Oid type);
 
 typedef enum
@@ -217,9 +217,9 @@ extern void chfdw_classify_conditions(PlannerInfo * root,
 extern bool chfdw_is_foreign_expr(PlannerInfo * root,
 								  RelOptInfo * baserel,
 								  Expr * expr);
-extern bool is_foreign_param(PlannerInfo *root,
-							 RelOptInfo *baserel,
-							 Expr *expr);
+extern bool is_foreign_param(PlannerInfo * root,
+							 RelOptInfo * baserel,
+							 Expr * expr);
 extern char *chfdw_deparse_insert_sql(StringInfo buf, RangeTblEntry * rte,
 									  Index rtindex, Relation rel,
 									  List * targetAttrs);
@@ -229,7 +229,7 @@ extern void chfdw_deparse_select_stmt_for_rel(StringInfo buf, PlannerInfo * root
 											  bool has_final_sort, bool has_limit, bool is_subquery,
 											  List * *retrieved_attrs, List * *params_list);
 extern const char *chfdw_get_jointype_name(JoinType jointype);
-char * chfdw_array_to_ch_literal(Datum arr);
+char	   *chfdw_array_to_ch_literal(Datum arr);
 
 /* in shippable.c */
 extern bool chfdw_is_builtin(Oid objectId);

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -47,7 +47,7 @@ void		ch_http_init(int verbose, uint32_t query_id_prefix);
 void		ch_http_set_progress_func(void *progressfunc);
 ch_http_connection_t *ch_http_connection(ch_connection_details * details);
 void		ch_http_close(ch_http_connection_t * conn);
-ch_http_response_t *ch_http_simple_query(ch_http_connection_t * conn, const ch_query *query);
+ch_http_response_t *ch_http_simple_query(ch_http_connection_t * conn, const ch_query * query);
 char	   *ch_http_last_error(void);
 
 /* read */

--- a/src/include/kv_list.h
+++ b/src/include/kv_list.h
@@ -13,7 +13,7 @@ typedef struct kv_list
 {
 	int			length;
 	/* key/value char * pairs follow the length field. */
-	char data[];
+	char		data[];
 }			kv_list;
 
 /*
@@ -24,11 +24,12 @@ typedef struct kv_list
  *         printf("%i, %s => %s\n", iter.num, iter.name, iter.value);
  *     }
  */
-typedef struct kv_iter {
-    int togo;
-    char * name;
-    char * value;
-} kv_iter;
+typedef struct kv_iter
+{
+	int			togo;
+	char	   *name;
+	char	   *value;
+}			kv_iter;
 
 /*
  * Defines the allocator to use when creating a new kv_list.
@@ -46,15 +47,15 @@ enum kv_pair_alloc
  * Create a new kv_list from a PostgreSQL List of DefElem. Allocate the memory
  * using the specified allocator.
 */
-kv_list * new_kv_list_from_pg_list(List * list, int allocate);
+kv_list    *new_kv_list_from_pg_list(List * list, int allocate);
 
 /* Create a new kv_iter for a key_pairs. */
-kv_iter new_kv_iter(const kv_list * ns);
+kv_iter		new_kv_iter(const kv_list * ns);
 
 /* Iterate to the next item. Returns false if there are no items. */
-bool kv_iter_next(kv_iter * state);
+bool		kv_iter_next(kv_iter * state);
 
-/* Retruns true if iteration by kv_iter is complete. */
-bool kv_iter_done(kv_iter * state);
+/* Returns true if iteration by kv_iter is complete. */
+bool		kv_iter_done(kv_iter * state);
 
 #endif							/* PG_CLICKHOUSE_KV_LIST_H */

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -661,7 +661,7 @@ binary_fetch_row(ch_cursor * cursor, List * attrs, TupleDesc tupdesc,
 							MemoryContextSwitchTo(old_mcxt);
 
 							if (s == NULL)
-								/* no conversion but state is initalized */
+								/* no conversion but state is initialized */
 								cursor->conversion_states[j] = 1;
 							else
 								cursor->conversion_states[j] = (uintptr_t) s;


### PR DESCRIPTION
Move the code for `make indent` into `dev/indent.sh`, and fix it to also indent `*.h` files. It does not currently indent `*.cpp` files because `pg_bsd_indent` breaks them.

Add `.pre-commit-config.yaml` and configure it with typical commit checks, plus indentation. Fix issues it finds (typos, indentation of `*.h` files, formatting of `META.json`, removal of trailing blank space).

Add targets for linting to the `Makefile`, including installation of `git/hooks/pre-commit`, `lint`, and installing `pre-commit` on Debian.

Add `.github/workflows/lint.yml` to run `pre-commit` for every push and pull request.

While at it, remove duplicate items from `CHANGELOG.md` and delegate the `docker compose` items in `Makefile` to `dev/Makefile`.