### PR TITLE
Use StringInfoData for TSV, drop breaking settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,19 @@ All notable changes to this project will be documented in this file. It uses the
     `lower(hex(MD5()))` in ClickHouse.
 *   Added support for mapping PostgreSQL BYTEA columns to ClickHouse String
     columns.
+*   Added explicit setting of `format_tsv_null_representation`, and
+    `output_format_tsv_crlf_end_of_line` to all http requests, as unexpected
+    values will interfere with it operation.
 
 ### 📔 Notes
 
 *   Refactored and improved the http engine's result processing, bringing it
     into closer alignment with the binary engine and removing double
     processing of row values.
+*   The http driver now ignores the following session settings from the
+    `pg_clickhouse.session_settings` to prevent them from interfering with its
+    operation: `date_time_output_format`, `format_tsv_null_representation`,
+    and `output_format_tsv_crlf_end_of_line`.
 
   [v0.1.4]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.3...v0.1.4
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -681,8 +681,8 @@ queries. Example:
 SET pg_clickhouse.session_settings = 'join_use_nulls 1, final 1';
 ```
 
-The default is `join_use_nulls 1`. Set it to an empty string to fall back on
-the ClickHouse server's settings.
+The default is `join_use_nulls 1, group_by_use_nulls 1, final 1`. Set it to an
+empty string to fall back on the ClickHouse server's settings.
 
 ```sql
 SET pg_clickhouse.session_settings = '';
