### PR TITLE
Run `installcheck` tests in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ compile_commands.json
 .env
 .cache/
 log/
+/test/schedule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file. It uses the
     (almost) always fetches these values in UTC, so can store them as
     `TIMESTAMPTZ` values.
 *   Implemented `INSERT` support for the UUID and INET (IPv4 and IPv6) types.
-    Thanks to Rahul Mehta for the report (#127)!
+    Thanks to Rahul Mehta for the report ([#127])!
 
 ### 🪲 Bug Fixes
 
@@ -37,8 +37,16 @@ All notable changes to this project will be documented in this file. It uses the
 *   Added tests demonstrating subqueries that pg_clickhouse does not yet push
     down, to be improved in future releases.
 
-  [v0.1.3]: https://github.com/clickhouse/pg_clickhouse/compare/v0.1.2...v0.1.3
+### 🏗️ Build Setup
+
+*   Configured `make installcheck` to run the tests in parallel, resulting in
+    far faster test execution on multi-core systems. Adjusted the schemas in
+    which some of the tests work to ensure they don't stomp on each other.
+
+  [v0.1.3]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.2...v0.1.3
   [ClickHouse Issue 88088]: https://github.com/ClickHouse/ClickHouse/pull/88088
+  [#127]: https://github.com/ClickHouse/pg_clickhouse/issues/127
+    "ClickHouse/pg_clickhouse#127 INSERT into ClickHouse table with UUID column fails: unexpected column type for 2950: UUID"
 
 ## [v0.1.2] — 2026-01-07
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DISTVERSION  = $(shell grep -m 1 '[[:space:]]\{3\}"version":' META.json | \
 DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
 TESTS        = $(wildcard test/sql/*.sql)
-REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
+REGRESS      = --schedule test/schedule
 REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 PG_CONFIG   ?= pg_config
 MODULE_big   = $(EXTENSION)
@@ -71,7 +71,7 @@ ifneq ($(OS),darwin)
 endif
 
 # Clean up the clickhouse-cpp build directory and generated files.
-EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql src/fdw.c compile_commands.json $(EXTENSION)-$(DISTVERSION).zip
+EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql src/fdw.c compile_commands.json test/schedule $(EXTENSION)-$(DISTVERSION).zip
 ifndef NO_VENDOR_CLEAN
 	EXTRA_CLEAN += $(CH_CPP_BUILD_DIR)
 endif
@@ -136,6 +136,11 @@ dist: $(EXTENSION)-$(DISTVERSION).zip
 
 $(EXTENSION)-$(DISTVERSION).zip:
 	git archive-all -v --prefix "$(EXTENSION)-$(DISTVERSION)/" --force-submodules $(EXTENSION)-$(DISTVERSION).zip
+
+test/schedule:
+	@echo "test: $(patsubst test/sql/%.sql,%,$(TESTS))" > $@
+
+installcheck: test/schedule
 
 # Test the PGXN distribution.
 dist-test: $(EXTENSION)-$(DISTVERSION).zip

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -76,7 +76,9 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
+CREATE SCHEMA binary_inserts_test;
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
+SET search_path = binary_inserts_test, public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -182,7 +184,7 @@ SELECT * FROM null_ints ORDER BY c1;
 /* check dates and strings */
 ALTER TABLE complex ALTER COLUMN c8 SET DATA TYPE timestamp(3);
 \d+ complex
-                                                 Foreign table "public.complex"
+                                          Foreign table "binary_inserts_test.complex"
  Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
  c1     | integer                        |           | not null |         |             | plain    |              | 
@@ -250,7 +252,7 @@ SELECT * FROM arrays ORDER BY c1;
 
 /* Check UUIDs and IPs */
 \d addr
-                 Foreign table "public.addr"
+           Foreign table "binary_inserts_test.addr"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
  c1     | uuid |           | not null |         | 

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -76,7 +76,9 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
+CREATE SCHEMA binary_inserts_test;
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
+SET search_path = binary_inserts_test, public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -182,7 +184,7 @@ SELECT * FROM null_ints ORDER BY c1;
 /* check dates and strings */
 ALTER TABLE complex ALTER COLUMN c8 SET DATA TYPE timestamp(3);
 \d+ complex
-                                                 Foreign table "public.complex"
+                                          Foreign table "binary_inserts_test.complex"
  Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
  c1     | integer                        |           | not null |         |             | plain    |              | 
@@ -241,7 +243,7 @@ SELECT * FROM arrays ORDER BY c1;
 
 /* Check UUIDs and IPs */
 \d addr
-                 Foreign table "public.addr"
+           Foreign table "binary_inserts_test.addr"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
  c1     | uuid |           | not null |         | 

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 --------------------------------------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC NULLS LAST
 (5 rows)

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 --------------------------------------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC NULLS LAST
 (5 rows)

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -338,7 +340,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- NullTest
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 IS NULL))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 IS NOT NULL))
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 --------------------------------------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC NULLS LAST
 (5 rows)

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -338,7 +340,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- NullTest
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 IS NULL))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 IS NOT NULL))
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 -----------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2
 (5 rows)

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 --------------------------------------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC NULLS LAST
 (5 rows)

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -45,6 +45,8 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int
  
 (1 row)
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -165,7 +167,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OF
    ->  Sort
          Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
          Sort Key: t1.c1, t1.tableoid
