### PR TITLE
Pushdown string and date formatting functions

### DIFF
--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -53,6 +53,18 @@
 #define F_REGEXP_LIKE_TEXT_TEXT 6263
 #endif
 
+/* Pre-PG14 compat for function OIDs used in new translations. */
+#if PG_VERSION_NUM < 140000
+#define F_SPLIT_PART 2088
+#define F_REGEXP_REPLACE_TEXT_TEXT_TEXT 2284
+#define F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT 2285
+#define F_CONCAT_WS 3059
+#define F_ARRAY_TO_STRING_ANYARRAY_TEXT 395
+#define F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT 384
+#define F_TO_CHAR_TIMESTAMP_TEXT 2049
+#define F_TO_CHAR_TIMESTAMPTZ_TEXT 1770
+#endif
+
 #define STR_STARTS_WITH(str, sub) strncmp(str, sub, strlen(sub)) == 0
 #define STR_EQUAL(a, b) strcmp(a, b) == 0
 
@@ -202,6 +214,14 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_MD5_BYTEA:
 			case F_MD5_TEXT:
 			case F_TO_TIMESTAMP_FLOAT8:
+			case F_SPLIT_PART:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT:
+			case F_CONCAT_WS:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
+			case F_TO_CHAR_TIMESTAMP_TEXT:
+			case F_TO_CHAR_TIMESTAMPTZ_TEXT:
 				special_builtin = true;
 				break;
 			default:
@@ -297,6 +317,38 @@ chfdw_check_for_custom_function(Oid funcid)
 					 */
 					strcpy(entry->custom_name, "fromUnixTimestamp(toInt64");
 					entry->paren_count = 2;
