### PR TITLE
Support query cancellation for the binary driver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: destroyed-symlinks
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude: "[.]out$"
       - id: fix-byte-order-marker
       - id: mixed-line-ending
         exclude: "[.]out$"

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -232,6 +232,12 @@ extern "C"
 			client->Select(clickhouse::Query(query->sql)
 						   .SetQuerySettings(ch_binary_settings(query))
 						   .SetParams(ch_binary_params(query))
+						   .OnProgress(
+						   [&check_cancel](const Progress &)
+						   {
+							   if (check_cancel && check_cancel())
+								   throw std::runtime_error("query was canceled");
+						   })
 						   .OnDataCancelable(
 						   [&resp, &values, &check_cancel](const Block &block)
 						   {

--- a/src/fdw.c.in
+++ b/src/fdw.c.in
@@ -931,6 +931,9 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 	TupleDesc	tupdesc;
 	ch_query	query = new_query(fsstate->query, fsstate->numParams, fsstate->param_values);
 
+	/* Allow query cancel (e.g. Ctrl+C) between tuple fetches. */
+	CHECK_FOR_INTERRUPTS();
+
 	/* make query if needed */
 	if (fsstate->ch_cursor == NULL)
 	{

--- a/test/expected/query_cancel.out
+++ b/test/expected/query_cancel.out
@@ -1,0 +1,96 @@
+-- Test that query cancellation (e.g. Ctrl+C / statement_timeout) works for
+-- both the HTTP and binary drivers during remote query execution.
+-- HTTP driver
+CREATE SERVER cancel_http FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'cancel_test', driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_http;
+-- Binary driver
+CREATE SERVER cancel_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'cancel_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS cancel_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE cancel_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE cancel_test.t1 (c1 Int32)
+    ENGINE = MergeTree ORDER BY c1');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO cancel_test.t1
+    SELECT number FROM numbers(100)');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE cancel_http_ft (c1 int)
+    SERVER cancel_http OPTIONS (table_name 't1');
+CREATE FOREIGN TABLE cancel_binary_ft (c1 int)
+    SERVER cancel_binary OPTIONS (table_name 't1');
+-- Warm up connections so the cancel test only covers query execution.
+SELECT count(*) FROM cancel_http_ft;
+ count 
+-------
+   100
+(1 row)
+
+SELECT count(*) FROM cancel_binary_ft;
+ count 
+-------
+   100
+(1 row)
+
+-- HTTP: a multi-way cross join produces a huge result that will take far
+-- longer than the 10 ms timeout, exercising the curl progress-callback
+-- cancel path.
+BEGIN;
+SET LOCAL statement_timeout = '10ms';
+SELECT count(*) FROM cancel_http_ft a CROSS JOIN cancel_http_ft b
+    CROSS JOIN cancel_http_ft c CROSS JOIN cancel_http_ft d;
+ERROR:  pg_clickhouse: query was aborted
+COMMIT;
+-- Binary: same test, exercising the OnProgress cancel path.
+BEGIN;
+SET LOCAL statement_timeout = '10ms';
+SELECT count(*) FROM cancel_binary_ft a CROSS JOIN cancel_binary_ft b
+    CROSS JOIN cancel_binary_ft c CROSS JOIN cancel_binary_ft d;
+ERROR:  pg_clickhouse: query was canceled
+DETAIL:  Remote Query: SELECT count(*) FROM    cancel_test.t1 r1 ALL INNER JOIN cancel_test.t1 r2 ON (TRUE) ALL INNER JOIN cancel_test.t1 r4 ON (TRUE) ALL INNER JOIN cancel_test.t1 r6 ON (TRUE)
+COMMIT;
+-- Verify the connection still works after cancellation.
+SELECT count(*) FROM cancel_http_ft;
+ count 
+-------
+   100
+(1 row)
+
+SELECT count(*) FROM cancel_binary_ft;
+ count 
+-------
+   100
+(1 row)
+
+-- Cleanup
+DROP FOREIGN TABLE cancel_http_ft;
+DROP FOREIGN TABLE cancel_binary_ft;
+DROP USER MAPPING FOR CURRENT_USER SERVER cancel_http;
+DROP USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
+DROP SERVER cancel_http;
+DROP SERVER cancel_binary;
+SELECT clickhouse_raw_query('DROP DATABASE cancel_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+

--- a/test/expected/query_cancel.out
+++ b/test/expected/query_cancel.out
@@ -93,4 +93,3 @@ SELECT clickhouse_raw_query('DROP DATABASE cancel_test');
 ----------------------
  
 (1 row)
-

--- a/test/expected/query_cancel.out
+++ b/test/expected/query_cancel.out
@@ -93,3 +93,4 @@ SELECT clickhouse_raw_query('DROP DATABASE cancel_test');
 ----------------------
  
 (1 row)
+

--- a/test/sql/query_cancel.sql
+++ b/test/sql/query_cancel.sql
@@ -1,0 +1,57 @@
+-- Test that query cancellation (e.g. Ctrl+C / statement_timeout) works for
+-- both the HTTP and binary drivers during remote query execution.
+
+-- HTTP driver
+CREATE SERVER cancel_http FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'cancel_test', driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_http;
+
+-- Binary driver
+CREATE SERVER cancel_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'cancel_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS cancel_test');
+SELECT clickhouse_raw_query('CREATE DATABASE cancel_test');
+SELECT clickhouse_raw_query('CREATE TABLE cancel_test.t1 (c1 Int32)
+    ENGINE = MergeTree ORDER BY c1');
+SELECT clickhouse_raw_query('INSERT INTO cancel_test.t1
+    SELECT number FROM numbers(100)');
+
+CREATE FOREIGN TABLE cancel_http_ft (c1 int)
+    SERVER cancel_http OPTIONS (table_name 't1');
+CREATE FOREIGN TABLE cancel_binary_ft (c1 int)
+    SERVER cancel_binary OPTIONS (table_name 't1');
+
+-- Warm up connections so the cancel test only covers query execution.
+SELECT count(*) FROM cancel_http_ft;
+SELECT count(*) FROM cancel_binary_ft;
+
+-- HTTP: a multi-way cross join produces a huge result that will take far
+-- longer than the 10 ms timeout, exercising the curl progress-callback
+-- cancel path.
+BEGIN;
+SET LOCAL statement_timeout = '10ms';
+SELECT count(*) FROM cancel_http_ft a CROSS JOIN cancel_http_ft b
+    CROSS JOIN cancel_http_ft c CROSS JOIN cancel_http_ft d;
+COMMIT;
+
+-- Binary: same test, exercising the OnProgress cancel path.
+BEGIN;
+SET LOCAL statement_timeout = '10ms';
+SELECT count(*) FROM cancel_binary_ft a CROSS JOIN cancel_binary_ft b
+    CROSS JOIN cancel_binary_ft c CROSS JOIN cancel_binary_ft d;
+COMMIT;
+
+-- Verify the connection still works after cancellation.
+SELECT count(*) FROM cancel_http_ft;
+SELECT count(*) FROM cancel_binary_ft;
+
+-- Cleanup
+DROP FOREIGN TABLE cancel_http_ft;
+DROP FOREIGN TABLE cancel_binary_ft;
+DROP USER MAPPING FOR CURRENT_USER SERVER cancel_http;
+DROP USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
+DROP SERVER cancel_http;
+DROP SERVER cancel_binary;
+SELECT clickhouse_raw_query('DROP DATABASE cancel_test');


### PR DESCRIPTION
## Summary

- Add `OnProgress` cancel callback to the binary driver so that
  Ctrl+C / `statement_timeout` works during server-side computation,
  not only between data blocks.
- Add `CHECK_FOR_INTERRUPTS()` in `clickhouseIterateForeignScan` so
  cancellation is processed between local tuple fetches.
- Add `query_cancel` regression test covering both HTTP and binary
  drivers.

## Background

The HTTP driver already handled cancel via a curl progress callback.
The binary driver's `OnDataCancelable` only fires on data blocks,
but during computation ClickHouse sends Progress packets instead —
leaving the client blocked with no cancel check.

## Test plan

- [ ] `make tempcheck` passes all 22 tests (including new `query_cancel`)
- [ ] Manual: run a slow query via the binary driver, press Ctrl+C,
      confirm it cancels promptly and subsequent queries still work