-         ->  Foreign Scan on public.ft1 t1
+         ->  Foreign Scan on binary_queries_test.ft1 t1
                Output: c1, c2, c3, c4, c5, c6, c7, c8, tableoid
                Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (8 rows)
@@ -188,7 +190,7 @@ SELECT * FROM ft1 t1 ORDER BY t1.c1, t1.tableoid OFFSET 100 LIMIT 10;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT t1 FROM ft1 t1 ORDER BY t1.c1 OFFSET 100 LIMIT 10;
                                                            QUERY PLAN                                                           
 --------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: t1.*, c1
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 ORDER BY c1 ASC NULLS LAST LIMIT 10 OFFSET 100
 (3 rows)
@@ -216,7 +218,7 @@ SELECT * FROM ft1 WHERE false;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 101 AND t1.c6 = '1' AND t1.c7 >= '1';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c7 >= '1')) AND ((c1 = 101)) AND ((c6 = '1'))
 (3 rows)
@@ -322,7 +324,7 @@ RESET enable_nestloop;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Var, OpExpr(b), Const
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 1))
 (3 rows)
@@ -330,7 +332,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 1;         -- Va
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE t1.c1 = 100 AND t1.c2 = 0; -- BoolExpr
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = 100)) AND ((c2 = 0))
 (3 rows)
@@ -346,7 +348,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NULL;        -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- NullTest
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1
 (3 rows)
@@ -354,7 +356,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 IS NOT NULL;    -- Nu
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -- FuncExpr
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((round(abs(c1), 0) = 1))
 (3 rows)
@@ -362,7 +364,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE round(abs(c1), 0) = 1; -
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- OpExpr(l)
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (- c1)))
 (3 rows)
@@ -370,7 +372,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = -c1;          -- Op
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);           -- OpExpr(r)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((1 = factorial(c1)))
 (3 rows)
@@ -378,7 +380,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE 1 = factorial(c1);      
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL); -- DistinctExpr
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE (((c1 IS NOT NULL) IS DISTINCT FROM (c1 IS NOT NULL)))
 (3 rows)
@@ -386,7 +388,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE (c1 IS NOT NULL) IS DIST
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]); -- ScalarArrayOpExpr
                                                      QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([c2, 1, (c1 + 0)],c1)))
 (3 rows)
@@ -509,7 +511,7 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c1 = (([c1, c2, 3])[1])))
 (3 rows)
@@ -632,7 +634,7 @@ SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  -- check special chars
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c6 = 'foo''s\\bar'))
 (3 rows)
@@ -640,7 +642,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c6 = E'foo''s\\bar';  --
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be sent to remote
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Foreign Scan on public.ft1 t1
+ Foreign Scan on binary_queries_test.ft1 t1
    Output: c1, c2, c3, c4, c5, c6, c7, c8
    Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((c8 = 'foo'))
 (3 rows)
@@ -700,7 +702,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 --------------------------------------------------------------------------------------
  Aggregate
    Output: count(DISTINCT c1) FILTER (WHERE (c1 < 20))
-   ->  Foreign Scan on public.ft2
+   ->  Foreign Scan on binary_queries_test.ft2
          Output: c1, c2
          Remote SQL: SELECT c1 FROM binary_queries_test.t2 ORDER BY c1 ASC NULLS LAST
 (5 rows)

--- a/test/expected/custom_casts.out
+++ b/test/expected/custom_casts.out
@@ -34,11 +34,13 @@ $$);
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA casts_test FROM SERVER casts_loopback INTO public;
+CREATE SCHEMA casts_test;
+IMPORT FOREIGN SCHEMA casts_test FROM SERVER casts_loopback INTO casts_test;
+SET search_path = casts_test, public;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUInt8(num) IN (8, 3, 5);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt8(num) IN (8,3,5)))
 (3 rows)
