### PR TITLE
Map `md5()` to `lower(hex(MD5()))`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.1.4] — Unreleased
+
+### ⚡ Improvements
+
+*   Added support for the PostgreSQL `md5()` function, mapped to
+    `lower(hex(MD5()))` in ClickHouse.
+
+  [v0.1.4]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.3...v0.1.4
+
 ## [v0.1.3] — 2026-01-23
 
 This release makes binary-only changes. Once installed, any existing use of

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DISTVERSION  = $(shell grep -m 1 '[[:space:]]\{3\}"version":' META.json | \
 
 DATA         = $(sort $(wildcard sql/$(EXTENSION)--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql)
 DOCS         = $(wildcard doc/*.md)
-TESTS        = $(wildcard test/sql/*.sql)
+TESTS        ?= $(wildcard test/sql/*.sql)
 REGRESS      = --schedule test/schedule
 REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 PG_CONFIG   ?= pg_config
@@ -107,7 +107,7 @@ $(OBJS): $(CH_CPP_DIR)/CMakeLists.txt
 # Build clickhouse-cpp.
 $(CH_CPP_LIB): export CXXFLAGS=-fPIC
 $(CH_CPP_LIB): export CFLAGS=-fPIC
-$(CH_CPP_LIB): $(CH_CPP_DIR)/CMakeLists.txt
+$(CH_CPP_LIB): $(CH_CPP_DIR)/CMakeLists.txt # Sync with "Reset Vendor Timestamp" steps in workflows.
 	cmake -B $(CH_CPP_BUILD_DIR) -S $(CH_CPP_DIR) $(CH_CPP_FLAGS) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 	cmake --build $(CH_CPP_BUILD_DIR) --parallel $$(nproc) --target all
 
@@ -139,6 +139,7 @@ dist: $(EXTENSION)-$(DISTVERSION).zip
 $(EXTENSION)-$(DISTVERSION).zip:
 	git archive-all -v --prefix "$(EXTENSION)-$(DISTVERSION)/" --force-submodules $(EXTENSION)-$(DISTVERSION).zip
 
+.PHONY: test/schedule # Depends on $(TESTS), so always rebuild.
 test/schedule:
 	@echo "test: $(patsubst test/sql/%.sql,%,$(TESTS))" > $@
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ adding DML features. Our road map:
 
 ## Copyright
 
-*   Copyright (c) 2025, ClickHouse
+*   Copyright (c) 2025-2026, ClickHouse
 *   Portions Copyright (c) 2023-2025, Ildus Kurbangaliev
 *   Portions Copyright (c) 2019-2023, Adjust GmbH
 *   Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -894,6 +894,7 @@ maps the following functions:
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 *   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
 
 ### Custom Functions
 
@@ -976,7 +977,7 @@ are not supported and will raise an error.
 
 ## Copyright
 
-Copyright (c) 2025, ClickHouse.
+Copyright (c) 2025-2026, ClickHouse.
 
   [foreign data wrapper]: https://www.postgresql.org/docs/current/fdwhandler.html
     "PostgreSQL Docs: Writing a Foreign Data Wrapper"

--- a/src/connection.c
+++ b/src/connection.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 2019-2022, Adjust GmbH
- * Copyright (c) 2025, ClickHouse, Inc.
+ * Copyright (c) 2025-2026, ClickHouse, Inc.
  *
  * IDENTIFICATION
  *		  github.com/clickhouse/pg_clickhouse/src/connection.c

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -197,6 +197,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
 			case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
 			case F_ARRAY_AGG_ANYNONARRAY:
+			case F_MD5_BYTEA:
+			case F_MD5_TEXT:
 				special_builtin = true;
 				break;
 			default:
@@ -274,6 +276,14 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_ARRAY_AGG_ANYNONARRAY:
 				{
 					strcpy(entry->custom_name, "groupArray");
+					break;
+				}
+			case F_MD5_BYTEA:
+			case F_MD5_TEXT:
+				{
+					/* Special hashing function returns lowercase hex. */
+					entry->cf_type = CF_MD5;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 		}

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 2019-2022, Adjust GmbH
- * Copyright (c) 2025, ClickHouse, Inc.
+ * Copyright (c) 2025-2026, ClickHouse, Inc.
  *
  * IDENTIFICATION
  *		  github.com/clickhouse/pg_clickhouse/src/deparse.c
@@ -2488,6 +2488,9 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 		appendStringInfoChar(buf, ')');
 		return;
 	}
+	else if (cdef && cdef->cf_type == CF_MD5)
+		/* Postgres MD5 returns a lowecase hex string. */
+		appendStringInfoString(buf, "lower(hex(MD5");
 
 	appendStringInfoChar(buf, '(');
 	if (cdef && (cdef->cf_type == CF_TIMEZONE || cdef->cf_type == CF_MATCH))
@@ -2514,6 +2517,8 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 
 	context->func = old_cdef;
 	appendStringInfoChar(buf, ')');
+	if (cdef && cdef->cf_type == CF_MD5)
+		appendStringInfoString(buf, "))");
 }
 
 static void

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 2019-2022, Adjust GmbH
- * Copyright (c) 2025, ClickHouse, Inc.
+ * Copyright (c) 2025-2026, ClickHouse, Inc.
  *
  * IDENTIFICATION
  *		  github.com/clickhouse/pg_clickhouse/src/include/fdw.h
