### PR TITLE
Support more array functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to this project will be documented in this file. It uses the
     prepending them to the regular expression (e.g., `(?i)foo`).
 *   Added pushdown for `regexp_split_to_array()` to `splitByRegexp()`,
     including flags.
+*   Added pushdown mappings for array functions: `array_cat`, `array_append`,
+    `array_remove`, `array_to_string`, `cardinality`, `array_length`,
+    `array_prepend`, `string_to_array`, `trim_array`, `array_fill`,
+    `array_reverse`, `array_shuffle`, `array_sample`, `array_sort`.
+*   Added pushdown for array operators: `@>` (`hasAll`), `<@` (`hasAll`),
+    `&&` (`hasAny`).
+*   Array slice syntax (`arr[L:U]`, `arr[:U]`, `arr[L:]`) now pushes down
+    as `arraySlice()`.
 
 ### ⬆️ Dependency Updates
 
@@ -39,6 +47,10 @@ All notable changes to this project will be documented in this file. It uses the
     unable to map a ClickHouse type to a Postgres type.
 *   Fixed reversal of the arguments passed to the ClickHouse `match()`
     function by the mapping from `regexp_like()`.
+*   `array_dims`, `array_ndims`, `array_lower`, `array_upper`, `array_replace`,
+    `array_positions`, `array_fill (3-arg)`, `array_sort (3-arg)`, and
+    `string_to_array(3-arg)` now evaluate locally instead of being pushed to
+    ClickHouse where they would fail.
 
   [v0.1.11]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.10...v0.1.11
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -287,13 +287,13 @@ Use [CREATE FOREIGN TABLE] to create a foreign table that can query data from
 a ClickHouse database:
 
 ```sql
-CREATE FOREIGN TABLE uact (
+CREATE FOREIGN TABLE acts (
     user_id    bigint NOT NULL,
     page_views int,
     duration   smallint,
     sign       smallint
 ) SERVER taxi_srv OPTIONS(
-    table_name 'uact',
+    table_name 'acts',
     engine 'CollapsingMergeTree'
 );
 ```
@@ -325,8 +325,6 @@ option:
 
 Example:
 
-(aggregatefunction 'sum')
-
 ```sql
 CREATE FOREIGN TABLE test (
     column1 bigint  OPTIONS(AggregateFunction 'uniq'),
@@ -354,14 +352,14 @@ TABLE].
 Use [DROP FOREIGN TABLE] to remove a foreign table:
 
 ```sql
-DROP FOREIGN TABLE uact;
+DROP FOREIGN TABLE acts;
 ```
 
 This command fails if there are any objects that depend on the foreign table.
 Use the `CASCADE` clause to drop them, too:
 
 ```sql
-DROP FOREIGN TABLE uact CASCADE;
+DROP FOREIGN TABLE acts CASCADE;
 ```
 
 ## DML SQL Reference
@@ -422,7 +420,7 @@ like any other tables:
 try=# SELECT start_at, duration, resource FROM logs WHERE req_id = 4117909262;
           start_at          | duration |    resource
 ----------------------------+----------+----------------
- 2025-12-05 15:07:32.944188 |      175 | /widgets/totam
+ 2025-12-05 15:07:32.944188 |      175 | /widgets/totem
 (1 row)
 ```
 
@@ -922,7 +920,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM texts ORDER B
 
 The text columns will be correct:
 
-```pgdsql
+```pgsql
 
  c1 |                          encode                          |              encode
 ----+----------------------------------------------------------+----------------------------------
@@ -1029,6 +1027,19 @@ maps the following functions:
     *   `date_trunc('quarter')`: [toStartOfQuarter](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfQuarter)
     *   `date_trunc('year')`: [toStartOfYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfYear)
 *   `array_position`: [indexOf](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf)
+*   `array_cat`: [arrayConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayConcat)
+*   `array_append`: [arrayPushBack](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushBack)
+*   `array_prepend`: [arrayPushFront](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushFront)
+*   `array_remove`: [arrayRemove](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRemove)
+*   `array_length` & `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
+*   `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayStringConcat)
+*   `string_to_array`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString)
+*   `trim_array`: [arrayResize](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayResize)
+*   `array_fill`: [arrayWithConstant](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayWithConstant)
+*   `array_reverse`: [arrayReverse](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverse)
+*   `array_shuffle`: [arrayShuffle](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayShuffle)
+*   `array_sample`: [arrayRandomSample](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRandomSample)
+*   `array_sort`: [arraySort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySort) / [arrayReverseSort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverseSort)
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 *   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
@@ -1055,6 +1066,19 @@ maps the following functions:
 *   `USER`: Passed as value from PostgreSQL function.
 *   `CURRENT_ROLE`: Passed as value from PostgreSQL function.
 *   `SESSION_USER`: Passed as value from PostgreSQL function.