@@ -54,7 +56,7 @@ SELECT num FROM things WHERE toUInt8(num) IN (8, 3, 5);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUInt8(name) IN (1, 2, 3);
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt8(name) IN (1,2,3)))
 (3 rows)
@@ -70,7 +72,7 @@ SELECT num FROM things WHERE toUInt8(name) IN (1, 2, 3);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint16(num) IN (8, 3, 5);
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt16(num) IN (8,3,5)))
 (3 rows)
@@ -86,7 +88,7 @@ SELECT num FROM things WHERE toUint16(num) IN (8, 3, 5);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint16(name) IN (1, 2, 3);
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt16(name) IN (1,2,3)))
 (3 rows)
@@ -102,7 +104,7 @@ SELECT num FROM things WHERE toUint16(name) IN (1, 2, 3);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint32(num) IN (8, 3, 5);
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt32(num) IN (8,3,5)))
 (3 rows)
@@ -118,7 +120,7 @@ SELECT num FROM things WHERE toUint32(num) IN (8, 3, 5);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint32(name) IN (1, 2, 3);
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt32(name) IN (1,2,3)))
 (3 rows)
@@ -134,7 +136,7 @@ SELECT num FROM things WHERE toUint32(name) IN (1, 2, 3);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint64(num) IN (8, 3, 5);
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt64(num) IN (8,3,5)))
 (3 rows)
@@ -150,7 +152,7 @@ SELECT num FROM things WHERE toUint64(num) IN (8, 3, 5);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint64(name) IN (1, 2, 3);
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt64(name) IN (1,2,3)))
 (3 rows)
@@ -166,7 +168,7 @@ SELECT num FROM things WHERE toUint64(name) IN (1, 2, 3);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint128(num) IN (8, 3, 5);
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt128(num) IN (8,3,5)))
 (3 rows)
@@ -182,7 +184,7 @@ SELECT num FROM things WHERE toUint128(num) IN (8, 3, 5);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint128(name) IN (1, 2, 3);
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Foreign Scan on public.things
+ Foreign Scan on casts_test.things
    Output: num
    Remote SQL: SELECT num FROM casts_test.things WHERE ((toUInt128(name) IN (1,2,3)))
 (3 rows)

--- a/test/expected/deparse_checks.out
+++ b/test/expected/deparse_checks.out
@@ -28,9 +28,11 @@ SELECT clickhouse_raw_query('
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "deparse_test" FROM SERVER deparse_lookback INTO public;
+CREATE SCHEMA deparse_test;
+IMPORT FOREIGN SCHEMA deparse_test FROM SERVER deparse_lookback INTO deparse_test;
+SET search_path = deparse_test, public;
 \d+ t1
-                                        Foreign table "public.t1"
+                                     Foreign table "deparse_test.t1"
  Column |   Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
 --------+----------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer  |           | not null |         |             | plain   |              | 
@@ -63,7 +65,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Foreign Scan on public.t1
+ Foreign Scan on deparse_test.t1
    Output: a, b
    Remote SQL: SELECT a, b FROM deparse_test.t1 ORDER BY a ASC NULLS FIRST, b ASC NULLS LAST LIMIT 3
 (3 rows)

--- a/test/expected/deparse_checks_1.out
+++ b/test/expected/deparse_checks_1.out
@@ -28,9 +28,11 @@ SELECT clickhouse_raw_query('
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "deparse_test" FROM SERVER deparse_lookback INTO public;
+CREATE SCHEMA deparse_test;
+IMPORT FOREIGN SCHEMA deparse_test FROM SERVER deparse_lookback INTO deparse_test;
+SET search_path = deparse_test, public;
 \d+ t1
-                                        Foreign table "public.t1"
+                                     Foreign table "deparse_test.t1"
  Column |   Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
 --------+----------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer  |           | not null |         |             | plain   |              | 
@@ -60,7 +62,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Foreign Scan on public.t1
+ Foreign Scan on deparse_test.t1
    Output: a, b
    Remote SQL: SELECT a, b FROM deparse_test.t1 ORDER BY a ASC NULLS FIRST, b ASC NULLS LAST LIMIT 3
 (3 rows)

--- a/test/expected/engines.out
+++ b/test/expected/engines.out
@@ -93,9 +93,11 @@ SELECT clickhouse_raw_query('
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "engines_test" FROM SERVER engines_loopback INTO public;
+CREATE SCHEMA engines_test;
+IMPORT FOREIGN SCHEMA engines_test FROM SERVER engines_loopback INTO engines_test;
+SET search_path = engines_test, public;
 \d+ t1
-                                       Foreign table "public.t1"
+                                    Foreign table "engines_test.t1"
  Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           | not null |         |             | plain   |              | 
@@ -107,7 +109,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't1', engine 'MergeTree')
 
 \d+ t1_aggr
-                                            Foreign table "public.t1_aggr"
+                                         Foreign table "engines_test.t1_aggr"
  Column |  Type   | Collation | Nullable | Default |        FDW options        | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                           | plain   |              | 
@@ -119,7 +121,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't1_aggr', engine 'MaterializedView')
 
 \d+ t2
-                                              Foreign table "public.t2"
+                                           Foreign table "engines_test.t2"
  Column |  Type   | Collation | Nullable | Default |        FDW options        | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                           | plain   |              | 
@@ -131,7 +133,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't2', engine 'AggregatingMergeTree')
 
 \d+ t3
