### PR TITLE
Document DateTime mapping to TIMESTAMPTZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.3] — Unreleased
 
+
+### ⚡ Improvements
+
+*   Changed the default mapping for `DateTime` and `DateTime64` values from
+    `TIMESTAMP` to `TIMESTAMPTZ`, because ClickHouse stores `DateTime`s as a
+    Unix timestamp, always normalized to UTC, even if it displays as a
+    different time zone. As of the first bug fix listed below, pg_clickhouse
+    (almost) always fetches these values in UTC, so can store them as
+    `TIMESTAMPTZ` values.
+
 ### 🪲 Bug Fixes
 
 *   Fixed time zone conversion in the http engine so that for ClickHouse v25

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -791,30 +791,28 @@ cluster to be restart when the library is updated.
 pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
 types:
 
-```
- ClickHouse |    PostgreSQL    |             Notes
-------------+------------------+-------------------------------
- Bool       | boolean          |
- Date       | date             |
- Date32     | date             |
- DateTime   | timestamp        |
- Decimal    | numeric          |
- Float32    | real             |
- Float64    | double precision |
- IPv4       | inet             |
- IPv6       | inet             |
- Int16      | smallint         |
- Int32      | integer          |
- Int64      | bigint           |
- Int8       | smallint         |
- JSON       | jsonb            | HTTP engine only
- String     | text             |
- UInt16     | integer          |
- UInt32     | bigint           |
- UInt64     | bigint           | Errors on values > BIGINT max
- UInt8      | smallint         |
- UUID       | uuid             |
-```
+| ClickHouse |    PostgreSQL    |             Notes             |
+|------------|------------------|-------------------------------|
+| Bool       | boolean          |                               |
+| Date       | date             |                               |
+| Date32     | date             |                               |
+| DateTime   | timestamptz      |                               |
+| Decimal    | numeric          |                               |
+| Float32    | real             |                               |
+| Float64    | double precision |                               |
+| IPv4       | inet             |                               |
+| IPv6       | inet             |                               |
+| Int16      | smallint         |                               |
+| Int32      | integer          |                               |
+| Int64      | bigint           |                               |
+| Int8       | smallint         |                               |
+| JSON       | jsonb            | HTTP engine only              |
+| String     | text             |                               |
+| UInt16     | integer          |                               |
+| UInt32     | bigint           |                               |
+| UInt64     | bigint           | Errors on values > BIGINT max |
+| UInt8      | smallint         |                               |
+| UUID       | uuid             |                               |
 
 ### Functions
 

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -220,54 +220,54 @@ Success! Use `\d` to show all the columns:
 
 ```pgsql
 taxi=# \d taxi.trips
-                                     Foreign table "taxi.trips"
-        Column         |            Type             | Collation | Nullable | Default | FDW options
------------------------+-----------------------------+-----------+----------+---------+-------------
- trip_id               | bigint                      |           | not null |         |
- vendor_id             | text                        |           | not null |         |
- pickup_date           | date                        |           | not null |         |
- pickup_datetime       | timestamp without time zone |           | not null |         |
- dropoff_date          | date                        |           | not null |         |
- dropoff_datetime      | timestamp without time zone |           | not null |         |
- store_and_fwd_flag    | smallint                    |           | not null |         |
- rate_code_id          | smallint                    |           | not null |         |
- pickup_longitude      | double precision            |           | not null |         |
- pickup_latitude       | double precision            |           | not null |         |
- dropoff_longitude     | double precision            |           | not null |         |
- dropoff_latitude      | double precision            |           | not null |         |
- passenger_count       | smallint                    |           | not null |         |
- trip_distance         | double precision            |           | not null |         |
- fare_amount           | numeric(10,2)               |           | not null |         |
- extra                 | numeric(10,2)               |           | not null |         |
- mta_tax               | numeric(10,2)               |           | not null |         |
- tip_amount            | numeric(10,2)               |           | not null |         |
- tolls_amount          | numeric(10,2)               |           | not null |         |
- ehail_fee             | numeric(10,2)               |           | not null |         |
- improvement_surcharge | numeric(10,2)               |           | not null |         |
- total_amount          | numeric(10,2)               |           | not null |         |
- payment_type          | text                        |           | not null |         |
- trip_type             | smallint                    |           | not null |         |
- pickup                | character varying(25)       |           | not null |         |
- dropoff               | character varying(25)       |           | not null |         |
- cab_type              | text                        |           | not null |         |
- pickup_nyct2010_gid   | smallint                    |           | not null |         |
- pickup_ctlabel        | real                        |           | not null |         |
- pickup_borocode       | smallint                    |           | not null |         |
- pickup_ct2010         | text                        |           | not null |         |
- pickup_boroct2010     | text                        |           | not null |         |
- pickup_cdeligibil     | text                        |           | not null |         |
- pickup_ntacode        | character varying(4)        |           | not null |         |
- pickup_ntaname        | text                        |           | not null |         |
- pickup_puma           | integer                     |           | not null |         |
- dropoff_nyct2010_gid  | smallint                    |           | not null |         |
- dropoff_ctlabel       | real                        |           | not null |         |
- dropoff_borocode      | smallint                    |           | not null |         |
- dropoff_ct2010        | text                        |           | not null |         |
- dropoff_boroct2010    | text                        |           | not null |         |
- dropoff_cdeligibil    | text                        |           | not null |         |
- dropoff_ntacode       | character varying(4)        |           | not null |         |
- dropoff_ntaname       | text                        |           | not null |         |
- dropoff_puma          | integer                     |           | not null |         |
+                                   Foreign table "taxi.trips"
+        Column         |           Type           | Collation | Nullable | Default | FDW options
+-----------------------+--------------------------+-----------+----------+---------+-------------
+ trip_id               | bigint                   |           | not null |         |
+ vendor_id             | text                     |           | not null |         |
+ pickup_date           | date                     |           | not null |         |
+ pickup_datetime       | timestamp with time zone |           | not null |         |
+ dropoff_date          | date                     |           | not null |         |
+ dropoff_datetime      | timestamp with time zone |           | not null |         |
+ store_and_fwd_flag    | smallint                 |           | not null |         |
+ rate_code_id          | smallint                 |           | not null |         |
+ pickup_longitude      | double precision         |           | not null |         |
+ pickup_latitude       | double precision         |           | not null |         |
+ dropoff_longitude     | double precision         |           | not null |         |
+ dropoff_latitude      | double precision         |           | not null |         |
+ passenger_count       | smallint                 |           | not null |         |
+ trip_distance         | double precision         |           | not null |         |
+ fare_amount           | numeric(10,2)            |           | not null |         |
+ extra                 | numeric(10,2)            |           | not null |         |
+ mta_tax               | numeric(10,2)            |           | not null |         |
+ tip_amount            | numeric(10,2)            |           | not null |         |
+ tolls_amount          | numeric(10,2)            |           | not null |         |
+ ehail_fee             | numeric(10,2)            |           | not null |         |
+ improvement_surcharge | numeric(10,2)            |           | not null |         |
+ total_amount          | numeric(10,2)            |           | not null |         |
+ payment_type          | text                     |           | not null |         |
+ trip_type             | smallint                 |           | not null |         |
+ pickup                | character varying(25)    |           | not null |         |
+ dropoff               | character varying(25)    |           | not null |         |
+ cab_type              | text                     |           | not null |         |
+ pickup_nyct2010_gid   | smallint                 |           | not null |         |
+ pickup_ctlabel        | real                     |           | not null |         |
+ pickup_borocode       | smallint                 |           | not null |         |
+ pickup_ct2010         | text                     |           | not null |         |
+ pickup_boroct2010     | text                     |           | not null |         |
+ pickup_cdeligibil     | text                     |           | not null |         |
+ pickup_ntacode        | character varying(4)     |           | not null |         |
+ pickup_ntaname        | text                     |           | not null |         |
+ pickup_puma           | integer                  |           | not null |         |
+ dropoff_nyct2010_gid  | smallint                 |           | not null |         |
+ dropoff_ctlabel       | real                     |           | not null |         |
+ dropoff_borocode      | smallint                 |           | not null |         |
+ dropoff_ct2010        | text                     |           | not null |         |
+ dropoff_boroct2010    | text                     |           | not null |         |
+ dropoff_cdeligibil    | text                     |           | not null |         |
+ dropoff_ntacode       | character varying(4)     |           | not null |         |
+ dropoff_ntaname       | text                     |           | not null |         |
+ dropoff_puma          | integer                  |           | not null |         |
 Server: taxi_srv
 FDW options: (database 'taxi', table_name 'trips', engine 'MergeTree')
 ```
