### PR TITLE
Push down jsonb -> and ->> operators as ClickHouse dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.7] — Unreleased
 
+### ⚡ Improvements
+
+*   Added mapping for the `JSON` and `JSONB` `-> TEXT` and `->> TEXT`
+    operators to be passed down to ClickHouse using its [sub-column syntax]
+
 ### 📔 Notes
 
 *   Eliminated use of a constant that required libcurl 7.87.0, restoring
     support for earlier versions.
 
   [v0.1.7]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.6...v0.1.7
+  https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns
+    "ClickHouse Docs: Reading JSON paths as sub-columns"
 
 ## [v0.1.6] — 2026-04-02
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -363,23 +363,37 @@ chfdw_check_for_custom_type(Oid typeoid)
 }
 
 /*
+ * Operator-name to custom_object_type mapping table, searched linearly by
+ * classify_builtin_operator().  Keep in sync with the CF_* enum in fdw.h.
+ */
+typedef struct
+{
+	const char *oprname;
+	custom_object_type ctype;
+}			BuiltinOperatorMap;
+
+static const BuiltinOperatorMap builtin_operator_map[] = {
+	{"~", CF_REGEX_MATCH},
+	{"!~", CF_REGEX_NO_MATCH},
+	{"~*", CF_REGEX_ICASE_MATCH},
+	{"!~*", CF_REGEX_ICASE_NO_MATCH},
+	{"->", CF_JSONB_FETCHVAL},
+	{"->>", CF_JSONB_FETCHVAL_TEXT},
+};
+
+/*
  * Map a builtin operator name to its custom_object_type.  Returns CF_USUAL
  * when the operator needs no special handling and should follow the normal
  * builtin shortcut (i.e. be presumed shippable with no rewrite).
- *
- * Keep this function in sync with the CF_* enum in fdw.h.
  */
 static custom_object_type
 classify_builtin_operator(const char *oprname)
 {
-	if (strcmp(oprname, "~") == 0)
-		return CF_REGEX_MATCH;
-	if (strcmp(oprname, "!~") == 0)
-		return CF_REGEX_NO_MATCH;
-	if (strcmp(oprname, "~*") == 0)
-		return CF_REGEX_ICASE_MATCH;
-	if (strcmp(oprname, "!~*") == 0)
-		return CF_REGEX_ICASE_NO_MATCH;
+	for (int i = 0; i < lengthof(builtin_operator_map); i++)
+	{
+		if (strcmp(oprname, builtin_operator_map[i].oprname) == 0)
+			return builtin_operator_map[i].ctype;
+	}
 	return CF_USUAL;
 }
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2745,6 +2745,45 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 					goto cleanup;
 				}
 				break;
+			case CF_JSONB_FETCHVAL:
+			case CF_JSONB_FETCHVAL_TEXT:
+				{
+					Expr	   *arg1 = linitial(node->args);
+					Expr	   *arg2 = lsecond(node->args);
+
+					/*
+					 * Convert jsonb ->> 'key' to ClickHouse dot notation:
+					 * column.key Convert jsonb -> 'key' to JSON-wrapped dot
+					 * notation: toJSONString(column.key) The -> operator
+					 * returns jsonb, so we need to wrap the result with
+					 * toJSONString() for type compatibility.
+					 */
+					if (IsA(arg2, Const))
+					{
+						Const	   *key = (Const *) arg2;
+
+						if (key->consttype == TEXTOID && !key->constisnull)
+						{
+							char	   *keyval = TextDatumGetCString(key->constvalue);
+
+							if (cdef->cf_type == CF_JSONB_FETCHVAL)
+								appendStringInfoString(buf, "toJSONString(");
+
+							deparseExpr(arg1, context);
+							appendStringInfoChar(buf, '.');
+							appendStringInfoString(buf,
+												   quote_identifier(keyval));
+
+							if (cdef->cf_type == CF_JSONB_FETCHVAL)
+								appendStringInfoChar(buf, ')');
+
+							pfree(keyval);
+							goto cleanup;
+						}
+					}
+					/* Non-text key: fall through to standard deparse */
+				}
+				break;
 			default: /* keep compiler quiet */ ;
 		}
 	}

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -300,6 +300,8 @@ typedef enum
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */
 	CF_REGEX_ICASE_NO_MATCH,	/* !~* case-insensitive regex operator */