+					break;
+				}
+			case F_SPLIT_PART:
+				{
+					entry->cf_type = CF_SPLIT_PART;
+					entry->custom_name[0] = '\1';
+					break;
+				}
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT:
+				{
+					entry->cf_type = CF_REGEXP_REPLACE;
+					entry->custom_name[0] = '\1';
+					break;
+				}
+			case F_CONCAT_WS:
+				{
+					entry->cf_type = CF_CONCAT_WS;
+					entry->custom_name[0] = '\1';
+					break;
+				}
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
+				{
+					strcpy(entry->custom_name, "arrayStringConcat");
+					break;
+				}
+			case F_TO_CHAR_TIMESTAMP_TEXT:
+			case F_TO_CHAR_TIMESTAMPTZ_TEXT:
+				{
+					entry->cf_type = CF_TO_CHAR;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 		}

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2352,6 +2352,164 @@ deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context)
 }
 
 /*
+ * Translate a PostgreSQL to_char() format string to a ClickHouse
+ * formatDateTime() format string.  Caller must pfree the result.
+ */
+static char *
+translate_to_char_format(const char *pgfmt)
+{
+	StringInfoData chfmt;
+
+	initStringInfo(&chfmt);
+
+	for (const char *p = pgfmt; *p;)
+	{
+		if (strncmp(p, "YYYY", 4) == 0)
+		{
+			appendStringInfoString(&chfmt, "%Y");
+			p += 4;
+		}
+		else if (strncmp(p, "HH24", 4) == 0)
+		{
+			appendStringInfoString(&chfmt, "%H");
+			p += 4;
+		}
+		else if (strncmp(p, "HH12", 4) == 0)
+		{
+			appendStringInfoString(&chfmt, "%I");
+			p += 4;
+		}
+		else if (strncmp(p, "MI", 2) == 0)
+		{
+			appendStringInfoString(&chfmt, "%i");
+			p += 2;
+		}
+		else if (strncmp(p, "MM", 2) == 0)
+		{
+			appendStringInfoString(&chfmt, "%m");
+			p += 2;
+		}
+		else if (strncmp(p, "DD", 2) == 0)
+		{
+			appendStringInfoString(&chfmt, "%d");
+			p += 2;
+		}
+		else if (strncmp(p, "SS", 2) == 0)
+		{
+			appendStringInfoString(&chfmt, "%S");
+			p += 2;
+		}
+		else
+		{
+			appendStringInfoChar(&chfmt, *p);
+			p++;
+		}
+	}
+
+	return chfmt.data;
+}
+
+/*
+ * split_part(str, delim, n) → splitByString(delim, str)[n]
+ */
+static void
+deparseSplitPart(FuncExpr * node, deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	Expr	   *str_arg = (Expr *) linitial(node->args);
+	Expr	   *delim_arg = (Expr *) list_nth(node->args, 1);
+	Const	   *idx_const = (Const *) list_nth(node->args, 2);
+	int32		idx = DatumGetInt32(idx_const->constvalue);
+
+	appendStringInfoString(buf, "splitByString(");
+	deparseExpr(delim_arg, context);
+	appendStringInfoString(buf, ", ");
+	deparseExpr(str_arg, context);
+	appendStringInfo(buf, ")[%d]", idx);
+}
+
+/*
+ * regexp_replace(str, pat, rep)      → replaceRegexpOne(str, pat, rep)
+ * regexp_replace(str, pat, rep, 'g') → replaceRegexpAll(str, pat, rep)
+ */
+static void
+deparseRegexpReplace(FuncExpr * node, deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	int			nargs = list_length(node->args);
+
+	if (nargs == 4)
+	{
+		Const	   *flags = (Const *) list_nth(node->args, 3);
+		char	   *flagstr = TextDatumGetCString(flags->constvalue);
+
+		if (strchr(flagstr, 'g') != NULL)
+			appendStringInfoString(buf, "replaceRegexpAll(");
+		else
+			appendStringInfoString(buf, "replaceRegexpOne(");
+		pfree(flagstr);
+	}
+	else
+		appendStringInfoString(buf, "replaceRegexpOne(");
+
+	deparseExpr((Expr *) linitial(node->args), context);
+	appendStringInfoString(buf, ", ");
+	deparseExpr((Expr *) list_nth(node->args, 1), context);
+	appendStringInfoString(buf, ", ");
+	deparseExpr((Expr *) list_nth(node->args, 2), context);
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * concat_ws(sep, a, b, ...) →
+ *   arrayStringConcat(arrayFilter(x -> x != '',
+ *     [ifNull(a,''), ifNull(b,''), ...]), sep)
+ */
+static void
+deparseConcatWs(FuncExpr * node, deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	Expr	   *sep_arg = (Expr *) linitial(node->args);
+	ListCell   *lc;
+	bool		first_val = true;
+
+	appendStringInfoString(buf, "arrayStringConcat(arrayFilter(x -> x != '', [");
+
+	for_each_cell(lc, node->args, list_second_cell(node->args))
+	{
+		if (!first_val)
+			appendStringInfoString(buf, ", ");
+		appendStringInfoString(buf, "ifNull(");
+		deparseExpr((Expr *) lfirst(lc), context);
+		appendStringInfoString(buf, ", '')");
+		first_val = false;
+	}
+
+	appendStringInfoString(buf, "]), ");
+	deparseExpr(sep_arg, context);
+	appendStringInfoChar(buf, ')');
+}
+
+/*
+ * to_char(ts, fmt) → formatDateTime(ts, translated_fmt)
+ */
+static void
+deparseToChar(FuncExpr * node, deparse_expr_cxt * context)
+{
+	StringInfo	buf = context->buf;
+	Const	   *fmt_const = (Const *) list_nth(node->args, 1);
+	char	   *pgfmt = TextDatumGetCString(fmt_const->constvalue);
+	char	   *chfmt = translate_to_char_format(pgfmt);
+
+	appendStringInfoString(buf, "formatDateTime(");
+	deparseExpr((Expr *) linitial(node->args), context);
+	appendStringInfo(buf, ", '%s')", chfmt);
+
+	pfree(pgfmt);
+	pfree(chfmt);
+}
+
+/*
  * Deparse a function call.
  */
 static void
@@ -2495,6 +2653,27 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 		appendStringInfoChar(buf, '(');
 		deparseExpr(list_nth(node->args, 1), context);
 		appendStringInfoChar(buf, ')');
+		return;
+	}
+
+	if (cdef && cdef->cf_type == CF_SPLIT_PART)
+	{
+		deparseSplitPart(node, context);
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_REGEXP_REPLACE)
+	{
+		deparseRegexpReplace(node, context);
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_CONCAT_WS)
+	{
+		deparseConcatWs(node, context);
+		return;
+	}
+	else if (cdef && cdef->cf_type == CF_TO_CHAR)
+	{
+		deparseToChar(node, context);
 		return;
 	}
 

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -300,6 +300,10 @@ typedef enum
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */
 	CF_REGEX_ICASE_NO_MATCH,	/* !~* case-insensitive regex operator */
+	CF_SPLIT_PART,				/* split_part → splitByString */
+	CF_REGEXP_REPLACE,			/* regexp_replace → replaceRegexp* */
+	CF_CONCAT_WS,				/* concat_ws → arrayStringConcat */
+	CF_TO_CHAR,					/* to_char → formatDateTime */
 }			custom_object_type;
 
 typedef enum

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1440,6 +1440,148 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
  2042323443 | 2042323443.232
 (1 row)
 