+
+### Pushdown Operators
+
+*   Array slice (`arr[L:U]`): [arraySlice](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySlice)
+*   `@>` (array contains): [hasAll](https://clickhouse.com/docs/sql-reference/functions/array-functions#hasAll)
+*   `<@` (array contained by): [hasAll](https://clickhouse.com/docs/sql-reference/functions/array-functions#hasAll)
+*   `&&` (array overlap): [hasAny](https://clickhouse.com/docs/sql-reference/functions/array-functions#hasAny)
+*   `~` (regexp match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `!~` (regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `~*` (case insensitive regexp no match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `!~*` (case insensitive regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `->` (JSON extract element): [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `->>` (JSON extract element as text): [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 
 ### Custom Functions
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -4,6 +4,7 @@
 #include "access/htup.h"
 #include "access/htup_details.h"
 #include "catalog/dependency.h"
+#include "catalog/pg_operator_d.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
@@ -50,11 +51,31 @@
 #define F_EXTRACT_TEXT_TIMESTAMP 6202
 #define F_EXTRACT_TEXT_TIMESTAMPTZ 6203
 #define F_EXTRACT_TEXT_DATE 6199
+#define F_TRIM_ARRAY 6172
+#define F_STRING_TO_ARRAY_TEXT_TEXT 394
+#define F_STRING_TO_ARRAY_TEXT_TEXT_TEXT 376
+#define F_ARRAY_TO_STRING_ANYARRAY_TEXT 395
+#define F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT 384
+#define F_ARRAY_FILL_ANYELEMENT__INT4 F_ARRAY_FILL
+#define F_ARRAY_FILL_ANYELEMENT__INT4__INT4 F_ARRAY_FILL_WITH_LOWER_BOUNDS
+#define F_CARDINALITY F_ARRAY_CARDINALITY
 #endif
-/* regexp_like was added in Postgres 15; Mock it for earlier versions. */
+/* regexp_like was added in Postgres 15 */
 #if PG_VERSION_NUM < 150000
 #define F_REGEXP_LIKE_TEXT_TEXT 6263
 #define F_REGEXP_LIKE_TEXT_TEXT_TEXT 6264
+#endif
+/* array_shuffle, array_sample added in Postgres 16 */
+#if PG_VERSION_NUM < 160000
+#define F_ARRAY_SHUFFLE 6215
+#define F_ARRAY_SAMPLE 6216
+#endif
+/* array_reverse, array_sort added in Postgres 18 */
+#if PG_VERSION_NUM < 180000
+#define F_ARRAY_REVERSE 6381
+#define F_ARRAY_SORT_ANYARRAY 6388
+#define F_ARRAY_SORT_ANYARRAY_BOOL 6389
+#define F_ARRAY_SORT_ANYARRAY_BOOL_BOOL 6390
 #endif
 
 #define STR_STARTS_WITH(str, sub) strncmp(str, sub, strlen(sub)) == 0
@@ -217,6 +238,34 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_CLOCK_TIMESTAMP:
 			case F_CURRENT_SCHEMA:
 			case F_CURRENT_DATABASE:
+				/* array functions: simple mappings */
+			case F_ARRAY_CAT:
+			case F_ARRAY_APPEND:
+			case F_ARRAY_REMOVE:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT:
+			case F_CARDINALITY:
+			case F_ARRAY_REVERSE:
+			case F_ARRAY_SORT_ANYARRAY:
+			case F_ARRAY_SHUFFLE:
+			case F_ARRAY_SAMPLE:
+				/* array functions: arg rewriting */
+			case F_ARRAY_LENGTH:
+			case F_ARRAY_PREPEND:
+			case F_STRING_TO_ARRAY_TEXT_TEXT:
+			case F_TRIM_ARRAY:
+			case F_ARRAY_FILL_ANYELEMENT__INT4:
+			case F_ARRAY_SORT_ANYARRAY_BOOL:
+				/* array functions: unshippable */
+			case F_ARRAY_DIMS:
+			case F_ARRAY_NDIMS:
+			case F_ARRAY_LOWER:
+			case F_ARRAY_UPPER:
+			case F_ARRAY_REPLACE:
+			case F_ARRAY_POSITIONS:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
+			case F_STRING_TO_ARRAY_TEXT_TEXT_TEXT:
+			case F_ARRAY_FILL_ANYELEMENT__INT4__INT4:
+			case F_ARRAY_SORT_ANYARRAY_BOOL_BOOL:
 				special_builtin = true;
 				break;
 			default:
@@ -363,6 +412,69 @@ chfdw_check_for_custom_function(Oid funcid)
 					entry->custom_name[0] = '\1';
 					break;
 				}
+				/* array functions: unshippable */
+			case F_ARRAY_DIMS:
+			case F_ARRAY_NDIMS:
+			case F_ARRAY_LOWER:
+			case F_ARRAY_UPPER:
+			case F_ARRAY_REPLACE:
+			case F_ARRAY_POSITIONS:
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
+			case F_STRING_TO_ARRAY_TEXT_TEXT_TEXT:
+			case F_ARRAY_FILL_ANYELEMENT__INT4__INT4:
+			case F_ARRAY_SORT_ANYARRAY_BOOL_BOOL:
+				entry->cf_type = CF_UNSHIPPABLE;
+				break;
+				/* array functions: simple mappings */
+			case F_ARRAY_CAT:
+				strcpy(entry->custom_name, "arrayConcat");
+				break;
+			case F_ARRAY_APPEND:
+				strcpy(entry->custom_name, "arrayPushBack");
+				break;
+			case F_ARRAY_REMOVE:
+				strcpy(entry->custom_name, "arrayRemove");
+				break;
+			case F_ARRAY_TO_STRING_ANYARRAY_TEXT:
+				strcpy(entry->custom_name, "arrayStringConcat");
+				break;
+			case F_CARDINALITY:
+			case F_ARRAY_LENGTH:
+				entry->cf_type = CF_ARRAY_LENGTH;
+				strcpy(entry->custom_name, "length");
+				break;
+			case F_ARRAY_REVERSE:
+				strcpy(entry->custom_name, "arrayReverse");
+				break;
+			case F_ARRAY_SORT_ANYARRAY:
+				strcpy(entry->custom_name, "arraySort");
+				break;
+			case F_ARRAY_SHUFFLE:
+				strcpy(entry->custom_name, "arrayShuffle");
+				break;
+			case F_ARRAY_SAMPLE:
+				strcpy(entry->custom_name, "arrayRandomSample");
+				break;
+			case F_ARRAY_PREPEND:
+				entry->cf_type = CF_ARRAY_PREPEND;
+				strcpy(entry->custom_name, "arrayPushFront");
+				break;
+			case F_STRING_TO_ARRAY_TEXT_TEXT:
+				entry->cf_type = CF_STRING_TO_ARRAY;
+				strcpy(entry->custom_name, "splitByString");
+				break;
+			case F_TRIM_ARRAY:
+				entry->cf_type = CF_TRIM_ARRAY;
+				strcpy(entry->custom_name, "arrayResize");
+				break;
+			case F_ARRAY_FILL_ANYELEMENT__INT4:
+				entry->cf_type = CF_ARRAY_FILL;
+				strcpy(entry->custom_name, "arrayWithConstant");
+				break;
+			case F_ARRAY_SORT_ANYARRAY_BOOL:
+				entry->cf_type = CF_ARRAY_SORT_DESC;
+				entry->custom_name[0] = '\1';
+				break;
 		}
 
 		if (special_builtin)
@@ -426,39 +538,42 @@ chfdw_check_for_custom_type(Oid typeoid)
 	return entry;
 }
 
-/*
- * Operator-name to custom_object_type mapping table, searched linearly by
- * classify_builtin_operator().  Keep in sync with the CF_* enum in fdw.h.
- */
-typedef struct
-{
-	const char *oprname;
-	custom_object_type ctype;
-}			BuiltinOperatorMap;
-
-static const BuiltinOperatorMap builtin_operator_map[] = {
-	{"~", CF_REGEX_MATCH},
-	{"!~", CF_REGEX_NO_MATCH},
-	{"~*", CF_REGEX_ICASE_MATCH},
-	{"!~*", CF_REGEX_ICASE_NO_MATCH},
-	{"->", CF_JSONB_FETCHVAL},
-	{"->>", CF_JSONB_FETCHVAL_TEXT},
-};
+/* pg_operator_d.h only has oid_symbol for some operators */
+#define OID_TEXT_REGEX_NE_OP		642
+#define OID_TEXT_IREGEX_NE_OP		1229
+#define OID_JSONB_FETCHVAL_OP		3211
+#define OID_JSONB_FETCHVAL_TEXT_OP	3477
 
 /*
- * Map a builtin operator name to its custom_object_type.  Returns CF_USUAL
- * when the operator needs no special handling and should follow the normal
- * builtin shortcut (i.e. be presumed shippable with no rewrite).
+ * Map a builtin operator OID to its custom_object_type. Returns CF_USUAL
+ * when the operator needs no special handling.
  */
 static custom_object_type
-classify_builtin_operator(const char *oprname)
+classify_builtin_operator(Oid opoid)
 {
-	for (int i = 0; i < lengthof(builtin_operator_map); i++)
+	switch (opoid)
 	{
-		if (strcmp(oprname, builtin_operator_map[i].oprname) == 0)
-			return builtin_operator_map[i].ctype;
+		case OID_TEXT_REGEXEQ_OP:
+			return CF_REGEX_MATCH;
+		case OID_TEXT_REGEX_NE_OP:
+			return CF_REGEX_NO_MATCH;
+		case OID_TEXT_ICREGEXEQ_OP:
+			return CF_REGEX_ICASE_MATCH;
+		case OID_TEXT_IREGEX_NE_OP:
+			return CF_REGEX_ICASE_NO_MATCH;
+		case OID_JSONB_FETCHVAL_OP:
+			return CF_JSONB_FETCHVAL;
+		case OID_JSONB_FETCHVAL_TEXT_OP:
+			return CF_JSONB_FETCHVAL_TEXT;
+		case OID_ARRAY_CONTAINS_OP:
+			return CF_ARRAY_CONTAINS;
+		case OID_ARRAY_CONTAINED_OP:
+			return CF_ARRAY_CONTAINED_BY;
+		case OID_ARRAY_OVERLAP_OP:
+			return CF_ARRAY_OVERLAP;
+		default:
+			return CF_USUAL;
 	}
-	return CF_USUAL;
 }
 
 CustomObjectDef *
@@ -474,31 +589,10 @@ chfdw_check_for_custom_operator(Oid opoid, Form_pg_operator form)
 
 	if (chfdw_is_builtin(opoid))
 	{
-		switch (opoid)
+		ctype = classify_builtin_operator(opoid);
+		if (ctype == CF_USUAL && opoid != F_TIMESTAMPTZ_PL_INTERVAL)
 		{
-				/* timestamptz + interval */
-			case F_TIMESTAMPTZ_PL_INTERVAL:
-				break;
-			default:
-
-				/* Look up the operator name so we can classify it. */
-				if (!form)
-				{
-					tuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(opoid));
-					if (!HeapTupleIsValid(tuple))
-						ereport(ERROR,
-								errcode(ERRCODE_INTERNAL_ERROR),
-								errmsg("pg_clickhouse: cache lookup failed for operator %u", opoid));
-					form = (Form_pg_operator) GETSTRUCT(tuple);
-				}
-
-				ctype = classify_builtin_operator(NameStr(form->oprname));
-				if (ctype != CF_USUAL)
-					break;		/* fall through to cache + classify below */
-
-				if (tuple)
-					ReleaseSysCache(tuple);
-				return NULL;
+			return NULL;
 		}
 	}
 
@@ -516,10 +610,11 @@ chfdw_check_for_custom_operator(Oid opoid, Form_pg_operator form)
 		entry = hash_search(custom_objects_cache, (void *) &opoid, HASH_ENTER, NULL);
 		init_custom_entry(entry);
 
+		ctype = classify_builtin_operator(opoid);
 		if (opoid == F_TIMESTAMPTZ_PL_INTERVAL)
 			entry->cf_type = CF_TIMESTAMPTZ_PL_INTERVAL;
-		else if (form && classify_builtin_operator(NameStr(form->oprname)) != CF_USUAL)
-			entry->cf_type = classify_builtin_operator(NameStr(form->oprname));
+		else if (ctype != CF_USUAL)
+			entry->cf_type = ctype;
 		else
 		{
 			Oid			extoid = getExtensionOfObject(OperatorRelationId, opoid);

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2382,45 +2382,56 @@ static void
 deparseSubscriptingRef(SubscriptingRef * node, deparse_expr_cxt * context)
 {
 	StringInfo	buf = context->buf;
-	ListCell   *lowlist_item;
-	ListCell   *uplist_item;
 
-	/* Always parenthesize the expression. */
-	appendStringInfoChar(buf, '(');
-
-	/*
-	 * Deparse referenced array expression first. If that expression includes
-	 * a cast, we have to parenthesize to prevent the array subscript from
-	 * being taken as typename decoration. We can avoid that in the typical
-	 * case of subscripting a Var, but otherwise do it.
-	 */
-	if (IsA(node->refexpr, Var))
+	if (node->reflowerindexpr != NIL)
 	{
+		/*
+		 * Slice: CH doesn't support [L:U] syntax, emit arraySlice(). PG slice
+		 * is inclusive both ends, CH arraySlice takes (arr, offset, length).
+		 * Only 1D arrays are supported (enforced elsewhere).
+		 */
+		Expr	   *lower = (Expr *) linitial(node->reflowerindexpr);
+		Expr	   *upper = (Expr *) linitial(node->refupperindexpr);
+
+		appendStringInfoString(buf, "arraySlice(");
 		deparseExpr(node->refexpr, context);
+		appendStringInfoString(buf, ", ");
+
+		if (lower)
+			deparseExpr(lower, context);
+		else
+			appendStringInfoChar(buf, '1');
+
+		if (upper)
+		{
+			appendStringInfoString(buf, ", (");
+			deparseExpr(upper, context);
+			appendStringInfoString(buf, ") - (");
+			if (lower)
+				deparseExpr(lower, context);
+			else
+				appendStringInfoChar(buf, '1');
+			appendStringInfoString(buf, ") + 1");
+		}
+
+		appendStringInfoChar(buf, ')');
 	}
 	else
 	{
+		/* Single element: emit arr[idx] */
 		appendStringInfoChar(buf, '(');
-		deparseExpr(node->refexpr, context);
-		appendStringInfoChar(buf, ')');
-	}
-
-	/* Deparse subscript expressions. */
-	lowlist_item = list_head(node->reflowerindexpr);	/* could be NULL */
-	foreach(uplist_item, node->refupperindexpr)
-	{
-		appendStringInfoChar(buf, '[');
-		if (lowlist_item)
+		if (IsA(node->refexpr, Var))
+			deparseExpr(node->refexpr, context);
+		else
 		{
-			deparseExpr(lfirst(lowlist_item), context);
-			appendStringInfoChar(buf, ':');
-			lowlist_item = lnext_compat(node->reflowerindexpr, lowlist_item);
+			appendStringInfoChar(buf, '(');
+			deparseExpr(node->refexpr, context);
+			appendStringInfoChar(buf, ')');
 		}
-		deparseExpr(lfirst(uplist_item), context);
-		appendStringInfoChar(buf, ']');
+		appendStringInfoChar(buf, '[');
+		deparseExpr((Expr *) linitial(node->refupperindexpr), context);
+		appendStringInfoString(buf, "])");
 	}
-
-	appendStringInfoChar(buf, ')');
 }
 
 /*
@@ -2537,8 +2548,20 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 	}
 
 	/*
-	 * Normal function: display as proname(args).
+	 * Normal function: display as proname(args). CF_ARRAY_SORT_DESC name
+	 * depends on boolean arg, resolve before printing.
 	 */
+	cdef = chfdw_check_for_custom_function(node->funcid);
+	if (cdef && cdef->cf_type == CF_ARRAY_SORT_DESC)
+	{
+		Expr	   *desc_arg = (Expr *) list_nth(node->args, 1);
+
+		if (IsA(desc_arg, Const) && !((Const *) desc_arg)->constisnull
+			&& DatumGetBool(((Const *) desc_arg)->constvalue))
+			strcpy(cdef->custom_name, "arrayReverseSort");
+		else
+			strcpy(cdef->custom_name, "arraySort");
+	}
 	cdef = appendFunctionName(node->funcid, context);
 
 	if (cdef)
@@ -2676,6 +2699,8 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					return;
 				}
 			case CF_TIMEZONE:
+			case CF_ARRAY_PREPEND:
+			case CF_STRING_TO_ARRAY:
 				{
 					/* Arguments are reversed. */
 					appendStringInfoChar(buf, '(');
@@ -2705,6 +2730,35 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					appendStringInfoChar(buf, ')');
 					return;
 				}
+			case CF_ARRAY_LENGTH:
+				appendStringInfoChar(buf, '(');
+				deparseExpr((Expr *) linitial(node->args), context);
+				appendStringInfoChar(buf, ')');
+				return;
+			case CF_TRIM_ARRAY:
+				/* arrayResize(arr, length(arr) - n) */
+				appendStringInfoChar(buf, '(');
+				deparseExpr((Expr *) linitial(node->args), context);
+				appendStringInfoString(buf, ", length(");
+				deparseExpr((Expr *) linitial(node->args), context);
+				appendStringInfoString(buf, ") - ");
+				deparseExpr((Expr *) list_nth(node->args, 1), context);
+				appendStringInfoChar(buf, ')');
+				return;
+			case CF_ARRAY_SORT_DESC:
+				/* name resolved before appendFunctionName, drop boolean arg */
+				appendStringInfoChar(buf, '(');
+				deparseExpr((Expr *) linitial(node->args), context);
+				appendStringInfoChar(buf, ')');
+				return;
+			case CF_ARRAY_FILL:
+				/* arrayWithConstant(n, val): swap args */
+				appendStringInfoChar(buf, '(');
+				deparseExpr((Expr *) list_nth(node->args, 1), context);
+				appendStringInfoString(buf, ", ");
+				deparseExpr((Expr *) linitial(node->args), context);
+				appendStringInfoChar(buf, ')');
+				return;
 			default:
 				break;
 		}
@@ -3023,6 +3077,36 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 						elog(ERROR, "pg_clickhouse supports hstore fetchval "
 							 "only for scalars");
 
+					goto cleanup;
+				}
+				break;
+			case CF_ARRAY_CONTAINS:
+				{
+					appendStringInfoString(buf, "hasAll(");
+					deparseExpr(linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr(lsecond(node->args), context);
+					appendStringInfoChar(buf, ')');
+					goto cleanup;
+				}
+				break;
+			case CF_ARRAY_CONTAINED_BY:
+				{
+					appendStringInfoString(buf, "hasAll(");
+					deparseExpr(lsecond(node->args), context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr(linitial(node->args), context);
+					appendStringInfoChar(buf, ')');
+					goto cleanup;
+				}
+				break;
+			case CF_ARRAY_OVERLAP:
+				{
+					appendStringInfoString(buf, "hasAny(");
+					deparseExpr(linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr(lsecond(node->args), context);
+					appendStringInfoChar(buf, ')');
 					goto cleanup;
 				}
 				break;

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -316,6 +316,19 @@ typedef enum
 	CF_CURRENT_DATABASE,		/* CURRENT_DATABASE → string literal */
 	CF_CURRENT_SCHEMA,			/* CF_CURRENT_SCHEMA → string literal */
 	CF_CLOCK_TIMESTAMP,			/* clock_timestamp → nowInBlock64(6, $TZ) */
+	CF_ARRAY_LENGTH,			/* array_length → length, drop dim arg */
+	CF_ARRAY_PREPEND,			/* array_prepend → arrayPushFront, swap args */
+	CF_STRING_TO_ARRAY,			/* string_to_array → splitByString, swap
+								 * args */
+	CF_TRIM_ARRAY,				/* trim_array → arrayResize(arr,
+								 * length(arr)-n) */
+	CF_ARRAY_SORT_DESC,			/* array_sort(arr,desc) →
+								 * arrayReverseSort/arraySort */
+	CF_ARRAY_FILL,				/* array_fill → arrayWithConstant,
+								 * swap+extract */
+	CF_ARRAY_CONTAINS,			/* @> → hasAll(left, right) */
+	CF_ARRAY_CONTAINED_BY,		/* <@ → hasAll(right, left) */
+	CF_ARRAY_OVERLAP,			/* && → hasAny(left, right) */
 }			custom_object_type;
 
 typedef enum

--- a/test/expected/array_functions.out
+++ b/test/expected/array_functions.out
@@ -1,0 +1,424 @@
+CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.t1 (
+        id   Int32,
+        vals Array(Int32),
+        tags Array(String),
+        list String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO arr_test.t1 VALUES
+        (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
+        (2, [40,50],    ['d','e'], 'x//z'),
+        (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE SCHEMA arr_test;
+IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
+SET search_path = arr_test, public;
+-- array_cat → arrayConcat
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_cat(vals, ARRAY[99]) = ARRAY[10,20,30,99];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayConcat(vals, [99]) = [10,20,30,99]))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_cat(vals, ARRAY[99]) = ARRAY[10,20,30,99];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- array_append → arrayPushBack
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_append(vals, 99) = ARRAY[10,20,30,99];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayPushBack(vals, 99) = [10,20,30,99]))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_append(vals, 99) = ARRAY[10,20,30,99];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- array_remove → arrayRemove (CH 26+, EXPLAIN only)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_remove(vals, 20) = ARRAY[10,30];
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayRemove(vals, 20) = [10,30]))
+(3 rows)
+
+\unset ECHO
+NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)
+-- array_to_string → arrayStringConcat
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_to_string(tags, ',') = 'a,b,c';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayStringConcat(tags, ',') = 'a,b,c'))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_to_string(tags, ',') = 'a,b,c';
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- cardinality → length
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE cardinality(vals) = 3;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((length(vals) = 3))
+(3 rows)
+
+SELECT * FROM t1 WHERE cardinality(vals) = 3;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- array_position → indexOf
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((indexOf(vals, 20) = 2))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- array_length → length (drops dimension arg)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((length(vals) = 2))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
+ id |  vals   | tags  | list 
+----+---------+-------+------
+  2 | {40,50} | {d,e} | x//z
+(1 row)
+
+-- array_prepend → arrayPushFront (args reversed)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_prepend(99, vals) = ARRAY[99,10,20,30];
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayPushFront(vals, 99) = [99,10,20,30]))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_prepend(99, vals) = ARRAY[99,10,20,30];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- string_to_array → splitByString
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE string_to_array(list, '-') = ARRAY['aa','bb','cc'];
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((splitByString('-', list) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT * FROM t1 WHERE string_to_array(list, '-') = ARRAY['aa','bb','cc'];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['aa','bb','cc'];
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((splitByString(' -> ', list) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['Edit','Insert', 'Line Break'];
+ id | vals | tags |             list             
+----+------+------+------------------------------
+  3 | {60} | {f}  | Edit -> Insert -> Line Break
+(1 row)
+
+\unset ECHO
+NOTICE:  trim_array PUSHED DOWN: t
+NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)
+NOTICE:  array_reverse PUSHED DOWN: t
+NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)
+NOTICE:  array_sort PUSHED DOWN: f
+NOTICE:  (3,{60},{f},"Edit -> Insert -> Line Break")
+NOTICE:  array_sort(x, true) PUSHED DOWN: t
+NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)
+NOTICE:  array_sort(x, true, true) NOT PUSHED DOWN: t
+NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)
+-- Operators: @> → hasAll
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals @> ARRAY[10];
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (hasAll(vals, [10]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals @> ARRAY[10] ORDER BY id;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- Operators: <@ → hasAll (reversed)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals <@ ARRAY[10,20,30];
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (hasAll([10,20,30], vals))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals <@ ARRAY[10,20,30] ORDER BY id;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- Operators: && → hasAny
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals && ARRAY[20,40];
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (hasAny(vals, [20,40]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals && ARRAY[20,40] ORDER BY id;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+  2 | {40,50}    | {d,e}   | x//z
+(2 rows)
+
+-- Subscript pushdown
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[1] = 10;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((vals[1]) = 10))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals[1] = 10;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- Slicing pushdown
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[1:2] = ARRAY[10,20];
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arraySlice(vals, 1, (2) - (1) + 1) = [10,20]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals[1:2] = ARRAY[10,20];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[:2] = ARRAY[10,20];
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arraySlice(vals, 1, (2) - (1) + 1) = [10,20]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals[:2] = ARRAY[10,20];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[2:] = ARRAY[20,30];
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arraySlice(vals, 2) = [20,30]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals[2:] = ARRAY[20,30];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[:] = ARRAY[10,20,30];
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arraySlice(vals, 1) = [10,20,30]))
+(3 rows)
+
+SELECT * FROM t1 WHERE vals[:] = ARRAY[10,20,30];
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+-- Unshippable (function NOT in Remote SQL)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_dims(vals) = '[1:3]';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_dims(t1.vals) = '[1:3]'::text)
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_ndims(vals) = 1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_ndims(t1.vals) = 1)
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_lower(vals, 1) = 1;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_lower(t1.vals, 1) = 1)
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_upper(vals, 1) = 3;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_upper(t1.vals, 1) = 3)
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_replace(vals, 20, 99) = ARRAY[10,99,30];
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_replace(t1.vals, 20, 99) = '{10,99,30}'::integer[])
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_positions(vals, 20) = ARRAY[2];
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_positions(t1.vals, 20) = '{2}'::integer[])
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_to_string(vals, ',', '*') = '10,20,30';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_to_string(t1.vals, ','::text, '*'::text) = '10,20,30'::text)
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_fill(7, ARRAY[2], vals) = '[60:61]={7,7}'::int[];
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (array_fill(7, '{2}'::integer[], t1.vals) = '[60:61]={7,7}'::integer[])
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', 'nil') = ARRAY['x','','z'];
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Filter: (string_to_array(t1.list, '/'::text, 'nil'::text) = '{x,"",z}'::text[])
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1
+(4 rows)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
+SELECT clickhouse_raw_query('DROP DATABASE arr_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP SERVER arr_svr CASCADE;
+NOTICE:  drop cascades to foreign table t1

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -1,0 +1,228 @@
+CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
+SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.t1 (
+        id   Int32,
+        vals Array(Int32),
+        tags Array(String),
+        list String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+SELECT clickhouse_raw_query($$
+    INSERT INTO arr_test.t1 VALUES
+        (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
+        (2, [40,50],    ['d','e'], 'x//z'),
+        (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
+$$);
+
+CREATE SCHEMA arr_test;
+IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
+SET search_path = arr_test, public;
+
+-- array_cat → arrayConcat
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_cat(vals, ARRAY[99]) = ARRAY[10,20,30,99];
+SELECT * FROM t1 WHERE array_cat(vals, ARRAY[99]) = ARRAY[10,20,30,99];
+
+-- array_append → arrayPushBack
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_append(vals, 99) = ARRAY[10,20,30,99];
+SELECT * FROM t1 WHERE array_append(vals, 99) = ARRAY[10,20,30,99];
+
+-- array_remove → arrayRemove (CH 26+, EXPLAIN only)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_remove(vals, 20) = ARRAY[10,30];
+
+\unset ECHO
+-- Use a DO block to test arrayRemove on 26+ only.
+DO $$
+DECLARE
+	chv int[] := regexp_matches(clickhouse_raw_query('SELECT version()'), '^(\d+)\.(\d+)')::int[];
+    result record;
+BEGIN
+    IF chv[1] >= 26 THEN
+		FOR result IN SELECT * FROM t1 WHERE array_remove(vals, 20) = ARRAY[10,30] LOOP
+			RAISE NOTICE '%', result;
+		END LOOP;
+    ELSE
+		-- Fake it on earlier versions.
+		RAISE NOTICE '(1,"{10,20,30}","{a,b,c}",aa-bb-cc)';
+    END IF;
+END;
+$$;
+\set ECHO all
+
+-- array_to_string → arrayStringConcat
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_to_string(tags, ',') = 'a,b,c';
+SELECT * FROM t1 WHERE array_to_string(tags, ',') = 'a,b,c';
+
+-- cardinality → length
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE cardinality(vals) = 3;
+SELECT * FROM t1 WHERE cardinality(vals) = 3;
+
+-- array_position → indexOf
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
+SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
+
+-- array_length → length (drops dimension arg)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
+SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
+
+-- array_prepend → arrayPushFront (args reversed)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_prepend(99, vals) = ARRAY[99,10,20,30];
+SELECT * FROM t1 WHERE array_prepend(99, vals) = ARRAY[99,10,20,30];
+
+-- string_to_array → splitByString
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE string_to_array(list, '-') = ARRAY['aa','bb','cc'];
+SELECT * FROM t1 WHERE string_to_array(list, '-') = ARRAY['aa','bb','cc'];
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['aa','bb','cc'];
+SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['Edit','Insert', 'Line Break'];
+
+\unset ECHO
+-- Use DO to test functions available in Postgres 14+
+-- trim_array → arrayResize(arr, length(arr) - n)
+DO $$
+DECLARE
+    rec record;
+	output JSONB;
+BEGIN
+    IF current_setting('server_version_num')::int >= 140000 THEN
+        EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) SELECT * FROM t1 WHERE trim_array(vals, 1) = ARRAY[10,20]' INTO output;
+        RAISE NOTICE 'trim_array PUSHED DOWN: %', jsonb_path_query(
+            output, '$[0].Plan'
+        )->>'Remote SQL' = 'SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((arrayResize(vals, length(vals) - 1) = [10,20]))';
+        FOR rec IN EXECUTE 'SELECT * FROM t1 WHERE trim_array(vals, 1) = ARRAY[10,20]' LOOP
+            RAISE NOTICE '%', rec;
+        END LOOP;
+    ELSE
+        -- Fake it on earlier versions.
+        RAISE NOTICE 'trim_array PUSHED DOWN: t';
+        RAISE NOTICE '(1,"{10,20,30}","{a,b,c}",aa-bb-cc)';
+    END IF;
+END;
+$$;
+
+-- Use DO to test functions available in Postgres 18+
+DO $$
+DECLARE
+    rec record;
+    tc jsonb;
+    tests jsonb[] := ARRAY[
+        -- PG18+: array_reverse → arrayReverse
+        $_${
+          "func": "array_reverse",
+          "where": "array_reverse(vals) = ARRAY[30,20,10]",
+          "push": "((arrayReverse(vals) = [30,20,10]))"
+        }$_$,
+        -- PG18+: array_sort → arraySort
+        $_${
+          "func": "array_sort",
+          "where": "array_sort(vals, true) = vals",
+          "push": "((arraySort(vals) = vals))"
+        }$_$,
+        -- PG18+ 'array_sort(vals, true) = ARRAY[30,20,10]'
+        $_${
+          "func": "array_sort(x, true)",
+          "where": "array_sort(vals, true) = ARRAY[30,20,10]",
+          "push": "((arrayReverseSort(vals) = [30,20,10]))"
+        }$_$,
+        -- PG18+ unshippable: 'array_sort(vals, true, true) = ARRAY[30,20,10]'
+        $_${
+          "func": "array_sort(x, true, true)",
+          "where": "array_sort(vals, true, true) = ARRAY[30,20,10]"
+        }$_$
+    ];
+	output JSONB;
+BEGIN
+    IF current_setting('server_version_num')::int >= 180000 THEN
+        FOREACH tc IN ARRAY tests LOOP
+            EXECUTE format('EXPLAIN (VERBOSE, FORMAT JSON) SELECT * FROM t1 WHERE %s', tc->>'where') INTO output;
+            If tc ? 'push' THEN
+                RAISE NOTICE '% PUSHED DOWN: %', tc->>'func', jsonb_path_query(
+                    output, '$[0].Plan'
+                )->>'Remote SQL' = format('SELECT id, vals, tags, list FROM arr_test.t1 WHERE %s', tc->>'push');
+            ELSE
+                RAISE NOTICE '% NOT PUSHED DOWN: %', tc->>'func', jsonb_path_query(
+                    output, '$[0].Plan'
+                )->>'Remote SQL' = 'SELECT id, vals, tags, list FROM arr_test.t1';
+            END IF;
+            FOR rec IN EXECUTE format('SELECT * FROM t1 WHERE %s', tc->>'where') LOOP
+                RAISE NOTICE '%', rec;
+            END LOOP;
+        END LOOP;
+    ELSE
+        -- Fake it for earlier versions.
+        RAISE NOTICE 'array_reverse PUSHED DOWN: t';
+        RAISE NOTICE '(1,"{10,20,30}","{a,b,c}",aa-bb-cc)';
+        RAISE NOTICE 'array_sort PUSHED DOWN: f';
+        RAISE NOTICE '(3,{60},{f},"Edit -> Insert -> Line Break")';
+        RAISE NOTICE 'array_sort(x, true) PUSHED DOWN: t';
+        RAISE NOTICE '(1,"{10,20,30}","{a,b,c}",aa-bb-cc)';
+        RAISE NOTICE 'array_sort(x, true, true) NOT PUSHED DOWN: t';
+        RAISE NOTICE '(1,"{10,20,30}","{a,b,c}",aa-bb-cc)';
+    END IF;
+END;
+$$;
+\set ECHO all
+
+-- Operators: @> → hasAll
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals @> ARRAY[10];
+SELECT * FROM t1 WHERE vals @> ARRAY[10] ORDER BY id;
+
+-- Operators: <@ → hasAll (reversed)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals <@ ARRAY[10,20,30];
+SELECT * FROM t1 WHERE vals <@ ARRAY[10,20,30] ORDER BY id;
+
+-- Operators: && → hasAny
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals && ARRAY[20,40];
+SELECT * FROM t1 WHERE vals && ARRAY[20,40] ORDER BY id;
+
+-- Subscript pushdown
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[1] = 10;
+SELECT * FROM t1 WHERE vals[1] = 10;
+
+-- Slicing pushdown
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[1:2] = ARRAY[10,20];
+SELECT * FROM t1 WHERE vals[1:2] = ARRAY[10,20];
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[:2] = ARRAY[10,20];
+SELECT * FROM t1 WHERE vals[:2] = ARRAY[10,20];
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[2:] = ARRAY[20,30];
+SELECT * FROM t1 WHERE vals[2:] = ARRAY[20,30];
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE vals[:] = ARRAY[10,20,30];
+SELECT * FROM t1 WHERE vals[:] = ARRAY[10,20,30];
+
+-- Unshippable (function NOT in Remote SQL)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_dims(vals) = '[1:3]';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_ndims(vals) = 1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_lower(vals, 1) = 1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_upper(vals, 1) = 3;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_replace(vals, 20, 99) = ARRAY[10,99,30];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_positions(vals, 20) = ARRAY[2];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_to_string(vals, ',', '*') = '10,20,30';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_fill(7, ARRAY[2], vals) = '[60:61]={7,7}'::int[];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', 'nil') = ARRAY['x','','z'];
+
+DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
+SELECT clickhouse_raw_query('DROP DATABASE arr_test');
+DROP SERVER arr_svr CASCADE;


### PR DESCRIPTION
Builtin array functions were presumed shippable, emitted with PG names, failing on ClickHouse.
Map to CH equivalents, mark unmappable as unshippable
Previous subscript code passed `arr[x:y]` to ClickHouse as-is, which is unsupported syntax