@@ -725,8 +725,16 @@ SET pg_clickhouse.session_settings TO $$
 $$;
 ```
 
-pg_clickhouse does not validate the settings, but passes them on to ClickHouse
-for every query. It thus supports all settings for each ClickHouse version.
+Some settings will be ignored in cases where they would interfere with the
+operation of pg_clickhouse itself. These include:
+
+*   `date_time_output_format`: the http driver requires it to be "iso"
+*   `format_tsv_null_representation`: the http driver requires the default
+*   `output_format_tsv_crlf_end_of_line` the http driver requires the default
+
+Otherwise, pg_clickhouse does not validate the settings, but passes them on to
+ClickHouse for every query. It thus supports all settings for each ClickHouse
+version.
 
 Note that pg_clickhouse must be loaded before setting
 `pg_clickhouse.session_settings`; either use [shared library preloading] or

--- a/src/http.c
+++ b/src/http.c
@@ -181,13 +181,22 @@ ch_http_simple_query(ch_http_connection_t * conn, const ch_query * query)
 	/* Append each of the settings as a query param. */
 	for (iter = new_kv_iter(query->settings); !kv_iter_done(&iter); kv_iter_next(&iter))
 	{
+		/* Skip settings that would break parsing and type conversion. */
+		if (
+			strcmp(iter.name, "date_time_output_format") == 0 ||
+			strcmp(iter.name, "format_tsv_null_representation") == 0 ||
+			strcmp(iter.name, "output_format_tsv_crlf_end_of_line") == 0
+			)
+			continue;
 		buf = psprintf("%s=%s", iter.name, iter.value);
 		curl_url_set(cu, CURLUPART_QUERY, buf, CURLU_APPENDQUERY | CURLU_URLENCODE);
 		pfree(buf);
 	}
 
-	/* Always use ISO date format */
+	/* Always use ISO date format, \N for NULL, \n for EOL. */
 	curl_url_set(cu, CURLUPART_QUERY, "date_time_output_format=iso", CURLU_APPENDQUERY | CURLU_URLENCODE);
+	curl_url_set(cu, CURLUPART_QUERY, "format_tsv_null_representation=\\N", CURLU_APPENDQUERY | CURLU_URLENCODE);
+	curl_url_set(cu, CURLUPART_QUERY, "output_format_tsv_crlf_end_of_line=0", CURLU_APPENDQUERY | CURLU_URLENCODE);
 	curl_url_get(cu, CURLUPART_URL, &url, 0);
 	curl_url_cleanup(cu);
 

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -30,8 +30,7 @@ typedef struct
 	size_t		buflen;
 	size_t		curpos;
 	size_t		maxpos;
-	size_t		len;
-	char	   *val;
+	StringInfo	val;
 	bool		done;
 }			ch_http_read_state;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,26 +13,25 @@ ch_http_read_state_init(ch_http_read_state * state, char *data, size_t datalen)
 {
 	state->data = datalen > 0 ? data : NULL;
 	state->maxpos = datalen - 1;
-	state->buflen = 1024;
-	state->val = malloc(state->buflen);
+	state->val = makeStringInfo();
 	state->done = false;
 }
 
 void
 ch_http_read_state_free(ch_http_read_state * state)
 {
-	free(state->val);
+	/* destroyStringInfo not added till Postgres 17 */
+	pfree(state->val->data);
+	pfree(state->val);
 }
 
 int
 ch_http_read_next(ch_http_read_state * state)
 {
-	size_t		pos = state->curpos,
-				len = 0;
+	size_t		pos = state->curpos;
 	char	   *data = state->data;
 
-	state->val[0] = '\0';
-	state->len = 0;
+	resetStringInfo(state->val);
 	if (state->done)
 		return CH_EOF;
 
@@ -40,59 +39,47 @@ ch_http_read_next(ch_http_read_state * state)
 	{
 		if (data[pos] == '\\')
 		{
+			pos++;
 			/* unescape some sequences */
-			switch (data[pos + 1])
+			switch (data[pos])
 			{
-				case '\\':
-					state->val[len] = '\\';
-					break;
-				case '\'':
-					state->val[len] = '\'';
-					break;
 				case 'n':
-					state->val[len] = '\n';
+					appendStringInfoChar(state->val, '\n');
 					break;
 				case 't':
-					state->val[len] = '\t';
+					appendStringInfoChar(state->val, '\t');
 					break;
 				case '0':
-					state->val[len] = '\0';
+					appendStringInfoChar(state->val, '\0');
 					break;
 				case 'r':
-					state->val[len] = '\r';
+					appendStringInfoChar(state->val, '\r');
 					break;
 				case 'b':
-					state->val[len] = '\b';
+					appendStringInfoChar(state->val, '\b');
 					break;
 				case 'f':
-					state->val[len] = '\f';
+					appendStringInfoChar(state->val, '\f');
+					break;
+				case 'N':
+					/* NULL (format_tsv_null_representation) */
+					appendStringInfoString(state->val, "\\N");
 					break;
 				default:
-					goto copy;
+					appendStringInfoChar(state->val, data[pos]);
 			}
-			len++;
-			pos += 2;
+			pos++;
 		}
 		else
-	copy:
-			state->val[len++] = data[pos++];
-
-		/* extend the value size if needed */
-		if (len == state->buflen)
-		{
-			state->buflen *= 2;
-			state->val = realloc(state->val, state->buflen);
-		}
+			appendStringInfoChar(state->val, data[pos++]);
 	}
 
-	state->val[len] = '\0';
-	state->len = len;
 	state->curpos = pos + 1;
 
 	if (data[pos] == '\t')
 		return CH_CONT;
 
-	assert(data[pos] == '\n');
+	Assert(data[pos] == '\n');
 	int			res = pos < state->maxpos ? CH_EOL : CH_EOF;
 
 	state->done = (res == CH_EOF);

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -320,7 +320,7 @@ http_fetch_row(ChFdwScanRowContext * ctx)
 	{
 		Assert(ctx->values && ctx->nulls);
 		rc = ch_http_read_next(state);
-		if (rc != CH_CONT && state->val[0] == '\\' && state->val[1] == 'N')
+		if (rc != CH_CONT && state->val->data[0] == '\\' && state->val->data[1] == 'N')
 		{
 			ctx->nulls[0] = true;
 			ctx->values[0] = (Datum) 0;
@@ -346,7 +346,7 @@ http_fetch_row(ChFdwScanRowContext * ctx)
 		{
 			i = lfirst_int(lc) - 1;
 			rc = ch_http_read_next(state);
-			char_to_datum(ctx, i, state->val, state->len);
+			char_to_datum(ctx, i, state->val->data, state->val->len);
 		}
 	}
 	/* No TupleDesc, everything is text. */
@@ -356,10 +356,10 @@ http_fetch_row(ChFdwScanRowContext * ctx)
 		for (int idx = 0; idx < attcount; idx++)
 		{
 			rc = ch_http_read_next(state);
-			if (state->val[0] == '\\' && state->val[1] == 'N')
+			if (state->val->data[0] == '\\' && state->val->data[1] == 'N')
 				values[idx] = (Datum) 0;
 			else
-				values[idx] = PointerGetDatum(cstring_to_text(state->val));
+				values[idx] = PointerGetDatum(cstring_to_text(state->val->data));
 		}
 	}
 

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -23,88 +23,103 @@ NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value i
  join_use_nulls     | 1
 (3 rows)
 
-       pg_clickhouse.session_settings       
---------------------------------------------
-                                           +
-     connect_timeout 2,                    +
-     count_distinct_implementation uniq,   +
-     join_algorithm 'prefer_partial_merge',+
-     join_use_nulls 0,                     +
-     join_use_nulls 1,                     +
-     log_queries_min_type QUERY_FINISH,    +
-     max_block_size 32768,                 +
-     max_execution_time 45,                +
-     max_result_rows 1024,                 +
-     metrics_perf_events_list 'this,that', +
-     network_compression_method ZSTD,      +
-     poll_interval 5,                      +
-     totals_mode after_having_auto         +
+       pg_clickhouse.session_settings        
+---------------------------------------------
+                                            +
+     connect_timeout 2,                     +
+     count_distinct_implementation uniq,    +
+     date_time_output_format unix_timestamp,+
+     format_tsv_null_representation NOPE,   +
+     join_algorithm 'prefer_partial_merge', +
+     join_use_nulls 0,                      +
+     join_use_nulls 1,                      +
+     log_queries_min_type QUERY_FINISH,     +
+     max_block_size 32768,                  +
+     max_execution_time 45,                 +
+     max_result_rows 1024,                  +
+     metrics_perf_events_list 'this,that',  +
+     network_compression_method ZSTD,       +
+     output_format_tsv_crlf_end_of_line 1,  +
+     poll_interval 5,                       +
+     totals_mode after_having_auto          +
  
 (1 row)
 
-             name              |        value         
--------------------------------+----------------------
- connect_timeout               | 2
- count_distinct_implementation | uniq
- join_algorithm                | prefer_partial_merge
- join_use_nulls                | 1
- log_queries_min_type          | QUERY_FINISH
- max_block_size                | 32768
- max_execution_time            | 45
- max_result_rows               | 1024
- metrics_perf_events_list      | this,that
- network_compression_method    | ZSTD
- poll_interval                 | 5
- totals_mode                   | after_having_auto
-(12 rows)
+                name                |        value         
+------------------------------------+----------------------
+ connect_timeout                    | 2
+ count_distinct_implementation      | uniq
+ date_time_output_format            | unix_timestamp
+ format_tsv_null_representation     | NOPE
+ join_algorithm                     | prefer_partial_merge
+ join_use_nulls                     | 1
+ log_queries_min_type               | QUERY_FINISH
+ max_block_size                     | 32768
+ max_execution_time                 | 45
+ max_result_rows                    | 1024
+ metrics_perf_events_list           | this,that
+ network_compression_method         | ZSTD
+ output_format_tsv_crlf_end_of_line | 1
+ poll_interval                      | 5
+ totals_mode                        | after_having_auto
+(15 rows)
 
-             name              |        value         
--------------------------------+----------------------
- connect_timeout               | 2
- count_distinct_implementation | uniq
- join_algorithm                | prefer_partial_merge
- join_use_nulls                | 1
- log_queries_min_type          | QUERY_FINISH
- max_block_size                | 32768
- max_execution_time            | 45
- max_result_rows               | 1024
- metrics_perf_events_list      | this,that
- network_compression_method    | ZSTD
- poll_interval                 | 5
- totals_mode                   | after_having_auto
-(12 rows)
+                name                |        value         
+------------------------------------+----------------------
+ connect_timeout                    | 2
+ count_distinct_implementation      | uniq
+ date_time_output_format            | iso
+ format_tsv_null_representation     | 
+ join_algorithm                     | prefer_partial_merge
+ join_use_nulls                     | 1
+ log_queries_min_type               | QUERY_FINISH
+ max_block_size                     | 32768
+ max_execution_time                 | 45
+ max_result_rows                    | 1024
+ metrics_perf_events_list           | this,that
+ network_compression_method         | ZSTD
+ output_format_tsv_crlf_end_of_line | 0
+ poll_interval                      | 5
+ totals_mode                        | after_having_auto
+(15 rows)
 
-             name              | ?column? 
--------------------------------+----------
- connect_timeout               | t
- count_distinct_implementation | t
- join_algorithm                | t
- join_use_nulls                | t
- log_queries_min_type          | t
- max_block_size                | t
- max_execution_time            | t
- max_result_rows               | t
- metrics_perf_events_list      | t
- network_compression_method    | t
- poll_interval                 | t
- totals_mode                   | t
-(12 rows)
+                name                | ?column? 
+------------------------------------+----------
+ connect_timeout                    | t
+ count_distinct_implementation      | t
+ date_time_output_format            | t
+ format_tsv_null_representation     | t
+ join_algorithm                     | t
+ join_use_nulls                     | t
+ log_queries_min_type               | t
+ max_block_size                     | t
+ max_execution_time                 | t
+ max_result_rows                    | t
+ metrics_perf_events_list           | t
+ network_compression_method         | t
+ output_format_tsv_crlf_end_of_line | t
+ poll_interval                      | t
+ totals_mode                        | t
+(15 rows)
 
-             name              | ?column? 
--------------------------------+----------
- connect_timeout               | t
- count_distinct_implementation | t
- join_algorithm                | t
- join_use_nulls                | t
- log_queries_min_type          | t
- max_block_size                | t
- max_execution_time            | t
- max_result_rows               | t
- metrics_perf_events_list      | t
- network_compression_method    | t
- poll_interval                 | t
- totals_mode                   | t
-(12 rows)
+                name                | ?column? 
+------------------------------------+----------
+ connect_timeout                    | t
+ count_distinct_implementation      | t
+ date_time_output_format            | f
+ format_tsv_null_representation     | f
+ join_algorithm                     | t
+ join_use_nulls                     | t
+ log_queries_min_type               | t
+ max_block_size                     | t
+ max_execution_time                 | t
+ max_result_rows                    | t
+ metrics_perf_events_list           | t
+ network_compression_method         | t
+ output_format_tsv_crlf_end_of_line | t
+ poll_interval                      | t
+ totals_mode                        | t
+(15 rows)
 
 NOTICE:  drop cascades to foreign table bin_remote_settings
 NOTICE:  drop cascades to foreign table http_remote_settings

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -67,10 +67,12 @@ SELECT name, value FROM http_remote_settings
  WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final')
  ORDER BY name;
 
--- List of seeings changed below.
+-- List of settings changed below.
 select '{
     connect_timeout,
     count_distinct_implementation,
+    date_time_output_format,
+    format_tsv_null_representation,
     join_algorithm,
     join_use_nulls,
     log_queries_min_type,
@@ -79,6 +81,7 @@ select '{
     max_result_rows,
     metrics_perf_events_list,
     network_compression_method,
+    output_format_tsv_crlf_end_of_line,
     poll_interval,
     totals_mode
 }' set_list \gset
@@ -95,6 +98,8 @@ SELECT name, value
 SET pg_clickhouse.session_settings TO $$
     connect_timeout 2,
     count_distinct_implementation uniq,
+    date_time_output_format unix_timestamp,
+    format_tsv_null_representation NOPE,
     join_algorithm 'prefer_partial_merge',
     join_use_nulls 0,
     join_use_nulls 1,
@@ -104,6 +109,7 @@ SET pg_clickhouse.session_settings TO $$
     max_result_rows 1024,
     metrics_perf_events_list 'this,that',
     network_compression_method ZSTD,
+    output_format_tsv_crlf_end_of_line 1,
     poll_interval 5,
     totals_mode after_having_auto
 $$;
@@ -130,6 +136,7 @@ SELECT remote.name, remote.value IS NOT DISTINCT FROM def.value
 WHERE remote.name = ANY(:'set_list')
 ORDER BY remote.name;
 
+-- date_time_output_format and format_tsv_null_representation are distinct.
 SELECT remote.name, remote.value IS NOT DISTINCT FROM def.value
  FROM http_remote_settings remote
  JOIN default_settings def ON remote.name = def.name


### PR DESCRIPTION
Replace the custom string buffer management in `ch_http_read_state` with the Postgres `StringInfo` object, and let it handle memory management and buffer growth as appropriate. This simplifies the code somewhat, and lays the ground for forthcoming TSV parsing improvements.

While at it, explicitly set the `format_tsv_null_representation`, and `output_format_tsv_crlf_end_of_line` settings for all http requests, as any other values will break its TSV parsing.

Also fix the documentation of the default value of the `pg_clickhouse.session_settings` GUC.