### PR TITLE
Fix flaky -Merge combinator on AggregateFunction columns

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -593,7 +593,30 @@ foreign_expr_walker(Node * node,
 						return false;
 
 					if (inner_cxt.found_AggregateFunction)
-						agg->location = -2;
+					{
+						/*
+						 * Record in fpinfo so deparseAggref appends the
+						 * -Merge combinator.  Walk down the relation chain to
+						 * store in every fpinfo (current, outer,
+						 * outer-of-outer …) so deparseAggref always finds
+						 * it regardless of which rel is used as scanrel.
+						 */
+						RelOptInfo *r = glob_cxt->foreignrel;
+
+						while (r != NULL)
+						{
+							CHFdwRelationInfo *fi =
+								(CHFdwRelationInfo *) r->fdw_private;
+
+							if (!list_member_oid(fi->merge_agg_oids,
+												 agg->aggfnoid))
+								fi->merge_agg_oids =
+									lappend_oid(fi->merge_agg_oids,
+												agg->aggfnoid);
+
+							r = fi->outerrel;
+						}
+					}
 
 					/* Prevent propagating to earlier nodes. */
 					inner_cxt.found_AggregateFunction = false;
@@ -3185,6 +3208,7 @@ appendAggOrderBy(List * orderList, List * targetList, deparse_expr_cxt * context
 	}
 }
 
+
 /*
  * Deparse an Aggref node.
  */
@@ -3214,8 +3238,12 @@ deparseAggref(Aggref * node, deparse_expr_cxt * context)
 	if (context->func && context->func->cf_type == CF_SIGN_COUNT && !node->aggstar)
 		sign_count_filter = true;
 
-	/* We use this field as indicator of aggregate functions */
-	if (node->location == -2)
+	/*
+	 * Append -Merge combinator if this aggregate operates on a ClickHouse
+	 * AggregateFunction column.  The walker records qualifying aggfnoids in
+	 * fpinfo->merge_agg_oids during the shippability check.
+	 */
+	if (list_member_oid(fpinfo->merge_agg_oids, node->aggfnoid))
 		appendStringInfoString(buf, "Merge");
 
 	if (node->aggfilter || sign_count_filter)

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -208,6 +208,13 @@ typedef struct CHFdwRelationInfo
 	CHRemoteTableEngine ch_table_engine;
 
 	/*
+	 * Set of aggregate function OIDs that need the -Merge combinator because
+	 * their args reference AggregateFunction columns. Populated during
+	 * foreign_expr_walker, read during deparseAggref.
+	 */
+	List	   *merge_agg_oids; /* List of Oid values */
+
+	/*
 	 * Long enough for a quoted identifier with all but two characters
 	 * escaped.
 	 */


### PR DESCRIPTION
## Summary

Aggregates on ClickHouse `AggregateFunction` columns (e.g. `percentile_cont` on a `quantile` state column) must use the `-Merge` combinator in pushed-down SQL (`quantileMerge(…)` instead of `quantile(…)`).

The existing mechanism is a side-channel hack: `foreign_expr_walker` sets `agg->location = -2`, and `deparseAggref` checks that sentinel. This is **flaky** because PostgreSQL's planner can copy the `Aggref` node *before* the walker runs. When the planner picks the copy for the final plan, its `location` field still holds the original SQL offset, so `deparseAggref` never appends `Merge`. Which plan wins is non-deterministic, producing intermittent failures in the `engines` regression test:

```
-   Remote SQL: SELECT a, quantileMerge(0.75)(f) FROM engines_test.t4 GROUP BY a
+   Remote SQL: SELECT a, quantile(0.75)(f) FROM engines_test.t4 GROUP BY a
```

### Fix

- Add `merge_agg_oids` (a `List` of `Oid`) to `CHFdwRelationInfo`.
- During `foreign_expr_walker`, when an aggregate on an `AggregateFunction` column is found, record its `aggfnoid` in every fpinfo in the relation chain (upper rel → base scan rel).
- In `deparseAggref`, check the fpinfo list in addition to the legacy `location == -2` marker.

This ensures the `-Merge` decision survives regardless of which `Aggref` copy the planner selects.

## Test plan

- [x] Ran `pgch test` (full 26-cell matrix across PG 13–18 × CH 23.3–26.3 × dso/static) 5 consecutive times with `--no-cache` — all 130 runs passed (0 failures).
- [x] Previously reproduced the flake reliably (~1 in 3 full-matrix runs) and confirmed the fix eliminates it.