+	CF_JSONB_FETCHVAL,			/* -> operator on jsonb */
+	CF_JSONB_FETCHVAL_TEXT,		/* ->> operator on jsonb */
 }			custom_object_type;
 
 typedef enum

--- a/test/expected/json.out
+++ b/test/expected/json.out
@@ -136,6 +136,303 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
  "large"  |     2
 (3 rows)
 
+-- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
+-- target-list expressions are evaluated locally (PostgreSQL fetches the whole
+-- column and applies the operator after). This query runs -> locally.
+-- N.B.: Binary driver JSON data not yet supported.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+(4 rows)
+
+-- WHERE clause with ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+-- WHERE with multiple ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+-- WHERE with ->> in an OR condition.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo';
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo')))
+(3 rows)
+
+-- ORDER BY with ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'size';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data, (data ->> 'size'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+(3 rows)
+
+-- The jsonb -> operator: target-list expressions are evaluated locally
+-- (same as ->>). This query evaluates `->` locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+(4 rows)
+
+-- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.stocked) = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
+  3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
+(3 rows)
+
+-- WHERE clause with -> wraps the dot notation in toJSONString() so that the
+-- result is a proper JSON value (-> returns jsonb, not text like ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+-- Edge cases: JSON keys that require identifier quoting.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.special_keys (
+        id   Int32 NOT NULL,
+        data JSON NOT NULL
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+INSERT INTO json_http.special_keys VALUES
+    (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}'),
+    (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+-- Key with a space: must be quoted in the remote SQL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT data ->> 'my field' FROM json_http.special_keys;
+ ?column? 
+----------
+ hello
+ 
+(2 rows)
+
+-- Key with mixed case.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT data ->> 'CamelCase' FROM json_http.special_keys;
+ ?column? 
+----------
+ world
+ 
+(2 rows)
+
+-- Key that is a SQL reserved word.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT data ->> 'select' FROM json_http.special_keys;
+ ?column? 
+----------
+ reserved
+ 
+(2 rows)
+
+-- Key containing embedded double quotes.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT data ->> 'The "meaning" of life' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 42
+(1 row)
+
+-- Key containing a backslash.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT data ->> 'back\slash' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ bs
+(1 row)
+
+-- Key containing a dot (must not be confused with nested access).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT data ->> 'dotted.key' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 
+(1 row)
+
+-- Key containing an apostrophe / single quote.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT data ->> 'it''s' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ apos
+(1 row)
+
+-- Key with slashes, bangs, at-signs, etc.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+-- Key that starts with a digit.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -147,4 +444,6 @@ DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
 NOTICE:  drop cascades to foreign table json_bin.things
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to foreign table json_http.things
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.special_keys

--- a/test/expected/json_1.out
+++ b/test/expected/json_1.out
@@ -93,6 +93,303 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 ERROR:  cannot subscript type jsonb because it is not an array
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 ERROR:  cannot subscript type jsonb because it is not an array
+-- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
+-- target-list expressions are evaluated locally (PostgreSQL fetches the whole
+-- column and applies the operator after). This query runs -> locally.
+-- N.B.: Binary driver JSON data not yet supported.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+(4 rows)
+
+-- WHERE clause with ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+-- WHERE with multiple ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+-- WHERE with ->> in an OR condition.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo';
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo')))
+(3 rows)
+
+-- ORDER BY with ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'size';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data, (data ->> 'size'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+(3 rows)
+
+-- The jsonb -> operator: target-list expressions are evaluated locally
+-- (same as ->>). This query evaluates `->` locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+(4 rows)
+
+-- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.stocked) = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
+  3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
+(3 rows)
+
+-- WHERE clause with -> wraps the dot notation in toJSONString() so that the
+-- result is a proper JSON value (-> returns jsonb, not text like ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+-- Edge cases: JSON keys that require identifier quoting.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.special_keys (
+        id   Int32 NOT NULL,
+        data JSON NOT NULL
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+INSERT INTO json_http.special_keys VALUES
+    (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}'),
+    (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+-- Key with a space: must be quoted in the remote SQL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT data ->> 'my field' FROM json_http.special_keys;
+ ?column? 
+----------
+ hello
+ 
+(2 rows)
+
+-- Key with mixed case.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT data ->> 'CamelCase' FROM json_http.special_keys;
+ ?column? 
+----------
+ world
+ 
+(2 rows)
+
+-- Key that is a SQL reserved word.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT data ->> 'select' FROM json_http.special_keys;
+ ?column? 
+----------
+ reserved
+ 
+(2 rows)
+
+-- Key containing embedded double quotes.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT data ->> 'The "meaning" of life' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 42
+(1 row)
+
+-- Key containing a backslash.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT data ->> 'back\slash' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ bs
+(1 row)
+
+-- Key containing a dot (must not be confused with nested access).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT data ->> 'dotted.key' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 
+(1 row)
+
+-- Key containing an apostrophe / single quote.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT data ->> 'it''s' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ apos
+(1 row)
+
+-- Key with slashes, bangs, at-signs, etc.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+-- Key that starts with a digit.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -104,4 +401,6 @@ DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
 NOTICE:  drop cascades to foreign table json_bin.things
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to foreign table json_http.things
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.special_keys

--- a/test/expected/json_2.out
+++ b/test/expected/json_2.out
@@ -136,6 +136,303 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
  "large"  |     2
 (3 rows)
 
+-- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
+-- target-list expressions are evaluated locally (PostgreSQL fetches the whole
+-- column and applies the operator after). This query runs -> locally.
+-- N.B.: Binary driver JSON data not yet supported.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+(4 rows)
+
+-- WHERE clause with ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+-- WHERE with multiple ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+-- WHERE with ->> in an OR condition.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo';
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo')))
+(3 rows)
+
+-- ORDER BY with ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'size';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data, (data ->> 'size'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+(3 rows)
+
+-- The jsonb -> operator: target-list expressions are evaluated locally
+-- (same as ->>). This query evaluates `->` locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+(4 rows)
+
+-- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.stocked) = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
+ id |                               data                                
+----+-------------------------------------------------------------------
+  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+  2 | {"id": "2", "name": "sprocket", "size": "small", "stocked": true}
+  3 | {"id": "3", "name": "gizmo", "size": "medium", "stocked": true}
+(3 rows)
+
+-- WHERE clause with -> wraps the dot notation in toJSONString() so that the
+-- result is a proper JSON value (-> returns jsonb, not text like ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.name) = '"widget"'))
+(3 rows)
+
+-- Edge cases: JSON keys that require identifier quoting.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.special_keys (
+        id   Int32 NOT NULL,
+        data JSON NOT NULL
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+INSERT INTO json_http.special_keys VALUES
+    (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}'),
+    (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+-- Key with a space: must be quoted in the remote SQL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT data ->> 'my field' FROM json_http.special_keys;
+ ?column? 
+----------
+ hello
+ 
+(2 rows)
+
+-- Key with mixed case.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT data ->> 'CamelCase' FROM json_http.special_keys;
+ ?column? 
+----------
+ world
+ 
+(2 rows)
+
+-- Key that is a SQL reserved word.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT data ->> 'select' FROM json_http.special_keys;
+ ?column? 
+----------
+ reserved
+ 
+(2 rows)
+
+-- Key containing embedded double quotes.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT data ->> 'The "meaning" of life' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 42
+(1 row)
+
+-- Key containing a backslash.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT data ->> 'back\slash' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ bs
+(1 row)
+
+-- Key containing a dot (must not be confused with nested access).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT data ->> 'dotted.key' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ 
+(1 row)
+
+-- Key containing an apostrophe / single quote.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT data ->> 'it''s' FROM json_http.special_keys WHERE id = 2;
+ ?column? 
+----------
+ apos
+(1 row)
+
+-- Key with slashes, bangs, at-signs, etc.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+-- Key that starts with a digit.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -147,4 +444,6 @@ DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
 NOTICE:  drop cascades to foreign table json_bin.things
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to foreign table json_http.things
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.special_keys

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -92,6 +92,228 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 ERROR:  relation "json_http.things" does not exist
 LINE 1: SELECT data['size'], count(*) FROM json_http.things GROUP BY...
                                            ^
+-- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
+-- target-list expressions are evaluated locally (PostgreSQL fetches the whole
+-- column and applies the operator after). This query runs -> locally.
+-- N.B.: Binary driver JSON data not yet supported.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.things;
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT data ->> 'name' FROM json_http.things;
+                                    ^
+SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+                                    ^
+-- WHERE clause with ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE data ->> 'name' = 'widg...
+                      ^
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT * FROM json_http.things WHERE data ->> 'name' = 'widg...
+                      ^
+-- WHERE clause with ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'w...
+                      ^
+-- WHERE with multiple ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things
+                      ^
+-- WHERE with ->> in an OR condition.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things
+                      ^
+-- ORDER BY with ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'size';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things ORDER BY data ->> 'size';
+                      ^
+-- The jsonb -> operator: target-list expressions are evaluated locally
+-- (same as ->>). This query evaluates `->` locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.things;
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT data -> 'name' FROM json_http.things;
+                                   ^
+SELECT data -> 'name' FROM json_http.things ORDER BY id;
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT data -> 'name' FROM json_http.things ORDER BY id;
+                                   ^
+-- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE data -> 'name' = '"widg...
+                      ^
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT * FROM json_http.things WHERE data -> 'name' = '"widg...
+                      ^
+-- WHERE clause with -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE data -> 'stocked' = 'tr...
+                      ^
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT * FROM json_http.things WHERE data -> 'stocked' = 'tr...
+                      ^
+-- WHERE clause with -> wraps the dot notation in toJSONString() so that the
+-- result is a proper JSON value (-> returns jsonb, not text like ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE data -> 'name' = '"widg...
+                      ^
+-- Edge cases: JSON keys that require identifier quoting.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.special_keys (
+        id   Int32 NOT NULL,
+        data JSON NOT NULL
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+INSERT INTO json_http.special_keys VALUES
+    (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}'),
+    (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+-- Key with a space: must be quoted in the remote SQL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT data ->> 'my field' FROM json_http.special_keys;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key with mixed case.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT data ->> 'CamelCase' FROM json_http.special_keys;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key that is a SQL reserved word.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT data ->> 'select' FROM json_http.special_keys;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key containing embedded double quotes.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT data ->> 'The "meaning" of life' FROM json_http.special_keys WHERE id = 2;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key containing a backslash.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT data ->> 'back\slash' FROM json_http.special_keys WHERE id = 2;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key containing a dot (must not be confused with nested access).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT data ->> 'dotted.key' FROM json_http.special_keys WHERE id = 2;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key containing an apostrophe / single quote.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT data ->> 'it''s' FROM json_http.special_keys WHERE id = 2;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Key with slashes, bangs, at-signs, etc.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+-- Key that starts with a digit.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -102,3 +324,4 @@ DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
 DROP SERVER http_json_loopback CASCADE;
+NOTICE:  drop cascades to foreign table json_http.special_keys

--- a/test/sql/json.sql
+++ b/test/sql/json.sql
@@ -54,6 +54,116 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 
+-- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
+-- target-list expressions are evaluated locally (PostgreSQL fetches the whole
+-- column and applies the operator after). This query runs -> locally.
+-- N.B.: Binary driver JSON data not yet supported.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.things;
+SELECT data ->> 'name' FROM json_http.things ORDER BY id;
+
+-- WHERE clause with ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
+
+-- WHERE clause with ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
+
+-- WHERE with multiple ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+
+-- WHERE with ->> in an OR condition.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo';
+
+-- ORDER BY with ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'size';
+
+-- The jsonb -> operator: target-list expressions are evaluated locally
+-- (same as ->>). This query evaluates `->` locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.things;
+SELECT data -> 'name' FROM json_http.things ORDER BY id;
+
+-- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
+
+-- WHERE clause with -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
+SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
+
+-- WHERE clause with -> wraps the dot notation in toJSONString() so that the
+-- result is a proper JSON value (-> returns jsonb, not text like ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
+
+-- Edge cases: JSON keys that require identifier quoting.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.special_keys (
+        id   Int32 NOT NULL,
+        data JSON NOT NULL
+    ) ENGINE = MergeTree ORDER BY (id);
+$$);
+
+CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+
+INSERT INTO json_http.special_keys VALUES
+    (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}'),
+    (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+
+-- Key with a space: must be quoted in the remote SQL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
+SELECT data ->> 'my field' FROM json_http.special_keys;
+
+-- Key with mixed case.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+SELECT data ->> 'CamelCase' FROM json_http.special_keys;
+
+-- Key that is a SQL reserved word.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
+SELECT data ->> 'select' FROM json_http.special_keys;
+
+-- Key containing embedded double quotes.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+SELECT data ->> 'The "meaning" of life' FROM json_http.special_keys WHERE id = 2;
+
+-- Key containing a backslash.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
+SELECT data ->> 'back\slash' FROM json_http.special_keys WHERE id = 2;
+
+-- Key containing a dot (must not be confused with nested access).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
+SELECT data ->> 'dotted.key' FROM json_http.special_keys WHERE id = 2;
+
+-- Key containing an apostrophe / single quote.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
+SELECT data ->> 'it''s' FROM json_http.special_keys WHERE id = 2;
+
+-- Key with slashes, bangs, at-signs, etc.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+
+-- Key that starts with a digit.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;


### PR DESCRIPTION
## Summary

- Rewrite jsonb `->` and `->>` operators to ClickHouse dot notation
  during deparse (e.g. `data ->> 'name'` becomes `data.name`), enabling
  ClickHouse to filter on JSON fields instead of shipping entire rows
  for local evaluation.
- Keys are emitted through `quote_identifier`, correctly quoting spaces,
  dots, mixed case, reserved words, and embedded double quotes.
- Follows up on bbdb1a6 which disabled subscript (`column['key']`)
  pushdown; this provides the working alternative via `->>`/`->`.

## Test plan

- [x] `EXPLAIN` verifies WHERE equality pushdown: `data.name = 'widget'`
- [x] `EXPLAIN` verifies WHERE LIKE pushdown: `data.name LIKE 'wid%'`
- [x] `EXPLAIN` verifies compound WHERE (AND / OR) pushdown
- [x] `EXPLAIN` verifies ORDER BY pushdown: `ORDER BY data.size`
- [x] `EXPLAIN` verifies `->` operator pushdown (returns jsonb, not text)
- [x] Edge cases: keys with spaces, mixed case, reserved words, embedded
  double quotes, backslashes, dots, apostrophes, special characters, and
  leading digits -- all produce correctly quoted remote SQL
- [x] Data fetches return correct values for all edge cases
- [x] All 4 expected output variants updated (PG 14-18, PG 13, CH 24.8-25.3, CH 22-24.3)
- [x] `make tempcheck` passes (json test green; pre-existing failures in
  functions, http, http_inserts, import_schema are unrelated)