@@ -420,9 +420,12 @@ your own SQL query.
     Time: 36.895 ms
     ```
 
-*   Retrieve rides to LaGuardia or JFK airports:
+*   Set display time zone for New York and retrieve rides to LaGuardia or JFK
+    airports:
 
     ```pgsql
+    taxi=# SET timezone = 'America/New_York';
+    SET
     taxi=# SELECT
         pickup_datetime,
         dropoff_datetime,
@@ -440,13 +443,13 @@ your own SQL query.
     WHERE dropoff_nyct2010_gid IN (132, 138)
     ORDER BY pickup_datetime
     LIMIT 5;
-       pickup_datetime   |  dropoff_datetime   | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour
-    ---------------------+---------------------+--------------+---------------------+----------------------+--------------+------+-----+------
-     2015-07-01 00:04:14 | 2015-07-01 00:15:29 |        13.30 |                 -34 |                  132 | JFK          | 2015 |   1 |    0
-     2015-07-01 00:09:42 | 2015-07-01 00:12:55 |         6.80 |                  50 |                  138 | LGA          | 2015 |   1 |    0
-     2015-07-01 00:23:04 | 2015-07-01 00:24:39 |         4.80 |                -125 |                  132 | JFK          | 2015 |   1 |    0
-     2015-07-01 00:27:51 | 2015-07-01 00:39:02 |        14.72 |                -101 |                  138 | LGA          | 2015 |   1 |    0
-     2015-07-01 00:32:03 | 2015-07-01 00:55:39 |        39.34 |                  48 |                  138 | LGA          | 2015 |   1 |    0
+        pickup_datetime     |    dropoff_datetime    | total_amount | pickup_nyct2010_gid | dropoff_nyct2010_gid | airport_code | year | day | hour
+    ------------------------+------------------------+--------------+---------------------+----------------------+--------------+------+-----+------
+     2015-06-30 20:04:14-04 | 2015-06-30 20:15:29-04 |        13.30 |                 -34 |                  132 | JFK          | 2015 |  30 |   20
+     2015-06-30 20:09:42-04 | 2015-06-30 20:12:55-04 |         6.80 |                  50 |                  138 | LGA          | 2015 |  30 |   20
+     2015-06-30 20:23:04-04 | 2015-06-30 20:24:39-04 |         4.80 |                -125 |                  132 | JFK          | 2015 |  30 |   20
+     2015-06-30 20:27:51-04 | 2015-06-30 20:39:02-04 |        14.72 |                -101 |                  138 | LGA          | 2015 |  30 |   20
+     2015-06-30 20:32:03-04 | 2015-06-30 20:55:39-04 |        39.34 |                  48 |                  138 | LGA          | 2015 |  30 |   20
     (5 rows)
 
     Time: 17.450 ms

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -767,8 +767,9 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 /*
  * Query to generate table for doc/pg_clickhouse.md. Keep in sync with
  * str_types_map below. On change, re-run and paste the output into
- * doc/pg_clickhouse.md.
+ * doc/pg_clickhouse.md. Perl: https://stackoverflow.com/a/58443028/79202
 
+	psql --no-psqlrc --pset border=2 --pset footer=off -c "
 	SELECT * FROM ( VALUES
 		('Bool',     'boolean',          ''),
 		('Int8',     'smallint',         ''),
@@ -790,8 +791,9 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 		('IPv4',     'inet',             ''),
 		('IPv6',     'inet',             ''),
 		('JSON',     'jsonb',            'HTTP engine only')
-	) AS v("ClickHouse", "PostgreSQL", "Notes")
-	ORDER BY "ClickHouse";
+	) AS v(\"ClickHouse\", \"PostgreSQL\", \"Notes\")
+	ORDER BY \"ClickHouse\";
+	" | perl -ne 'my $m = $.%2; print $buf[$m] if defined $buf[$m]; $buf[$m] = s/\+/|/gr if $.>1' | pbcopy
 
 */
 


### PR DESCRIPTION
Update the documentation to reflect the preference to map DateTime to TIMESTAMPTZ, added in 85e93de. Make use of the time zone support in the tutorial to show NYC timestamps in NYC time. Also note the change in `CHANGELOG.md`.

While at it, tweak the query to generate the data mapping table to output a Markdown table. PGXN now supports tables in Markdown documents, so we don't have to display it as literal text.