### PR TITLE
Add support for mapping BYTEA to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Added support for the PostgreSQL `md5()` function, mapped to
     `lower(hex(MD5()))` in ClickHouse.
+*   Added support for mapping PostgreSQL BYTEA columns to ClickHouse String
+    columns.
+
+### 📔 Notes
+
+*   Refactored and improved the http engine's result processing, bringing it
+    into closer alignment with the binary engine and removing double
+    processing of row values.
 
   [v0.1.4]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.3...v0.1.4
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 25.12.1.649-stable
     working_dir: /work
     volumes:
@@ -39,7 +38,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 25.8.12.129-lts
     working_dir: /work
     volumes:
@@ -59,7 +57,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 25.3.10.19-lts
     working_dir: /work
     volumes:
@@ -79,7 +76,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 25.3.9.72-lts
     working_dir: /work
     volumes:
@@ -99,7 +95,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 24.3.18.7-lts
     working_dir: /work
     volumes:
@@ -119,7 +114,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 23.8.16.40-lts
     working_dir: /work
     volumes:
@@ -139,7 +133,6 @@ services:
     stdin_open: true
     stop_grace_period: 10ms
     environment:
-      PGUSER: postgres
       CH_RELEASE: 23.3.22.3-lts
     working_dir: /work
     volumes:

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -784,12 +784,12 @@ shared_preload_libraries = pg_clickhouse
 Useful to save memory and load overhead for every session, but requires the
 cluster to be restart when the library is updated.
 
-## Function and Operator Reference
-
-### Data Types
+## Data Types
 
 pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