@@ -271,6 +271,7 @@ typedef enum
 	CF_INTARRAY_IDX,
 	CF_CH_FUNCTION,				/* adapted clickhouse function */
 	CF_MATCH,					/* regexp_match function */
+	CF_MD5,						/* md5() function */
 }			custom_object_type;
 
 typedef enum

--- a/src/option.c
+++ b/src/option.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 2019-2022, Adjust GmbH
- * Copyright (c) 2025, ClickHouse, Inc.
+ * Copyright (c) 2025-2026, ClickHouse, Inc.
  *
  * IDENTIFICATION
  *		  github.com/clickhouse/pg_clickhouse/src/option.c

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -5,7 +5,7 @@
  *
  * Portions Copyright (c) 2012-2019, PostgreSQL Global Development Group
  * Portions Copyright (c) 2019-2022, Adjust GmbH
- * Copyright (c) 2025, ClickHouse, Inc.
+ * Copyright (c) 2025-2026, ClickHouse, Inc.
  *
  * IDENTIFICATION
  *		  github.com/clickhouse/pg_clickhouse/src/shippable.c

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1348,6 +1348,22 @@ SELECT val FROM t4 WHERE regexp_like('^val\d', val);
  val2
 (2 rows)
 
+-- Check hashing functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, val
+   Remote SQL: SELECT key1, val FROM functions_test.t3_map WHERE ((lower(hex(MD5(val))) LIKE 'a%')) ORDER BY key1 ASC NULLS LAST
+(3 rows)
+
+SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+ key1 
+------
+    4
+    9
+(2 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1343,6 +1343,22 @@ ERROR:  function regexp_like(unknown, text) does not exist
 LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
                                  ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- Check hashing functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, val
+   Remote SQL: SELECT key1, val FROM functions_test.t3_map WHERE ((lower(hex(MD5(val))) LIKE 'a%')) ORDER BY key1 ASC NULLS LAST
+(3 rows)
+
+SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+ key1 
+------
+    4
+    9
+(2 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1343,6 +1343,22 @@ ERROR:  function regexp_like(unknown, text) does not exist
 LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
                                  ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- Check hashing functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, val
+   Remote SQL: SELECT key1, val FROM functions_test.t3_map WHERE ((lower(hex(MD5(val))) LIKE 'a%')) ORDER BY key1 ASC NULLS LAST
+(3 rows)
+
+SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+ key1 
+------
+    4
+    9
+(2 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -263,7 +263,6 @@ SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
 SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
 
-
 -- Check date_trunc mappings.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('year', ts) = '2026-01-01'::date;
 SELECT ts FROM t5 WHERE date_trunc('year', ts) = '2026-01-01'::date;
@@ -285,6 +284,10 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 -- check regexp_like.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
 SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+
+-- Check hashing functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
+SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');


### PR DESCRIPTION
The Postgres `md5()` function returns a hex string, so can be mapped to ClickHouse `lower(hex(MD5()))` pretty easily. Support for other hashing functions will have to wait for proper BYTEA support.

While at it, restore support for passing `TESTS` to `make installcheck` and update the Copyright year.