### PR TITLE
pglink.c: handle OOM preventing error being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to this project will be documented in this file. It uses the
     `jsonb_extract_path()` to ClickHouse [sub-column syntax]. Thanks Kaushik
     Iska for the PR ([#176]).
 
+### 🪲 Bug Fixes
+
+*   Improved memory management, fixing potential crashes in out of memory
+    situations. Thanks to Philip Dubé for the PRs ([#173], [#173]).
+
 ### 📔 Notes
 
 *   Eliminated use of a constant that required libcurl 7.87.0, restoring
@@ -30,6 +35,10 @@ All notable changes to this project will be documented in this file. It uses the
     "pg_clickhouse#169 Push down jsonb -> and ->> operators as ClickHouse dot notation"
   [#176]: https://github.com/ClickHouse/pg_clickhouse/pull/176
     "pg_clickhouse#176 Pushdown jsonb_extract_path_text and jsonb_extract_path"
+  [#173]: https://github.com/ClickHouse/pg_clickhouse/pull/173
+    "pg_clickhouse#173 ch_http_simple_query: return NULL on OOM"
+  [#178]: https://github.com/ClickHouse/pg_clickhouse/pull/178
+    "pg_clickhouse#178 pglink.c: handle OOM preventing error being set"
 
 ## [v0.1.6] — 2026-04-02
 

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -196,7 +196,11 @@ http_simple_query(void *conn, const ch_query * query)
 again:
 	resp = ch_http_simple_query(conn, query);
 	if (resp == NULL)
-		elog(ERROR, "out of memory");
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
+				 errmsg("out of memory")));
+	}
 
 	attempts++;
 	if (resp->http_status == 419)
@@ -614,14 +618,22 @@ chfdw_binary_connect(ch_connection_details * details)
 
 	if (conn == NULL)
 	{
-		Assert(ch_error);
-		char	   *error = pstrdup(ch_error);
+		if (ch_error == NULL)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FDW_OUT_OF_MEMORY),
+					 errmsg("out of memory")));
+		}
+		else
+		{
+			char	   *error = pstrdup(ch_error);
 
-		free(ch_error);
+			free(ch_error);
 
-		ereport(ERROR,
-				(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-				 errmsg("pg_clickhouse: connection error: %s", error)));
+			ereport(ERROR,
+					(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+					 errmsg("pg_clickhouse: connection error: %s", error)));
+		}
 	}
 
 	res.conn = conn;


### PR DESCRIPTION
`Assert(ch_error)` is incorrect since it's sourced from `strdup(e.what())`