-types:
+types. [IMPORT FOREIGN SCHEMA](#import-foreign-schema) use the first type in
+the PostgreSQL column when importing columns; additional types may be used in
+[CREATE FOREIGN TABLE](#create-foreign-table) statements:
 
 | ClickHouse |    PostgreSQL    |             Notes             |
 |------------|------------------|-------------------------------|
@@ -807,12 +807,134 @@ types:
 | Int64      | bigint           |                               |
 | Int8       | smallint         |                               |
 | JSON       | jsonb            | HTTP engine only              |
-| String     | text             |                               |
+| String     | text, bytea      |                               |
 | UInt16     | integer          |                               |
 | UInt32     | bigint           |                               |
 | UInt64     | bigint           | Errors on values > BIGINT max |
 | UInt8      | smallint         |                               |
 | UUID       | uuid             |                               |
+
+Additional notes and details follow.
+
+### BYTEA
+
+ClickHouse does not provide the equivalent of the PostgreSQL [BYTEA] type, but
+allows any bytes to be stored in [String] type. In general ClickHouse strings
+should be mapped to the PostgreSQL [TEXT], but when using binary data, map it
+to [BYTEA]. Example:
+
+```sql
+-- Create clickHouse table with String columns.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE bytes (
+	      c1 Int8, c2 String, c3 String
+    ) ENGINE = MergeTree ORDER BY (c1);
+$$);
+
+-- Create foreign table with BYTEA columns.
+CREATE FOREIGN TABLE bytes (
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER ch_srv OPTIONS( table_name 'bytes' );
+
+-- Insert binary data into the foreign table.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- View the results.
+SELECT * FROM bytes;
+```
+
+That final `SELECT` query will output:
+
+```pgsql
+ c1 |                             c2                             |                 c3
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+Note that if there are any nul bytes in the ClickHouse columns, a foreign
+table using [TEXT] columns will not output the proper values:
+
+```sql
+-- Create foreign table with TEXT columns.
+CREATE FOREIGN TABLE texts (
+    c1 int,
+    c2 TEXT,
+    c3 TEXT
+) SERVER ch_srv OPTIONS( table_name 'bytes' );
+
+-- Encode binary data as hex.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM texts ORDER BY c1;
+```
+
+Will output:
+
+```pgsql
+ c1 |                          encode                          |              encode
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+Note that rows two and three contain truncated values. This is because
+PostgreSQL relies on nul-terminated strings and does not support nuls in its
+strings.
+
+Attempting to insert binary values into [TEXT] columns will succeed and work
+as expected:
+
+```sql
+-- Insert via text columns:
+TRUNCATE texts;
+INSERT INTO texts
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- View the data.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM texts ORDER BY c1;
+```
+
+The text columns will be correct:
+
+```pgdsql
+
+ c1 |                          encode                          |              encode
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+```
+
+But reading them as [BYTEA] will not:
+
+```pgsql
+# SELECT * FROM bytes;
+ c1 |                                                           c2                                                           |                                   c3
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+```
+
+> [!TIP]
+> As a rule, only use [TEXT] columns for encoded strings and use [BYTEA]
+> columns only for binary data, and never switch between them.
+
+## Function and Operator Reference
 
 ### Functions
 
@@ -1060,3 +1182,9 @@ Copyright (c) 2025-2026, ClickHouse.
     "ClickHouse/ClickHouse#85847 Some queries in a multipart forms don't read settings"
   [fixed]: https://github.com/ClickHouse/ClickHouse/pull/85570
     "ClickHouse/ClickHouse#85570 fix HTTP with multipart"
+  [BYTEA]: https://www.postgresql.org/docs/current/datatype-binary.html
+    "PostgreSQL Docs: Binary Data Types"
+  [String]: https://clickhouse.com/docs/sql-reference/data-types/string
+    "ClickHouse Docs: String"
+  [TEXT]: https://www.postgresql.org/docs/current/datatype-character.html
+    "PostgreSQL Docs: Character Types"

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -526,7 +526,14 @@ static void column_append(clickhouse::ColumnRef col, Datum val, Oid valtype, boo
 			break;
 		}
 		case TEXTOID: {
-			char * s = TextDatumGetCString(val);
+			/*
+			 * ClickHouse allows nuls in strings, and val can be bytea, so
+			 * don't rely on nul termination but copy the full length of the
+			 * data.
+			 */
+			text	   *string = PG_DETOAST_DATUM(val);
+			std::string s;
+			s.assign(VARDATA(string), VARSIZE_ANY_EXHDR(string));
 
 			switch (col->Type()->GetCode())
 			{
@@ -748,7 +755,7 @@ void ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_respons
  * This function calls postgres functions, which can call `palloc` so we can end up
  * with elog(ERROR) and longjmp to upper postgres code with leaking c++ memory.
  *
- * There is no an adequate (without huge overheads) solution, we just consider
+ * There is not an adequate (without huge overheads) solution, we just consider
  * this state unfixable.
  */
 static Datum make_datum(clickhouse::ColumnRef col, size_t row, Oid * valtype, bool * is_null)
@@ -885,13 +892,15 @@ nested_col:
 		break;
 		case Type::Code::FixedString: {
 			auto s = std::string(col->As<ColumnFixedString>()->At(row));
-			ret = CStringGetTextDatum(s.c_str());
+			/* ClickHouse allows nuls in strings, so copy by full length. */
+			ret = PointerGetDatum(cstring_to_text_with_len(s.data(), s.size()));
 			*valtype = TEXTOID;
 		}
 		break;
 		case Type::Code::String: {
 			auto s = std::string(col->As<ColumnString>()->At(row));
-			ret = CStringGetTextDatum(s.c_str());
+			/* ClickHouse allows nuls in strings, so copy by full length. */
+			ret = PointerGetDatum(cstring_to_text_with_len(s.data(), s.size()));
 			*valtype = TEXTOID;
 		}
 		break;
@@ -1008,11 +1017,7 @@ nested_col:
 			slot->len = len;
 
 			for (size_t i = 0; i < len; ++i)
-			{
-				auto tuple_col = (*tuple)[i];
-
-				slot->datums[i] = make_datum(tuple_col, row, &slot->types[i], &slot->nulls[i]);
-			}
+				slot->datums[i] = make_datum((*tuple)[i], row, &slot->types[i], &slot->nulls[i]);
 
 			/* this one will need additional work, since we just return raw slot */
 			ret = PointerGetDatum(slot);

--- a/src/convert.c
+++ b/src/convert.c
@@ -191,6 +191,10 @@ ch_binary_convert_datum(void *state, Datum val)
 void	   *
 ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype)
 {
+	/* make_datum() binary.cpp copies all bytes, no cast needed. */
+	if (intype == TEXTOID && outtype == BYTEAOID)
+		return NULL;
+
 	ch_convert_state *state = palloc0(sizeof(ch_convert_state));
 
 	state->intype = intype;
@@ -353,6 +357,10 @@ static void
 init_output_convert_state(ch_convert_output_state * state)
 {
 	if (state->outtype == state->intype)
+		return;
+
+	/* column_append() binary.cpp copies all bytes, no cast needed. */
+	if (state->intype == BYTEAOID && state->outtype == TEXTOID)
 		return;
 
 	/* Postgres has no cast from bool to INT16, so provide our own. */

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -53,7 +53,7 @@ static Datum * binary_fetch_row(ChFdwScanRowContext * ctx);
 static void binary_insert_tuple(void *, TupleTableSlot * slot);
 static void *binary_prepare_insert(void *, ResultRelInfo *, List *,
 								   const ch_query * query, char *table_name);
-static size_t ch_escape_string(char *to, const char *from, size_t length);
+static char *ch_escape_string(const char *s, size_t len);
 static void ch_quote_literal_internal(char *dst, const char *src, size_t len);
 extern char *ch_quote_literal(const char *rawstr);
 
@@ -423,6 +423,13 @@ char_to_datum(ChFdwScanRowContext * ctx, int attidx, char *data, size_t len)
 		 */
 		data += strlen("1970-01-01T");
 	}
+	else if (pgtype == BYTEAOID)
+	{
+		/* Postgres input function won't work, we have raw data. */
+		ctx->nulls[attidx] = data == NULL;
+		ctx->values[attidx] = PointerGetDatum((bytea *) cstring_to_text_with_len(data, len));
+		return;
+	}
 
 	/* Apply the input function even to nulls, to support domains */
 	ctx->nulls[attidx] = data == NULL;
@@ -474,22 +481,23 @@ chfdw_datum_to_ch_literal(Datum value, Oid type)
 		case JSONBOID:
 		case NAMEOID:
 		case BITOID:
-		case BYTEAOID:
 		case UUIDOID:
 		case INETOID:
 			{
-				char	   *text,
-						   *result;
-				size_t		len;
+				char	   *text;
 				bool		tl = false;
 				Oid			typoutput = InvalidOid;
 
 				getTypeOutputInfo(type, &typoutput, &tl);
 				text = OidOutputFunctionCall(typoutput, value);
-				len = strlen(text);
-				result = palloc(len * 2 + 1);
-				ch_escape_string(result, text, len + 1);
-				return result;
+				return ch_escape_string(text, strlen(text));
+			}
+		case BYTEAOID:
+			{
+				/* Copy all of the bytes into a ClickHouse literal string. */
+				bytea	   *bytes = PG_DETOAST_DATUM(value);
+
+				return ch_escape_string(VARDATA(bytes), VARSIZE_ANY_EXHDR(bytes));
 			}
 		case DATEOID:
 			/* we expect Date on other side */
@@ -908,7 +916,7 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 		('Float32',  'real',             ''),
 		('Float64',  'double precision', ''),
 		('Decimal',  'numeric',          ''),
-		('String',   'text',             ''),
+		('String',   'text, bytea',      ''),
 		('DateTime', 'timestamptz',      ''),
 		('Date',     'date',             ''),
 		('Date32',   'date',             ''),
@@ -1209,103 +1217,78 @@ chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * se
 }
 
 /*
- * Escaping arbitrary strings to get valid ClickHouse SQL literal strings.
+ * Escape len bytes from s as an unquoted ClickHouse literal string. Returns a
+ * pointer to a palloc'd string.
  *
- * length is the length of the source string. (Note: if a terminating NUL is
- * encountered sooner, ch_escape_string stops short of "length"; the behavior
- * is thus rather like strncpy.)
- *
- * For safety the buffer at "to" must be at least 2*length + 1 bytes long. A
- * terminating NUL character is added to the output string, whether the input
- * is NUL-terminated or not.
- *
- * Returns the actual length of the output (not counting the terminating NUL).
+ * Based on ConvertToSQLString() in src/Client/BuzzHouse/AST/SQLProtoStr.cpp
+ * and writeAnyEscapedStringO() in src/IO/WriteHelpers.h in the ClickHouse
+ * source code.
  */
-static size_t
-ch_escape_string(char *to, const char *from, size_t length)
+static char *
+ch_escape_string(const char *from, size_t len)
 {
+	char	   *result;
+	size_t		remaining = len;
 	const char *source = from;
-	char	   *target = to;
-	size_t		remaining = length;
 
-	while (remaining > 0 && *source != '\0')
+	result = palloc(len * 2 + 1);
+	char	   *target = result;
+
+	while (remaining > 0)
 	{
 		char		c = *source;
-		int			len;
-		int			i;
 
-		/* Fast path for plain ASCII */
-		if (!IS_HIGHBIT_SET(c))
+		switch (c)
 		{
-			/* Apply quoting if needed */
-			if (c == '\\')
-			{
-				*target++ = c;
-				*target++ = c;
-			}
-			else if (c == '\'')
-			{
+			case '\'':
 				*target++ = '\\';
 				*target++ = c;
-			}
-			else if (c == '\n')
-			{
-				*target++ = '\\';
-				*target++ = 'n';
-			}
-			else if (c == '\t')
-			{
-				*target++ = '\\';
-				*target++ = 't';
-			}
-			else if (c == '\0')
-			{
-				*target++ = '\\';
-				*target++ = '0';
-			}
-			else if (c == '\r')
-			{
-				*target++ = '\\';
-				*target++ = 'r';
-			}
-			else if (c == '\b')
-			{
+				break;
+			case '\\':
+				*target++ = c;
+				*target++ = c;
+				break;
+			case '\b':
 				*target++ = '\\';
 				*target++ = 'b';
-			}
-			else if (c == '\f')
-			{
+				break;
+			case '\f':
 				*target++ = '\\';
 				*target++ = 'f';
-			}
-			else
-				*target++ = c;
-
-			source++;
-			remaining--;
-			continue;
-		}
-
-		/* Slow path for possible multibyte characters */
-		len = pg_encoding_mblen(PG_SQL_ASCII, source);
-
-		/* Copy the character */
-		for (i = 0; i < len; i++)
-		{
-			if (remaining == 0 || *source == '\0')
 				break;
-			*target++ = *source++;
-			remaining--;
+			case '\r':
+				*target++ = '\\';
+				*target++ = 'r';
+				break;
+			case '\n':
+				*target++ = '\\';
+				*target++ = 'n';
+				break;
+			case '\t':
+				*target++ = '\\';
+				*target++ = 't';
+				break;
+			case '\0':
+				*target++ = '\\';
+				*target++ = '0';
+				break;
+			case '\a':
+				*target++ = '\\';
+				*target++ = 'a';
+				break;
+			case '\v':
+				*target++ = '\\';
+				*target++ = 'v';
+				break;
+			default:
+				*target++ = c;
 		}
-
-		if (i < len)
-			elog(ERROR, "pg_clickhouse: incomplete multibyte character");
+		source++;
+		remaining--;
 	}
 
-	/* Write the terminating NUL character. */
 	*target = '\0';
-
-	return target - to;
+	return result;
 }
 
 /*

--- a/test/expected/binary.out
+++ b/test/expected/binary.out
@@ -101,6 +101,27 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
+    c1 Int8,
+    c2 String,
+    c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
+    number,
+    SHA1(''val'' || toString(number)),
+    MD5(''val'' || toString(number))
+    FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE FOREIGN TABLE fints (
 	c1 int2,
 	c2 int2,
@@ -131,12 +152,17 @@ CREATE FOREIGN TABLE farrays2 (
 	c1 int8[],
     c2 text[]
 ) SERVER binary_loopback OPTIONS (table_name 'arrays');
-CREATE TABLE tupformat(a int, b text, c float4);
+CREATE TYPE tupformat AS (a int, b text, c float4);
 CREATE FOREIGN TABLE ftuples (
     c1 int,
     c2 tupformat,
     c3 bool
 ) SERVER binary_loopback OPTIONS (table_name 'tuples');
+CREATE FOREIGN TABLE fbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER binary_loopback OPTIONS (table_name 'bytes');
 COPY fints FROM stdin;
 -- integers
 SELECT * FROM fints ORDER BY c1;
@@ -255,6 +281,22 @@ SELECT * FROM ftuples ORDER BY c1;
   9 | (9,9,10) | t
 (10 rows)
 
+-- Bytes.
+SELECT * FROM fbytes ORDER BY c1;
+ c1 |                     c2                     |                 c3                 
+----+--------------------------------------------+------------------------------------
+  0 | \x24e3800ca47f2504c25917d3b07306a28d0ac6fc | \x8664dccd1d83673d4fa8ef755ae88439
+  1 | \x5e6e4c0fb8ef47b4f1d6eea3e6c51152dbee94ec | \x8de92ce2033cf3ca03fa8cc63e7a703f
+  2 | \x4f47fdcd4e8d3b4802d50f990b401066bbfe0379 | \x38ceaa3b09c5a07d329888ba1ccde9ad
+  3 | \xb6a0af46ee8d92da3f0c176da8d88517a1b21c54 | \x9163c8c66d03c512404cca8549a250e7
+  4 | \xba42461dcb3e24f04e0d236f61d6804a4f4b3bee | \xa8516b0468eb31028c3dd669867c15b1
+  5 | \x483d5aa3a98e3d1d9f3f40c26ac15c9d42c2f6b8 | \x294a6e0d759cdbcf55753c4a58161721
+  6 | \x7d6934814141b108771faa00ba53750372cb413c | \x1b18b7cd2d63787cbe1d97e57a54853c
+  7 | \xd750c9d1e88df77272d3bde4a0ad16ca7ca6f14a | \x7e526a670883f267ce15deff74740a6e
+  8 | \x7673723fea187e3e78522d4b19ea97eb1a3d6787 | \xeafd00c5d025e9d71e9ed588f7f97e4b
+  9 | \xda1a828a08d9d57450ce10a89cb5ee91dc2feed7 | \xa2da4af9e1d8f4d37887f719cda60bda
+(10 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_test');
  clickhouse_raw_query 
@@ -263,9 +305,10 @@ SELECT clickhouse_raw_query('DROP DATABASE binary_test');
 (1 row)
 
 DROP SERVER binary_loopback CASCADE;
-NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table fints
 drop cascades to foreign table ftypes
 drop cascades to foreign table farrays
 drop cascades to foreign table farrays2
 drop cascades to foreign table ftuples
+drop cascades to foreign table fbytes

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -76,6 +76,14 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA binary_inserts_test;
 IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 SET search_path = binary_inserts_test, public;
@@ -274,6 +282,76 @@ SELECT * FROM addr ORDER BY c1;
  c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
 (3 rows)
 
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER binary_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                             c2                             |                 c3                 
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+ERROR:  value too long for type character varying(16)
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                                                           c2                                                           |                                   c3                                   
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 
@@ -282,11 +360,13 @@ SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
 (1 row)
 
 DROP SERVER binary_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table addr
 drop cascades to foreign table arrays
+drop cascades to foreign table bytes
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints
 drop cascades to foreign table null_ints
 drop cascades to foreign table uints
+drop cascades to foreign table bbytes

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -76,6 +76,14 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA binary_inserts_test;
 IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 SET search_path = binary_inserts_test, public;
@@ -265,6 +273,76 @@ SELECT * FROM addr ORDER BY c1;
  c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
 (3 rows)
 
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER binary_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                             c2                             |                 c3                 
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+ERROR:  value too long for type character varying(16)
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                                                           c2                                                           |                                   c3                                   
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 
@@ -273,11 +351,13 @@ SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
 (1 row)
 
 DROP SERVER binary_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table addr
 drop cascades to foreign table arrays
+drop cascades to foreign table bytes
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints
 drop cascades to foreign table null_ints
 drop cascades to foreign table uints
+drop cascades to foreign table bbytes

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -76,6 +76,14 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -275,6 +283,76 @@ SELECT * FROM addr ORDER BY c1;
  c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
 (3 rows)
 
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER http_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                             c2                             |                 c3                 
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+ERROR:  value too long for type character varying(16)
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                                                           c2                                                           |                                   c3                                   
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 
@@ -283,11 +361,13 @@ SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
 (1 row)
 
 DROP SERVER http_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table addr
 drop cascades to foreign table arrays
+drop cascades to foreign table bytes
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints
 drop cascades to foreign table null_ints
 drop cascades to foreign table uints
+drop cascades to foreign table bbytes

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -76,6 +76,14 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -266,6 +274,76 @@ SELECT * FROM addr ORDER BY c1;
  c62848ed-7316-4d15-92f3-9bb71eb69640 | 183.247.232.58 | 2a02:e980:1e::1
 (3 rows)
 
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER http_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                             c2                             |                 c3                 
+----+------------------------------------------------------------+------------------------------------
+  1 | \x1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | \xae3b28cde02542f81acce8783245430d
+  2 | \x5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | \x23e7c6cacb8383f878ad093b0027d72b
+  3 | \x53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | \x7e969132fc656148b97b6a2ee8bc83c1
+  4 | \x4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | \x8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b
+  3 | 53ac2c1fa83c8f64603fe9568d883331                         | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
+SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+ERROR:  value too long for type character varying(16)
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+SELECT * FROM bbytes ORDER BY c1;
+ c1 |                                                           c2                                                           |                                   c3                                   
+----+------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------
+  1 | \x5c783162663766306363383231643331313738363136613535613865306335323637373733353339376364646536663431353361396664336437 | \x5c786165336232386364653032353432663831616363653837383332343534333064
+  2 | \x5c783566366539653132636438353932373132653633383031366634623161326537333233306565343064623439386330663062316463383431 | \x5c783233653763366361636238333833663837386164303933623030323764373262
+  3 | \x5c783533616332633166613833633866363436303366653935363864383833333331303037643632383164653333306134623565373238663965 | \x5c783765393639313332666336353631343862393762366132656538626338336331
+  4 | \x5c783465336332653463623735343261343531373361386461633933396464633462633735323032653334326562633736396230663564613266 | \x5c783865663330663434633635343830643132623635306162366232623034323435
+(4 rows)
+
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+ c1 |                          encode                          |              encode              
+----+----------------------------------------------------------+----------------------------------
+  1 | 1bf7f0cc821d31178616a55a8e0c52677735397cdde6f4153a9fd3d7 | ae3b28cde02542f81acce8783245430d
+  2 | 5f6e9e12cd8592712e638016f4b1a2e73230ee40db498c0f0b1dc841 | 23e7c6cacb8383f878ad093b0027d72b
+  3 | 53ac2c1fa83c8f64603fe9568d883331007d6281de330a4b5e728f9e | 7e969132fc656148b97b6a2ee8bc83c1
+  4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 
@@ -274,11 +352,13 @@ SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
 (1 row)
 
 DROP SERVER http_inserts_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table addr
 drop cascades to foreign table arrays
+drop cascades to foreign table bytes
 drop cascades to foreign table complex
 drop cascades to foreign table floats
 drop cascades to foreign table ints
 drop cascades to foreign table null_ints
 drop cascades to foreign table uints
+drop cascades to foreign table bbytes

--- a/test/sql/binary.sql
+++ b/test/sql/binary.sql
@@ -57,6 +57,18 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
     number % 2
     FROM numbers(10);');
 
+SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
+    c1 Int8,
+    c2 String,
+    c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+');
+SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
+    number,
+    SHA1(''val'' || toString(number)),
+    MD5(''val'' || toString(number))
+    FROM numbers(10);');
+
 CREATE FOREIGN TABLE fints (
 	c1 int2,
 	c2 int2,
@@ -91,12 +103,18 @@ CREATE FOREIGN TABLE farrays2 (
     c2 text[]
 ) SERVER binary_loopback OPTIONS (table_name 'arrays');
 
-CREATE TABLE tupformat(a int, b text, c float4);
+CREATE TYPE tupformat AS (a int, b text, c float4);
 CREATE FOREIGN TABLE ftuples (
     c1 int,
     c2 tupformat,
     c3 bool
 ) SERVER binary_loopback OPTIONS (table_name 'tuples');
+
+CREATE FOREIGN TABLE fbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER binary_loopback OPTIONS (table_name 'bytes');
 
 COPY fints FROM stdin;
 \.
@@ -118,6 +136,9 @@ SELECT * FROM farrays2 ORDER BY c1;
 
 -- tuples
 SELECT * FROM ftuples ORDER BY c1;
+
+-- Bytes.
+SELECT * FROM fbytes ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_test');

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -39,6 +39,10 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
+SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+
 CREATE SCHEMA binary_inserts_test;
 IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 SET search_path = binary_inserts_test, public;
@@ -104,6 +108,41 @@ INSERT INTO addr VALUES
 	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
 ;
 SELECT * FROM addr ORDER BY c1;
+
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER binary_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+
+SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+SELECT * FROM bbytes ORDER BY c1;
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -39,6 +39,10 @@ SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
+SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+	c1 Int8, c2 String, c3 FixedString(16)
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
+
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -105,6 +109,41 @@ INSERT INTO addr VALUES
 	('C62848ED-7316-4D15-92F3-9BB71EB69640', '183.247.232.58', '2a02:e980:1e::1')
 ;
 SELECT * FROM addr ORDER BY c1;
+
+/* Check BYTEA */
+CREATE FOREIGN TABLE bbytes(
+    c1 int,
+    c2 BYTEA,
+    c3 BYTEA
+) SERVER http_inserts_loopback OPTIONS (table_name 'bytes');
+INSERT INTO bbytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- Should have full binary values, including nul bytes, from BYTEA columns.
+SELECT * FROM bbytes ORDER BY c1;
+
+-- Nul bytes should truncate TEXT columns.
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
+
+SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
+
+-- Should fail.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+-- Remove FixedString length.
+ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
+SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
+
+-- Should succeed.
+INSERT INTO bytes
+SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
+  FROM generate_series(1, 4) n;
+
+SELECT * FROM bbytes ORDER BY c1;
+SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');


### PR DESCRIPTION
Allow columns in foreign tables to map BYTEA columns to to ClickHouse Strings.

This requires changing how the binary and http drivers convert text values (or any varlena, really) to Strings to always copy data by its full length, and not stop at any nul values. They also no longer convert between text and bytea types, as they're the same type once they get to ClickHouse, and ClickHouse does not understand the PostgreSQL binary output format.

Simplify `ch_escape_string()` to return a value, rather than expect an allocated buffer, simplify its internals to work exclusively with bytes, since ClickHouse is not familiar with encodings, and use a `switch` statement to shave off a few execution cycles.

Add tests for binary values created via hash functions, for both String and FixedString ClickHouse columns.

Document the availability of BYTEA, including examples an explanation of the differences with TEXT handling.

While at it, remove `PGUSER` from the containers created by `dev/docker-compose.yml`, as a recent pgxn-tools update sets it.