### PR TITLE
Use CSV COPY instead of default TSV

### DIFF
--- a/doc/make-logs.sql
+++ b/doc/make-logs.sql
@@ -1,3 +1,14 @@
+/*
+ * clickhouse client --queries-file doc/make-logs.sql
+ *
+ * psql:
+ * CREATE SERVER ch_svr FOREIGN DATA WRAPPER clickhouse_fdw
+ *     OPTIONS(dbname 'default', driver 'binary');
+ * CREATE USER MAPPING FOR CURRENT_USER SERVER ch_svr;
+ * CREATE SCHEMA docs;
+ * IMPORT FOREIGN SCHEMA "default" FROM SERVER ch_svr INTO docs;
+ */
+
 CREATE TABLE logs (
     req_id    Int64 NOT NULL,
     start_at   DateTime64(6, 'UTC') NOT NULL,

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -359,8 +359,7 @@ DROP FOREIGN TABLE uact CASCADE;
 ## DML SQL Reference
 
 The SQL [DML] expressions below may use pg_clickhouse. Examples depend on
-these ClickHouse tables, created by [make-logs.sql](make-logs.sql): these
-tables in ClickHouse:
+these ClickHouse tables, created by [make-logs.sql](make-logs.sql):
 
 ```sql
 CREATE TABLE logs (
@@ -633,10 +632,10 @@ Use the [COPY] command to insert a batch of rows into a remote ClickHouse
 table:
 
 ```pgsql
-try=# COPY logs FROM stdin;
-4285871863	2025-12-05 11:13:58.360760	206	/widgets	POST	8	401
-4020882978	2025-12-05 11:33:48.248450	199	/users/1321945	HEAD	3	200
-3231273177	2025-12-05 12:20:42.158575	220	/search	GET	2	201
+try=# COPY logs FROM stdin CSV;
+4285871863,2025-12-05 11:13:58.360760,206,/widgets,POST,8,401
+4020882978,2025-12-05 11:33:48.248450,199,/users/1321945,HEAD,3,200
+3231273177,2025-12-05 12:20:42.158575,220,/search,GET,2,201
 \.
 >> COPY 3
 ```


### PR DESCRIPTION
The ClickHouse documentation forbids tabs, so use CSV instead. This will make it simpler to sync the docs in the future.

Also note how to load the contents of `doc/make-logs.sql` into ClickHouse and then import them into Postgres.