### PR TITLE
Add workflow caching for clickhouse-cpp

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -19,7 +19,7 @@ jobs:
         pgv: [18, 17, 16, 15, 14, 13]
     steps:
       - name: Checkout the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { submodules: true }
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -28,15 +28,24 @@ jobs:
       - name: Start Postgres
         run: pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev
       - name: Checkout the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { submodules: true }
       - name: Start ClickHouse
         env: { CH_RELEASE: "${{ matrix.ch }}" }
         run: .github/ubuntu/clickhouse.sh
+      - name: Cache Dependencies
+        uses: actions/cache@v5
+        with:
+          path: vendor/_build/*
+          key: vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.git/modules/clickhouse-cpp/refs/heads/master') }}
+      # Required to prevent clickhouse-cpp from rebuilding because it depends
+      # on this file in the Makefile. https://github.com/actions/checkout/issues/968
+      - name: Reset Vendor Timestamp
+        run: cd vendor/clickhouse-cpp && touch -d $(git log -1 --format="@%ct" CMakeLists.txt) CMakeLists.txt
       - name: Test DSO
         run: pg-build-test
       - name: Clean
-        run: make clean
+        run: make clean NO_VENDOR_CLEAN=1
       - name: Test Static
         run: pg-build-test
         env: { CH_BUILD: static }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Postgres
         run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev
       - name: Checkout the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pre-commit
         run: make debian-install-lint
       - name: Add Postgres to Path

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -20,14 +20,23 @@ jobs:
       - name: Start Postgres ${{ matrix.pg }}
         run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev uuid-dev
       - name: Checkout the Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { submodules: true }
       - name: Start ClickHouse
         run: .github/ubuntu/clickhouse.sh
+      - name: Cache Dependencies
+        uses: actions/cache@v5
+        with:
+          path: vendor/_build/*
+          key: vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.git/modules/clickhouse-cpp/refs/heads/master') }}
+      # Required to prevent clickhouse-cpp from rebuilding because it depends
+      # on this file in the Makefile. https://github.com/actions/checkout/issues/968
+      - name: Reset Vendor Timestamp
+        run: cd vendor/clickhouse-cpp && touch -d $(git log -1 --format="@%ct" CMakeLists.txt) CMakeLists.txt
       - name: Test DSO
         run: pg-build-test
       - name: Clean
-        run: make clean
+        run: make clean NO_VENDOR_CLEAN=1
       - name: Test Static
         run: pg-build-test
         env: { CH_BUILD: static }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     container: pgxn/pgxn-tools
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Start Postgres
         run: pg-start 18 libcurl4-openssl-dev uuid-dev
       - name: Start ClickHouse

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,22 @@ OBJS = $(sort \
     $(subst .c,.o, $(wildcard src/*.c src/*/*.c)) \
 )
 
-# clickhouse-cpp source and build directories.
-CH_CPP_DIR = vendor/clickhouse-cpp
-CH_CPP_BUILD_DIR = vendor/_build/$(OS)-$(ARCH)
-
-# List the clickhouse-cpp libraries we require.
-CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)
-CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
-
 # Build static on Darwin by default.
 ifndef CH_BUILD
 # ifeq ($(OS),darwin)
 	CH_BUILD = static
+# else
+# 	CH_BUILD = dynamic
 # endif
 endif
+
+# clickhouse-cpp source and build directories.
+CH_CPP_DIR = vendor/clickhouse-cpp
+CH_CPP_BUILD_DIR = vendor/_build/$(OS)-$(ARCH)-$(CH_BUILD)-$(shell git submodule status $(CH_CPP_DIR) | awk '{print substr($$1, 0, 7)}')
+
+# List the clickhouse-cpp libraries we require.
+CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)
+CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
 
 # Are we statically compiling clickhouse-cpp into the extension or no?
 ifeq ($(CH_BUILD), static)
@@ -107,7 +109,7 @@ $(CH_CPP_LIB): export CXXFLAGS=-fPIC
 $(CH_CPP_LIB): export CFLAGS=-fPIC
 $(CH_CPP_LIB): $(CH_CPP_DIR)/CMakeLists.txt
 	cmake -B $(CH_CPP_BUILD_DIR) -S $(CH_CPP_DIR) $(CH_CPP_FLAGS) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-	cmake --build $(CH_CPP_BUILD_DIR) --parallel $(nproc) --target all
+	cmake --build $(CH_CPP_BUILD_DIR) --parallel $$(nproc) --target all
 
 # Require the versioned C source and SQL script.
 all: sql/$(EXTENSION)--$(EXTVERSION).sql src/fdw.c


### PR DESCRIPTION
Unfortunately, the checkout action leaves the modified time of the files it checks out to the current time, rather than the last modified time. This results in `vendor/clickhouse-cpp/CMakeLists.txt` having a more recent time than `libclickhouse-cpp-lib.a`, so the Makefile target would decide it needs to be rebuilt anyway. So we have to add a hack to set the proper modified time for `CMakeLists.txt`.

While at it, update the directory used to build clickhouse-cpp to include its commit SHA-1, so that when it's updated a new directory is created and included in the cache. Also include "static" or (eventually "dynamic") in the directory name, so that the the cache will include both builds. As a result, the workflows no longer need to clean out the vendor build between the dynamic and static test builds.

While at it, fix the `--parallel` option to `cmake` to properly use the number of processors.