### PR TITLE
Add `INSERT` support for `UUID`, `INET` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.3] — Unreleased
 
-
 ### ⚡ Improvements
 
 *   Changed the default mapping for `DateTime` and `DateTime64` values from
@@ -18,6 +17,8 @@ All notable changes to this project will be documented in this file. It uses the
     different time zone. As of the first bug fix listed below, pg_clickhouse
     (almost) always fetches these values in UTC, so can store them as
     `TIMESTAMPTZ` values.
+*   Implemented `INSERT` support for the UUID and INET (IPv4 and IPv6) types.
+    Thanks to Rahul Mehta for the report (#127)!
 
 ### 🪲 Bug Fixes
 
@@ -26,6 +27,8 @@ All notable changes to this project will be documented in this file. It uses the
     for both ClickHouse and Postgres is the same. Does not work with
     parameterized execution on ClickHouse versions prior to 25.8 due to
     [ClickHouse Issue 88088].
+*   Fixed a server crash when attempting to insert types not yet supported by
+    the binary engine.
 
 ### 📔 Notes
 

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/elog.h"
+#include "utils/inet.h"
 #include "utils/lsyscache.h"
 #include "utils/memdebug.h"
 #include "utils/palloc.h"
@@ -43,9 +44,11 @@ using namespace clickhouse;
 #include <machine/endian.h>
 #include <libkern/OSByteOrder.h>
 #define HOST_TO_BIG_ENDIAN_64(x) OSSwapHostToBigInt64(x)
+#define BIG_ENDIAN_64_TO_HOST(x) OSSwapBigToHostInt64(x)
 #else
 #include <endian.h>
 #define HOST_TO_BIG_ENDIAN_64(x) htobe64(x)
+#define BIG_ENDIAN_64_TO_HOST(x) be64toh(x)
 #endif
 
 #define THROW_UNEXPECTED_COLUMN(exp_type, col) \
@@ -322,6 +325,9 @@ static Oid get_corr_postgres_type(const TypeRef & type)
 			return RECORDOID;
 		case Type::Code::Nullable:
 			return get_corr_postgres_type(type->As<NullableType>()->GetNestedType());
+		case Type::Code::IPv4:
+		case Type::Code::IPv6:
+			return INETOID;
 		default:
 			throw std::runtime_error("pg_clickhouse: unsupported column type " + type->GetName());
 	}