-                                         Foreign table "public.t3"
+                                      Foreign table "engines_test.t3"
  Column |   Type    | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+-----------+-----------+----------+---------+-------------+----------+--------------+-------------
  a      | integer   |           | not null |         |             | plain    |              | 
@@ -145,7 +147,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't3', engine 'MergeTree')
 
 \d+ t3_aggr
-                                           Foreign table "public.t3_aggr"
+                                        Foreign table "engines_test.t3_aggr"
  Column |  Type   | Collation | Nullable | Default |       FDW options       | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+-------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                         | plain   |              | 
@@ -157,7 +159,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't3_aggr', engine 'MaterializedView')
 
 \d+ t4
-                                                 Foreign table "public.t4"
+                                              Foreign table "engines_test.t4"
  Column |  Type   | Collation | Nullable | Default |           FDW options           | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                                 | plain   |              | 

--- a/test/expected/engines_1.out
+++ b/test/expected/engines_1.out
@@ -93,9 +93,11 @@ SELECT clickhouse_raw_query('
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA "engines_test" FROM SERVER engines_loopback INTO public;
+CREATE SCHEMA engines_test;
+IMPORT FOREIGN SCHEMA engines_test FROM SERVER engines_loopback INTO engines_test;
+SET search_path = engines_test, public;
 \d+ t1
-                                       Foreign table "public.t1"
+                                    Foreign table "engines_test.t1"
  Column |  Type   | Collation | Nullable | Default | FDW options | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+-------------+---------+--------------+-------------
  a      | integer |           | not null |         |             | plain   |              | 
@@ -104,7 +106,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't1', engine 'MergeTree')
 
 \d+ t1_aggr
-                                            Foreign table "public.t1_aggr"
+                                         Foreign table "engines_test.t1_aggr"
  Column |  Type   | Collation | Nullable | Default |        FDW options        | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                           | plain   |              | 
@@ -113,7 +115,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't1_aggr', engine 'MaterializedView')
 
 \d+ t2
-                                              Foreign table "public.t2"
+                                           Foreign table "engines_test.t2"
  Column |  Type   | Collation | Nullable | Default |        FDW options        | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                           | plain   |              | 
@@ -122,7 +124,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't2', engine 'AggregatingMergeTree')
 
 \d+ t3
-                                         Foreign table "public.t3"
+                                      Foreign table "engines_test.t3"
  Column |   Type    | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+-----------+-----------+----------+---------+-------------+----------+--------------+-------------
  a      | integer   |           | not null |         |             | plain    |              | 
@@ -132,7 +134,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't3', engine 'MergeTree')
 
 \d+ t3_aggr
-                                           Foreign table "public.t3_aggr"
+                                        Foreign table "engines_test.t3_aggr"
  Column |  Type   | Collation | Nullable | Default |       FDW options       | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+-------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                         | plain   |              | 
@@ -141,7 +143,7 @@ Server: engines_loopback
 FDW options: (database 'engines_test', table_name 't3_aggr', engine 'MaterializedView')
 
 \d+ t4
-                                                 Foreign table "public.t4"
+                                              Foreign table "engines_test.t4"
  Column |  Type   | Collation | Nullable | Default |           FDW options           | Storage | Stats target | Description 
 --------+---------+-----------+----------+---------+---------------------------------+---------+--------------+-------------
  a      | integer |           | not null |         |                                 | plain   |              | 

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -76,7 +76,9 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
+CREATE SCHEMA http_inserts_test;
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
+SET search_path = http_inserts_test, public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -182,7 +184,7 @@ SELECT * FROM null_ints ORDER BY c1;
 /* check dates and strings */
 ALTER TABLE complex ALTER COLUMN c8 SET DATA TYPE timestamp(3);
 \d+ complex