+-- check split_part → splitByString.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((splitByString('l', val)[2] = '1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+ val  
+------
+ val1
+(1 row)
+
+-- check regexp_replace → replaceRegexpOne (no flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpOne(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check regexp_replace → replaceRegexpAll ('g' flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpAll(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check array_to_string → arrayStringConcat.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (id UInt64, tags Array(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t8 VALUES (1, ['a','b','c']), (2, ['x'])$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t8 (id bigint, tags text[]) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (array_to_string(tags, ', '::text))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT arrayStringConcat(tags, ', ') FROM functions_test.t8 GROUP BY (arrayStringConcat(tags, ', ')) ORDER BY arrayStringConcat(tags, ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+    t    
+---------
+ a, b, c
+ x
+(2 rows)
+
+-- check concat_ws → arrayStringConcat with NULL filtering.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t9 (id UInt64, city Nullable(String), state Nullable(String), country Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t9 VALUES (1, 'Paris', NULL, 'France'), (2, 'London', 'England', 'UK')$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t9 (id bigint, city text, state text, country text) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (concat_ws(', '::text, city, state, country))
+   Relations: Aggregate on (t9)
+   Remote SQL: SELECT arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') FROM functions_test.t9 GROUP BY (arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ')) ORDER BY arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+        addr         
+---------------------
+ London, England, UK
+ Paris, France
+(2 rows)
+
+-- check to_char → formatDateTime.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((formatDateTime(ts, '%Y%m%d') = '20251015'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+         ts          
+---------------------
+ 2025-10-15 13:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text))
+   Relations: Aggregate on (t5)
+   Remote SQL: SELECT formatDateTime(ts, '%Y-%m-%d %H:%i:%S') FROM functions_test.t5 GROUP BY (formatDateTime(ts, '%Y-%m-%d %H:%i:%S')) ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(4 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+          d          
+---------------------
+ 2025-10-15 20:12:25
+ 2026-11-17 08:13:26
+ 2027-12-17 22:14:27
+ 2028-01-18 23:15:28
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(6 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 
@@ -1448,7 +1590,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1456,3 +1598,5 @@ drop cascades to foreign table t3_map
 drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
+drop cascades to foreign table t8
+drop cascades to foreign table t9

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1435,6 +1435,148 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
  2042323443 | 2042323443.232
 (1 row)
 
+-- check split_part → splitByString.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((splitByString('l', val)[2] = '1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+ val  
+------
+ val1
+(1 row)
+
+-- check regexp_replace → replaceRegexpOne (no flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpOne(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check regexp_replace → replaceRegexpAll ('g' flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpAll(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check array_to_string → arrayStringConcat.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (id UInt64, tags Array(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t8 VALUES (1, ['a','b','c']), (2, ['x'])$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t8 (id bigint, tags text[]) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (array_to_string(tags, ', '::text))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT arrayStringConcat(tags, ', ') FROM functions_test.t8 GROUP BY (arrayStringConcat(tags, ', ')) ORDER BY arrayStringConcat(tags, ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+    t    
+---------
+ a, b, c
+ x
+(2 rows)
+
+-- check concat_ws → arrayStringConcat with NULL filtering.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t9 (id UInt64, city Nullable(String), state Nullable(String), country Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t9 VALUES (1, 'Paris', NULL, 'France'), (2, 'London', 'England', 'UK')$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t9 (id bigint, city text, state text, country text) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (concat_ws(', '::text, city, state, country))
+   Relations: Aggregate on (t9)
+   Remote SQL: SELECT arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') FROM functions_test.t9 GROUP BY (arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ')) ORDER BY arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+        addr         
+---------------------
+ London, England, UK
+ Paris, France
+(2 rows)
+
+-- check to_char → formatDateTime.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((formatDateTime(ts, '%Y%m%d') = '20251015'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+         ts          
+---------------------
+ 2025-10-15 13:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text))
+   Relations: Aggregate on (t5)
+   Remote SQL: SELECT formatDateTime(ts, '%Y-%m-%d %H:%i:%S') FROM functions_test.t5 GROUP BY (formatDateTime(ts, '%Y-%m-%d %H:%i:%S')) ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(4 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+          d          
+---------------------
+ 2025-10-15 20:12:25
+ 2026-11-17 08:13:26
+ 2027-12-17 22:14:27
+ 2028-01-18 23:15:28
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(6 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 
@@ -1443,7 +1585,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1451,3 +1593,5 @@ drop cascades to foreign table t3_map
 drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
+drop cascades to foreign table t8
+drop cascades to foreign table t9

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1435,6 +1435,148 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
  2042323443 | 2042323443.232
 (1 row)
 
+-- check split_part → splitByString.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((splitByString('l', val)[2] = '1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+ val  
+------
+ val1
+(1 row)
+
+-- check regexp_replace → replaceRegexpOne (no flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpOne(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check regexp_replace → replaceRegexpAll ('g' flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((replaceRegexpAll(val, '[0-9]', 'X') = 'valX'))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- check array_to_string → arrayStringConcat.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (id UInt64, tags Array(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t8 VALUES (1, ['a','b','c']), (2, ['x'])$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t8 (id bigint, tags text[]) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (array_to_string(tags, ', '::text))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT arrayStringConcat(tags, ', ') FROM functions_test.t8 GROUP BY (arrayStringConcat(tags, ', ')) ORDER BY arrayStringConcat(tags, ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+    t    
+---------
+ a, b, c
+ x
+(2 rows)
+
+-- check concat_ws → arrayStringConcat with NULL filtering.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t9 (id UInt64, city Nullable(String), state Nullable(String), country Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t9 VALUES (1, 'Paris', NULL, 'France'), (2, 'London', 'England', 'UK')$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE t9 (id bigint, city text, state text, country text) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (concat_ws(', '::text, city, state, country))
+   Relations: Aggregate on (t9)
+   Remote SQL: SELECT arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') FROM functions_test.t9 GROUP BY (arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ')) ORDER BY arrayStringConcat(arrayFilter(x -> x != '', [ifNull(city, ''), ifNull(state, ''), ifNull(country, '')]), ', ') ASC NULLS LAST
+(4 rows)
+
+SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+        addr         
+---------------------
+ London, England, UK
+ Paris, France
+(2 rows)
+
+-- check to_char → formatDateTime.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((formatDateTime(ts, '%Y%m%d') = '20251015'))
+(3 rows)
+
+SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+         ts          
+---------------------
+ 2025-10-15 13:12:25
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text))
+   Relations: Aggregate on (t5)
+   Remote SQL: SELECT formatDateTime(ts, '%Y-%m-%d %H:%i:%S') FROM functions_test.t5 GROUP BY (formatDateTime(ts, '%Y-%m-%d %H:%i:%S')) ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(4 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+          d          
+---------------------
+ 2025-10-15 20:12:25
+ 2026-11-17 08:13:26
+ 2027-12-17 22:14:27
+ 2028-01-18 23:15:28
+ 2029-02-19 01:16:29
+ 2030-03-20 02:16:30
+(6 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 
@@ -1443,7 +1585,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 7 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1451,3 +1593,5 @@ drop cascades to foreign table t3_map
 drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
+drop cascades to foreign table t8
+drop cascades to foreign table t9

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -309,6 +309,38 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
 
+-- check split_part → splitByString.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+SELECT val FROM t4 WHERE split_part(val, 'l', 2) = '1';
+
+-- check regexp_replace → replaceRegexpOne (no flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X') = 'valX';
+
+-- check regexp_replace → replaceRegexpAll ('g' flag).
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+SELECT val FROM t4 WHERE regexp_replace(val, '[0-9]', 'X', 'g') = 'valX';
+
+-- check array_to_string → arrayStringConcat.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (id UInt64, tags Array(String)) ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t8 VALUES (1, ['a','b','c']), (2, ['x'])$$);
+CREATE FOREIGN TABLE t8 (id bigint, tags text[]) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+SELECT array_to_string(tags, ', ') AS t FROM t8 GROUP BY t ORDER BY t;
+
+-- check concat_ws → arrayStringConcat with NULL filtering.
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t9 (id UInt64, city Nullable(String), state Nullable(String), country Nullable(String)) ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query($$INSERT INTO functions_test.t9 VALUES (1, 'Paris', NULL, 'France'), (2, 'London', 'England', 'UK')$$);
+CREATE FOREIGN TABLE t9 (id bigint, city text, state text, country text) SERVER functions_loopback;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+SELECT concat_ws(', ', city, state, country) AS addr FROM t9 GROUP BY addr ORDER BY addr;
+
+-- check to_char → formatDateTime.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+SELECT ts FROM t5 WHERE to_char(ts, 'YYYYMMDD') = '20251015';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS d FROM t5 GROUP BY d ORDER BY d;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;


### PR DESCRIPTION
## Summary

Add query pushdown for five PostgreSQL functions, eliminating local
evaluation for common string manipulation and date formatting patterns:

- **`split_part()`** → `splitByString()` with array indexing (arg reorder)
- **`regexp_replace()`** → `replaceRegexpOne()` / `replaceRegexpAll()` (flag-dependent)
- **`array_to_string()`** → `arrayStringConcat()`
- **`concat_ws()`** → `arrayStringConcat(arrayFilter(...))` with NULL filtering
- **`to_char()`** → `formatDateTime()` with PG→CH format string translation

These functions appear in roughly 25% of surveyed dbt models that
currently fall back to local evaluation.

Closes PG-132, PG-133, PG-134, PG-135.

## Test plan

- [ ] `make tempcheck` passes on local PG 18 + ClickHouse latest
- [ ] CI matrix passes across all supported ClickHouse versions (23.3–25.12)
- [ ] Verify pushdown via `EXPLAIN (VERBOSE, COSTS OFF)` for each function
- [ ] Edge cases: NULL args in `concat_ws`, `MI` vs `MM` ordering in `to_char`, flag variants in `regexp_replace`