### PR TITLE
Pushdown jsonb_extract_path_text and jsonb_extract_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ All notable changes to this project will be documented in this file. It uses the
 ### ⚡ Improvements
 
 *   Added mapping for the `JSON` and `JSONB` `-> TEXT` and `->> TEXT`
-    operators to be passed down to ClickHouse using its [sub-column syntax]
+    operators to be passed down to ClickHouse using its [sub-column syntax].
+    Thanks Kaushik Iska for the PR ([#169]).
+*   Added pushdown support for `jsonb_extract_path_text()` and
+    `jsonb_extract_path()` to ClickHouse [sub-column syntax]. Thanks Kaushik
+    Iska for the PR ([#176]).
 
 ### 📔 Notes
 
@@ -22,6 +26,10 @@ All notable changes to this project will be documented in this file. It uses the
   [v0.1.7]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.6...v0.1.7
   https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns
     "ClickHouse Docs: Reading JSON paths as sub-columns"
+  [#169]: https://github.com/ClickHouse/pg_clickhouse/pull/169
+    "pg_clickhouse#169 Push down jsonb -> and ->> operators as ClickHouse dot notation"
+  [#176]: https://github.com/ClickHouse/pg_clickhouse/pull/176
+    "pg_clickhouse#176 Pushdown jsonb_extract_path_text and jsonb_extract_path"
 
 ## [v0.1.6] — 2026-04-02
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -202,6 +202,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_MD5_BYTEA:
 			case F_MD5_TEXT:
 			case F_TO_TIMESTAMP_FLOAT8:
+			case F_JSONB_EXTRACT_PATH:
+			case F_JSONB_EXTRACT_PATH_TEXT:
 				special_builtin = true;
 				break;
 			default:
@@ -297,6 +299,18 @@ chfdw_check_for_custom_function(Oid funcid)
 					 */
 					strcpy(entry->custom_name, "fromUnixTimestamp(toInt64");
 					entry->paren_count = 2;
+					break;
+				}
+			case F_JSONB_EXTRACT_PATH_TEXT:
+				{
+					entry->cf_type = CF_JSONB_EXTRACT_PATH_TEXT;
+					entry->custom_name[0] = '\1';
+					break;
+				}
+			case F_JSONB_EXTRACT_PATH:
+				{
+					entry->cf_type = CF_JSONB_EXTRACT_PATH;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 		}

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -28,6 +28,7 @@
 #include "nodes/primnodes.h"
 #include "optimizer/tlist.h"
 #include "parser/parsetree.h"
+#include "utils/array.h"
 #include "utils/arrayaccess.h"
 #include "utils/builtins.h"
 #include "utils/catcache.h"
@@ -407,16 +408,38 @@ foreign_expr_walker(Node * node,
 				CustomObjectDef *cdef = NULL;
 				FuncExpr   *fe = (FuncExpr *) node;
 
-				/* not in ClickHouse */
-				if (fe->funcvariadic)
-					return false;
-
 				/*
 				 * If function used by the expression is not shippable, it
 				 * can't be sent to remote because it might have incompatible
 				 * semantics on remote side.
 				 */
 				if (!chfdw_is_shippable(fe->funcid, ProcedureRelationId, fpinfo, &cdef))
+					return false;
+
+				/*
+				 * jsonb_extract_path_text / jsonb_extract_path are always
+				 * presented by the planner in variadic form: two args where
+				 * the second is a text[] constant.  Allow them through the
+				 * variadic gate; only recurse on the column argument.
+				 */
+				if (cdef &&
+					(cdef->cf_type == CF_JSONB_EXTRACT_PATH_TEXT ||
+					 cdef->cf_type == CF_JSONB_EXTRACT_PATH))
+				{
+					if (list_length(fe->args) != 2 ||
+						!IsA(lsecond(fe->args), Const) ||
+						((Const *) lsecond(fe->args))->constisnull)
+						return false;
+
+					/* Only recurse on the column expression. */
+					if (!foreign_expr_walker((Node *) linitial(fe->args),
+											 glob_cxt, &inner_cxt))
+						return false;
+					break;
+				}
+
+				/* Other variadic functions are not in ClickHouse. */
+				if (fe->funcvariadic)
 					return false;
 
 				/*
@@ -2352,6 +2375,50 @@ deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context)
 }
 
 /*
+ * Deparse jsonb_extract_path_text() / jsonb_extract_path() into ClickHouse
+ * JSON dot notation.
+ *
+ *   jsonb_extract_path_text(col, 'k1', 'k2') → col."k1"."k2"
+ *   jsonb_extract_path(col, 'k1')            → toJSONString(col."k1")
+ *
+ * The planner presents these in variadic form: two args where the second
+ * is a text[] constant holding the path keys.
+ */
+static void
+deparseJsonbExtractPath(FuncExpr * node, deparse_expr_cxt * context,
+						bool wrap_json)
+{
+	StringInfo	buf = context->buf;
+	Const	   *arr = (Const *) lsecond(node->args);
+	ArrayType  *array;
+	Datum	   *elems;
+	bool	   *nulls;
+	int			nelems;
+
+	if (wrap_json)
+		appendStringInfoString(buf, "toJSONString(");
+
+	/* First arg is the JSONB column expression. */
+	deparseExpr((Expr *) linitial(node->args), context);
+
+	/* Second arg is text[] with path keys → dot notation. */
+	array = DatumGetArrayTypeP(arr->constvalue);
+	deconstruct_array(array, TEXTOID, -1, false, TYPALIGN_INT,
+					  &elems, &nulls, &nelems);
+
+	for (int i = 0; i < nelems; i++)
+	{
+		char	   *key = TextDatumGetCString(elems[i]);
+
+		appendStringInfoChar(buf, '.');
+		appendStringInfoString(buf, quote_identifier(key));
+	}
+
+	if (wrap_json)
+		appendStringInfoChar(buf, ')');
+}
+
+/*
  * Deparse a function call.
  */
 static void
@@ -2396,6 +2463,15 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 	 * Normal function: display as proname(args).
 	 */
 	cdef = appendFunctionName(node->funcid, context);
+
+	if (cdef && (cdef->cf_type == CF_JSONB_EXTRACT_PATH_TEXT ||
+				 cdef->cf_type == CF_JSONB_EXTRACT_PATH))
+	{
+		deparseJsonbExtractPath(node, context,
+								cdef->cf_type == CF_JSONB_EXTRACT_PATH);
+		return;
+	}
+
 	if (cdef && cdef->cf_type == CF_DATE_TRUNC)
 	{
 		Const	   *arg = (Const *) linitial(node->args);

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -302,6 +302,9 @@ typedef enum
 	CF_REGEX_ICASE_NO_MATCH,	/* !~* case-insensitive regex operator */
 	CF_JSONB_FETCHVAL,			/* -> operator on jsonb */
 	CF_JSONB_FETCHVAL_TEXT,		/* ->> operator on jsonb */
+	CF_JSONB_EXTRACT_PATH_TEXT, /* jsonb_extract_path_text() → col."k1"."k2" */
+	CF_JSONB_EXTRACT_PATH,		/* jsonb_extract_path() →
+								 * toJSONString(col."k1"."k2") */
 }			custom_object_type;
 
 typedef enum

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -180,6 +180,22 @@ chfdw_is_shippable(Oid objectId, Oid classId, CHFdwRelationInfo * fpinfo,
 			return (cdef->cf_type != CF_UNSHIPPABLE);
 	}
 
+	/*
+	 * For procedures, check for custom overrides before the builtin shortcut
+	 * so the caller gets the CustomObjectDef it needs for deparse.
+	 */
+	if (classId == ProcedureRelationId && chfdw_is_builtin(objectId))
+	{
+		CustomObjectDef *cdef = chfdw_check_for_custom_function(objectId);
+
+		if (cdef)
+		{
+			if (outcdef != NULL)
+				*outcdef = cdef;
+			return (cdef->cf_type != CF_UNSHIPPABLE);
+		}
+	}
+
 	/* Built-in objects are presumed shippable. */
 	if (chfdw_is_builtin(objectId))
 		return true;

--- a/test/expected/json.out
+++ b/test/expected/json.out
@@ -433,6 +433,129 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
    Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 (3 rows)
 
+-- =======================================================================
+-- jsonb_extract_path_text / jsonb_extract_path pushdown
+-- =======================================================================
+-- Create a table with nested JSON for multi-level path tests.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.events (
+        id         UInt32,
+        event_name String,
+        props      JSON
+    ) ENGINE = MergeTree ORDER BY (event_name, id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO json_test.events VALUES
+        (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
+        (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http_events (
+    id         integer,
+    event_name text,
+    props      jsonb
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+-- Target-list: jsonb_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: jsonb_extract_path (returns jsonb, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path(props, 'address') FROM json_http_events;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+-- WHERE: single-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: jsonb_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((toJSONString(props.address.city) = '"Paris"'))
+(3 rows)
+
+DROP FOREIGN TABLE json_http_events;
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/json_1.out
+++ b/test/expected/json_1.out
@@ -390,6 +390,129 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
    Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 (3 rows)
 
+-- =======================================================================
+-- jsonb_extract_path_text / jsonb_extract_path pushdown
+-- =======================================================================
+-- Create a table with nested JSON for multi-level path tests.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.events (
+        id         UInt32,
+        event_name String,
+        props      JSON
+    ) ENGINE = MergeTree ORDER BY (event_name, id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO json_test.events VALUES
+        (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
+        (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http_events (
+    id         integer,
+    event_name text,
+    props      jsonb
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+-- Target-list: jsonb_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: jsonb_extract_path (returns jsonb, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path(props, 'address') FROM json_http_events;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+-- WHERE: single-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: jsonb_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((toJSONString(props.address.city) = '"Paris"'))
+(3 rows)
+
+DROP FOREIGN TABLE json_http_events;
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/json_2.out
+++ b/test/expected/json_2.out
@@ -433,6 +433,129 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
    Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 (3 rows)
 
+-- =======================================================================
+-- jsonb_extract_path_text / jsonb_extract_path pushdown
+-- =======================================================================
+-- Create a table with nested JSON for multi-level path tests.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.events (
+        id         UInt32,
+        event_name String,
+        props      JSON
+    ) ENGINE = MergeTree ORDER BY (event_name, id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO json_test.events VALUES
+        (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
+        (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http_events (
+    id         integer,
+    event_name text,
+    props      jsonb
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+-- Target-list: jsonb_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events ORDER BY id;
+ jsonb_extract_path_text 
+-------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: jsonb_extract_path (returns jsonb, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path(props, 'address') FROM json_http_events;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+-- WHERE: single-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: jsonb_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((toJSONString(props.address.city) = '"Paris"'))
+(3 rows)
+
+DROP FOREIGN TABLE json_http_events;
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -314,6 +314,123 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
    Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 (3 rows)
 
+-- =======================================================================
+-- jsonb_extract_path_text / jsonb_extract_path pushdown
+-- =======================================================================
+-- Create a table with nested JSON for multi-level path tests.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.events (
+        id         UInt32,
+        event_name String,
+        props      JSON
+    ) ENGINE = MergeTree ORDER BY (event_name, id);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO json_test.events VALUES
+        (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
+        (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE json_http_events (
+    id         integer,
+    event_name text,
+    props      jsonb
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+-- Target-list: jsonb_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+-- Target-list: jsonb_extract_path (returns jsonb, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path(props, 'address') FROM json_http_events;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: jsonb_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+-- WHERE: single-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: jsonb_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.json_http_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((toJSONString(props.address.city) = '"Paris"'))
+(3 rows)
+
+DROP FOREIGN TABLE json_http_events;
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/sql/json.sql
+++ b/test/sql/json.sql
@@ -164,6 +164,65 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
 
+-- =======================================================================
+-- jsonb_extract_path_text / jsonb_extract_path pushdown
+-- =======================================================================
+
+-- Create a table with nested JSON for multi-level path tests.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE json_test.events (
+        id         UInt32,
+        event_name String,
+        props      JSON
+    ) ENGINE = MergeTree ORDER BY (event_name, id);
+$$);
+SELECT clickhouse_raw_query($$
+    INSERT INTO json_test.events VALUES
+        (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
+        (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
+$$);
+
+CREATE FOREIGN TABLE json_http_events (
+    id         integer,
+    event_name text,
+    props      jsonb
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+
+-- Target-list: jsonb_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events;
+SELECT jsonb_extract_path_text(props, 'customerId') FROM json_http_events ORDER BY id;
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events;
+SELECT jsonb_extract_path_text(props, 'address', 'city') FROM json_http_events ORDER BY id;
+
+-- Target-list: jsonb_extract_path (returns jsonb, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT jsonb_extract_path(props, 'address') FROM json_http_events;
+
+-- WHERE: single-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'customerId') = 'C100';
+
+-- WHERE: multi-level jsonb_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path_text(props, 'address', 'city') = 'Paris';
+
+-- WHERE: jsonb_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http_events
+WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+
+DROP FOREIGN TABLE json_http_events;
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;


### PR DESCRIPTION
## Summary

- Adds pushdown support for `jsonb_extract_path_text()` and `jsonb_extract_path()` to ClickHouse JSON dot notation (`col."k1"."k2"` / `toJSONString(col."k1")`)
- Fixes `chfdw_is_shippable` to populate `outcdef` for custom builtin functions before the generic builtin shortcut
- Handles PostgreSQL's variadic rewriting (path keys collapsed into a `text[]` constant) by special-casing these functions before the variadic gate

## Test plan

- [x] `make tempcheck` passes on PG 18 + latest ClickHouse (json test passes)
- [ ] CI validates PG 13–17 expected output variants (`json_1.out`)
- [ ] CI validates older ClickHouse expected output variants (`json_2.out`, `json_3.out`)

Resolves https://linear.app/clickhouse/issue/PG-131