-                                                 Foreign table "public.complex"
+                                           Foreign table "http_inserts_test.complex"
  Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
  c1     | integer                        |           | not null |         |             | plain    |              | 
@@ -249,7 +251,7 @@ SELECT * FROM arrays ORDER BY c1;
 
 /* Check UUIDs and IPs */
 \d addr
-                 Foreign table "public.addr"
+            Foreign table "http_inserts_test.addr"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
  c1     | uuid |           | not null |         | 

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -76,7 +76,9 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
  
 (1 row)
 
-IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
+CREATE SCHEMA http_inserts_test;
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
+SET search_path = http_inserts_test, public;
 /* ints */
 INSERT INTO ints
 	SELECT i, i + 1, i + 2, i+ 3 FROM generate_series(1, 3) i;
@@ -182,7 +184,7 @@ SELECT * FROM null_ints ORDER BY c1;
 /* check dates and strings */
 ALTER TABLE complex ALTER COLUMN c8 SET DATA TYPE timestamp(3);
 \d+ complex
-                                                 Foreign table "public.complex"
+                                           Foreign table "http_inserts_test.complex"
  Column |              Type              | Collation | Nullable | Default | FDW options | Storage  | Stats target | Description 
 --------+--------------------------------+-----------+----------+---------+-------------+----------+--------------+-------------
  c1     | integer                        |           | not null |         |             | plain    |              | 
@@ -240,7 +242,7 @@ SELECT * FROM arrays ORDER BY c1;
 
 /* Check UUIDs and IPs */
 \d addr
-                 Foreign table "public.addr"
+            Foreign table "http_inserts_test.addr"
  Column | Type | Collation | Nullable | Default | FDW options 
 --------+------+-----------+----------+---------+-------------
  c1     | uuid |           | not null |         | 

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -39,7 +39,9 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO public;
+CREATE SCHEMA binary_inserts_test;
+IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
+SET search_path = binary_inserts_test, public;
 
 /* ints */
 INSERT INTO ints

--- a/test/sql/binary_queries.sql
+++ b/test/sql/binary_queries.sql
@@ -18,6 +18,9 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 Str
 SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
 
+CREATE SCHEMA binary_queries_test;
+SET search_path = binary_queries_test, public;
+
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,

--- a/test/sql/custom_casts.sql
+++ b/test/sql/custom_casts.sql
@@ -18,7 +18,9 @@ SELECT clickhouse_raw_query($$
 	  FROM numbers(10);
 $$);
 
-IMPORT FOREIGN SCHEMA casts_test FROM SERVER casts_loopback INTO public;
+CREATE SCHEMA casts_test;
+IMPORT FOREIGN SCHEMA casts_test FROM SERVER casts_loopback INTO casts_test;
+SET search_path = casts_test, public;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUInt8(num) IN (8, 3, 5);
 SELECT num FROM things WHERE toUInt8(num) IN (8, 3, 5);

--- a/test/sql/deparse_checks.sql
+++ b/test/sql/deparse_checks.sql
@@ -11,7 +11,9 @@ SELECT clickhouse_raw_query('
 SELECT clickhouse_raw_query('
 	insert into deparse_test.t1 select number % 10, number % 10 > 5 from numbers(1, 100);');
 
-IMPORT FOREIGN SCHEMA "deparse_test" FROM SERVER deparse_lookback INTO public;
+CREATE SCHEMA deparse_test;
+IMPORT FOREIGN SCHEMA deparse_test FROM SERVER deparse_lookback INTO deparse_test;
+SET search_path = deparse_test, public;
 \d+ t1
 ALTER TABLE t1 ALTER COLUMN b SET DATA TYPE bool;
 

--- a/test/sql/engines.sql
+++ b/test/sql/engines.sql
@@ -48,7 +48,9 @@ SELECT clickhouse_raw_query('
 	engine = AggregatingMergeTree()
 	order by a');
 
-IMPORT FOREIGN SCHEMA "engines_test" FROM SERVER engines_loopback INTO public;
+CREATE SCHEMA engines_test;
+IMPORT FOREIGN SCHEMA engines_test FROM SERVER engines_loopback INTO engines_test;
+SET search_path = engines_test, public;
 
 \d+ t1
 \d+ t1_aggr

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -39,7 +39,9 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO public;
+CREATE SCHEMA http_inserts_test;
+IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
+SET search_path = http_inserts_test, public;
 
 /* ints */
 INSERT INTO ints


### PR DESCRIPTION
Configure `make installcheck` to run the tests in parallel, resulting in far faster test execution on multi-core systems. Adjust the schemas in which some of the tests work to ensure they don't stomp on each other.