@@ -384,10 +390,18 @@ void ch_binary_prepare_insert(void * conn, const ch_query * query, ch_binary_ins
 	AttrNumber i = 0;
 	for (Block::Iterator bi(*block); bi.IsValid(); bi.Next())
 	{
-		/* Determine the Postgres column type. */
-		Oid pg_type = get_corr_postgres_type(bi.Type());
-		const char * colname = bi.Name().c_str();
-
+		Oid pg_type;
+		const char * colname;
+		try
+		{
+			/* Determine the Postgres column type. */
+			pg_type = get_corr_postgres_type(bi.Type());
+			colname = bi.Name().c_str();
+		}
+		catch (const std::exception & e)
+		{
+			elog(ERROR, "pg_clickhouse: could not prepare insert - %s", e.what());
+		}
 		PG_TRY();
 		{
 			TupleDescInitEntry(state->outdesc, ++i, colname, pg_type, -1, 0);
@@ -599,6 +613,33 @@ static void column_append(clickhouse::ColumnRef col, Datum val, Oid valtype, boo
 			}
 			break;
 		}
+		case UUIDOID:
+		{
+			auto uuid_val = DatumGetUUIDP(val)->data;
+			auto ch_uuid = UUID{};
+			memcpy(&ch_uuid.first, uuid_val, 8);
+			memcpy(&ch_uuid.second, uuid_val+8, 8);
+			ch_uuid.first = BIG_ENDIAN_64_TO_HOST(ch_uuid.first);
+			ch_uuid.second = BIG_ENDIAN_64_TO_HOST(ch_uuid.second);
+			col->As<ColumnUUID>()->Append(ch_uuid);
+		}
+		break;
+		case INETOID:
+		{
+			char *s = DatumGetCString(DirectFunctionCall1(inet_out, val));
+			switch (col->Type()->GetCode())
+			{
+				case Type::Code::IPv4:
+					col->As<ColumnIPv4>()->Append(s);
+					break;
+				case Type::Code::IPv6:
+					col->As<ColumnIPv6>()->Append(s);
+					break;
+				default:
+					THROW_UNEXPECTED_COLUMN("INET", col);
+			}
+		}
+		break;
 		default: {
 			THROW_UNEXPECTED_COLUMN(std::to_string(valtype), col);
 		}

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -1562,6 +1562,10 @@ clickhouseAcquireSampleRowsFunc(Relation relation, int elevel,
 								double *totalrows,
 								double *totaldeadrows)
 {
+	/*
+	 * TODO: Consider using the SAMPLE clause:
+	 * https://clickhouse.com/docs/sql-reference/statements/select/sample
+	 */
 	return 0;
 }
 

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -371,6 +371,8 @@ chfdw_datum_to_ch_literal(Datum value, Oid type)
 		case NAMEOID:
 		case BITOID:
 		case BYTEAOID:
+		case UUIDOID:
+		case INETOID:
 			{
 				char	   *text,
 						   *result;

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -67,7 +67,16 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "binary_inserts_test" FROM SERVER binary_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -239,6 +248,30 @@ SELECT * FROM arrays ORDER BY c1;
   3 | {6,4}
 (3 rows)
 
+/* Check UUIDs and IPs */
+\d addr
+                 Foreign table "public.addr"
+ Column | Type | Collation | Nullable | Default | FDW options 
+--------+------+-----------+----------+---------+-------------
+ c1     | uuid |           | not null |         | 
+ c2     | inet |           | not null |         | 
+ c3     | inet |           | not null |         | 
+Server: binary_inserts_loopback
+FDW options: (database 'binary_inserts_test', table_name 'addr', engine 'MergeTree')
+
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
+                  c1                  |       c2       |              c3               
+--------------------------------------+----------------+-------------------------------
+ 00000000-0000-0000-0000-000000000000 | 127.0.0.1      | ::ffff:127.0.0.1
+ 61f0c404-5cb3-11e7-907b-a6006ad3dba0 | 116.106.34.242 | 2001:44c8:129:2632:33:0:252:2
+ c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 
@@ -247,8 +280,9 @@ SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
 (1 row)
 
 DROP SERVER binary_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to foreign table arrays
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to foreign table addr
+drop cascades to foreign table arrays
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -67,7 +67,16 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "binary_inserts_test" FROM SERVER binary_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -230,6 +239,30 @@ SELECT * FROM arrays ORDER BY c1;
   3 | {6,4}
 (3 rows)
 
+/* Check UUIDs and IPs */
+\d addr
+                 Foreign table "public.addr"
+ Column | Type | Collation | Nullable | Default | FDW options 
+--------+------+-----------+----------+---------+-------------
+ c1     | uuid |           | not null |         | 
+ c2     | inet |           | not null |         | 
+ c3     | inet |           | not null |         | 
+Server: binary_inserts_loopback
+FDW options: (database 'binary_inserts_test', table_name 'addr', engine 'MergeTree')
+
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
+                  c1                  |       c2       |              c3               
+--------------------------------------+----------------+-------------------------------
+ 00000000-0000-0000-0000-000000000000 | 127.0.0.1      | ::ffff:127.0.0.1
+ 61f0c404-5cb3-11e7-907b-a6006ad3dba0 | 116.106.34.242 | 2001:44c8:129:2632:33:0:252:2
+ c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 
@@ -238,8 +271,9 @@ SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
 (1 row)
 
 DROP SERVER binary_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to foreign table arrays
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to foreign table addr
+drop cascades to foreign table arrays
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -67,7 +67,16 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -238,6 +247,30 @@ SELECT * FROM arrays ORDER BY c1;
   3 | {6,4}
 (3 rows)
 
+/* Check UUIDs and IPs */
+\d addr
+                 Foreign table "public.addr"
+ Column | Type | Collation | Nullable | Default | FDW options 
+--------+------+-----------+----------+---------+-------------
+ c1     | uuid |           | not null |         | 
+ c2     | inet |           | not null |         | 
+ c3     | inet |           | not null |         | 
+Server: http_inserts_loopback
+FDW options: (database 'http_inserts_test', table_name 'addr', engine 'MergeTree')
+
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
+                  c1                  |       c2       |              c3               
+--------------------------------------+----------------+-------------------------------
+ 00000000-0000-0000-0000-000000000000 | 127.0.0.1      | ::ffff:127.0.0.1
+ 61f0c404-5cb3-11e7-907b-a6006ad3dba0 | 116.106.34.242 | 2001:44c8:129:2632:33:0:252:2
+ c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 
@@ -246,8 +279,9 @@ SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
 (1 row)
 
 DROP SERVER http_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to foreign table arrays
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to foreign table addr
+drop cascades to foreign table arrays
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -67,7 +67,16 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -229,6 +238,30 @@ SELECT * FROM arrays ORDER BY c1;
   3 | {6,4}
 (3 rows)
 
+/* Check UUIDs and IPs */
+\d addr
+                 Foreign table "public.addr"
+ Column | Type | Collation | Nullable | Default | FDW options 
+--------+------+-----------+----------+---------+-------------
+ c1     | uuid |           | not null |         | 
+ c2     | inet |           | not null |         | 
+ c3     | inet |           | not null |         | 
+Server: http_inserts_loopback
+FDW options: (database 'http_inserts_test', table_name 'addr', engine 'MergeTree')
+
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
+                  c1                  |       c2       |              c3               
+--------------------------------------+----------------+-------------------------------
+ 00000000-0000-0000-0000-000000000000 | 127.0.0.1      | ::ffff:127.0.0.1
+ 61f0c404-5cb3-11e7-907b-a6006ad3dba0 | 116.106.34.242 | 2001:44c8:129:2632:33:0:252:2
+ c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 
@@ -237,8 +270,9 @@ SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
 (1 row)
 
 DROP SERVER http_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 6 other objects
-DETAIL:  drop cascades to foreign table arrays
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to foreign table addr
+drop cascades to foreign table arrays
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -34,7 +34,12 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-IMPORT FOREIGN SCHEMA "binary_inserts_test" FROM SERVER binary_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
 
 /* ints */
 INSERT INTO ints
@@ -88,6 +93,15 @@ INSERT INTO arrays VALUES
 	(2, ARRAY[3,4,5]),
 	(3, ARRAY[6,4]);
 SELECT * FROM arrays ORDER BY c1;
+
+/* Check UUIDs and IPs */
+\d addr
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -34,7 +34,12 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-IMPORT FOREIGN SCHEMA "http_inserts_test" FROM SERVER http_inserts_loopback INTO public;
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+    c1 UUID, c2 IPv4, c3 IPv6
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
 
 /* ints */
 INSERT INTO ints
@@ -88,6 +93,15 @@ INSERT INTO arrays VALUES
 	(2, ARRAY[3,4,5]),
 	(3, ARRAY[6,4]);
 SELECT * FROM arrays ORDER BY c1;
+
+/* Check UUIDs and IPs */
+\d addr
+INSERT INTO addr VALUES
+	('61f0c404-5cb3-11e7-907b-a6006ad3dba0', '116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
+	('00000000-0000-0000-0000-000000000000', '127.0.0.1',      '::ffff:127.0.0.1'),
+	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
+;
+SELECT * FROM addr ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');


### PR DESCRIPTION
Teach the binary engine to convert ClickHouse `IPv4` and `IPv6` types to Postgres `INET`, then to convert Postgres `UUID` and `INET` values to ClickHouse binary values for inserts. Also fix a crash when attempting to insert an unsupported type with the binary engine.

Teach `chfdw_datum_to_ch_literal` to convert Postgres `UUID` and `INET` values to ClickHouse literal strings.

Add tests to `binary_inserts` and `http_inserts` test files that create tables using ClickHouse `UUID`, `IPv4`, and `IPv6` columns, import them as Postgres `UUID` and `INET` columns, insert values, and fetch them from ClickHouse.

While at it, add a comment to `clickhouseAcquireSampleRowsFunc()` suggesting that it be implemented using the ClickHouse `SELECT SAMPLE` feature.

Resolves #127.