### PR TITLE
Support CURRENT_TIME, refactor other timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ All notable changes to this project will be documented in this file. It uses the
 
 ## [v0.1.11] — Unreleased
 
+### ⚡ Improvements
 
+*   Changed the pushdown mappings for the current date and timestamp functions
+    to account for the session time zone and maximum precision, as follows:
+    *   `CURRENT_DATE` -> `toDate(now(TZ))`
+    *   `CURRENT_TIMESTAMP` and `LOCALTIMESTAMP` => `now64(9, TZ)`
+    *   `CURRENT_TIMESTAMP(n)` and `LOCALTIMESTAMP(n)` => `now64(n, TZ)`
+    *   `clock_timestamp()`, `statement_timestamp()` &
+        `transaction_timestamp()` => `nowInBlock64(n, TZ)`
+*   Added pushdown for the `CURRENT_TIME` and `LOCALTIME` SQL Value Functions
+    to `toTime64(now64(9, TZ), 9)`, supported by ClickHouse 25.8+.
 
   [v0.1.11]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.10...v0.1.11
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1033,15 +1033,19 @@ maps the following functions:
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
-*   `now`: [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
-*   `statement_timestamp`: [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
-*   `transaction_timestamp`: [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
-*   `clock_timestamp`: [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
-*   `CURRENT_DATE`: [today](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#today)
-*   `CURRENT_TIMESTAMP`: [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
-*   `CURRENT_TIMESTAMP(scale)`: [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
-*   `LOCALTIMESTAMP`: [now](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now)
-*   `LOCALTIMESTAMP(scale)`: [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
+*   `statement_timestamp`, `transaction_timestamp`, & `clock_timestamp`:
+    [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
+    (`nowInBlock64(9, $session_timezone)`)
+*   `CURRENT_DATE`:
+    [now](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now) and
+    [toDate](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toDate)
+    (`toDate(now($session_timezone))`)
+*   `now`, `CURRENT_TIMESTAMP`, & `LOCALTIMESTAMP`:
+    [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
+    (`now64(9, $session_timezone)`)
+*   `CURRENT_TIMESTAMP(n)` & `LOCALTIMESTAMP(n)`:
+    [now64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#now64)
+    (`now64(n, $session_timezone)`)
 *   `CURRENT_DATABASE`: Passed as value from PostgreSQL function.
 *   `CURRENT_SCHEMA`: Passed as value from PostgreSQL function.
 *   `CURRENT_CATALOG`: Passed as value from PostgreSQL function.

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -333,7 +333,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_TRANSACTION_TIMESTAMP:
 			case F_CLOCK_TIMESTAMP:
 				{
-					strcpy(entry->custom_name, "nowInBlock64");
+					entry->cf_type = CF_CLOCK_TIMESTAMP;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 			case F_CURRENT_SCHEMA:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -83,6 +83,9 @@
 /* Aggregate OIDs absent from fmgroids.h on all PG versions. */
 #define F_STRING_AGG_TEXT_TEXT 3538
 
+/* Oft-used syntax to quote quote the session time zone literal string. */
+#define QUOTED_TZ ch_quote_literal(pg_get_timezone_name(session_timezone))
+
 /* variable counter */
 static uint32 var_counter = 0;
 
@@ -455,21 +458,7 @@ foreign_expr_walker(Node * node,
 			}
 			break;
 		case T_SQLValueFunction:
-			{
-				/* deparseSQLValueFunction() does not support time functions. */
-				SQLValueFunction *svf = (SQLValueFunction *) node;
-
-				switch (svf->op)
-				{
-					case SVFOP_CURRENT_TIME:
-					case SVFOP_CURRENT_TIME_N:
-					case SVFOP_LOCALTIME:
-					case SVFOP_LOCALTIME_N:
-						return false;
-					default:
-						break;
-				}
-			}
+			/* All handled by deparseSQLValueFunction(). */
 			break;
 		case T_OpExpr:
 		case T_NullIfExpr:
@@ -2551,6 +2540,11 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					deparseSQLValueFunction(&svf, context);
 					return;
 				}
+			case CF_CLOCK_TIMESTAMP:
+				{
+					appendStringInfo(buf, "nowInBlock64(6, %s)", QUOTED_TZ);
+					return;
+				}
 			case CF_DATE_TRUNC:
 				{
 					Const	   *arg = (Const *) linitial(node->args);
@@ -2695,8 +2689,10 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 /*
  * Deparse a SQL Value function, which is a (potentially) parameterless
  * function with special grammar production separate from a regular function.
- * Some have ClickHouse equivalents; others we generate here in Postgres and
- * push down as a literal string. See `ExecEvalSQLValueFunction` in the
+ * Some have ClickHouse equivalents; in particular, date and time values
+ * always resolve relative to the Postgres session time zone (both "current"
+ * and "local" variants). Others we generate here in Postgres and push down as
+ * a literal string. See `ExecEvalSQLValueFunction` in the
  * `src/backend/executor/execExprInterp.c` Postgres source file for reference.
  */
 static void
@@ -2707,23 +2703,30 @@ deparseSQLValueFunction(SQLValueFunction * svf, deparse_expr_cxt * context)
 	LOCAL_FCINFO(fcinfo, 0);
 	Datum		datum;
 
+	/*
+	 * ClickHouse does not support TZs as part of DateTimes, so current and
+	 * local variants both render to the session time zone.
+	 */
 	switch (svf->op)
 	{
 		case SVFOP_CURRENT_DATE:
-			appendStringInfoString(buf, "today()");
+			appendStringInfo(buf, "toDate(now(%s))", QUOTED_TZ);
+			break;
+		case SVFOP_CURRENT_TIME:
+		case SVFOP_LOCALTIME:
+			appendStringInfo(buf, "toTime64(now64(6, %s), 6)", QUOTED_TZ);
+			break;
+		case SVFOP_CURRENT_TIME_N:
+		case SVFOP_LOCALTIME_N:
+			appendStringInfo(buf, "toTime64(now64(%1$d, %2$s), %1$d)", svf->typmod, QUOTED_TZ);
 			break;
 		case SVFOP_CURRENT_TIMESTAMP:
-			appendStringInfoString(buf, "now64()");
+		case SVFOP_LOCALTIMESTAMP:
+			appendStringInfo(buf, "now64(6, %s)", QUOTED_TZ);
 			break;
 		case SVFOP_CURRENT_TIMESTAMP_N:
-			appendStringInfo(buf, "now64(%d)", svf->typmod);
-			break;
-		case SVFOP_LOCALTIMESTAMP:
 		case SVFOP_LOCALTIMESTAMP_N:
-			if (svf->typmod < 0)
-				appendStringInfo(buf, "now(%s)", ch_quote_literal(pg_get_timezone_name(session_timezone)));
-			else
-				appendStringInfo(buf, "now64(%d, %s)", svf->typmod, ch_quote_literal(pg_get_timezone_name(session_timezone)));
+			appendStringInfo(buf, "now64(%d, %s)", svf->typmod, QUOTED_TZ);
 			break;
 		case SVFOP_CURRENT_ROLE:
 		case SVFOP_CURRENT_USER:

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -314,6 +314,7 @@ typedef enum
 	CF_STRING_AGG,				/* string_agg → groupConcat(delim)(expr) */
 	CF_CURRENT_DATABASE,		/* CURRENT_DATABASE → string literal */
 	CF_CURRENT_SCHEMA,			/* CF_CURRENT_SCHEMA → string literal */
+	CF_CLOCK_TIMESTAMP,			/* clock_timestamp → nowInBlock64(6, $TZ) */
 }			custom_object_type;
 
 typedef enum

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1478,11 +1478,11 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
@@ -1493,11 +1493,11 @@ SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
@@ -1508,11 +1508,11 @@ SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
@@ -1524,11 +1524,11 @@ SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
 
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1539,11 +1539,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1554,11 +1554,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1569,11 +1569,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1598,8 +1598,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t
@@ -1672,7 +1673,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1681,3 +1682,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table times

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1473,11 +1473,11 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
@@ -1488,11 +1488,11 @@ SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
@@ -1503,11 +1503,11 @@ SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
@@ -1519,11 +1519,11 @@ SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
 
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1534,11 +1534,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1549,11 +1549,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1564,11 +1564,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1593,8 +1593,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t
@@ -1667,7 +1668,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1676,3 +1677,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table times

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1473,11 +1473,11 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
@@ -1488,11 +1488,11 @@ SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
@@ -1503,11 +1503,11 @@ SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
@@ -1519,11 +1519,11 @@ SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
 
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1534,11 +1534,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1549,11 +1549,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1564,11 +1564,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1593,8 +1593,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t
@@ -1667,7 +1668,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1676,3 +1677,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table times

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1478,45 +1478,45 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1527,11 +1527,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1542,11 +1542,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1557,11 +1557,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1586,8 +1586,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1478,45 +1478,45 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1527,11 +1527,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1542,11 +1542,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1557,11 +1557,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1586,8 +1586,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1478,45 +1478,45 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1527,11 +1527,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1542,11 +1542,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1557,11 +1557,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1586,8 +1586,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1478,45 +1478,45 @@ SELECT * FROM t1 WHERE c < NOW() ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64() ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64())) ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < today()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < toDate(now('America/Los_Angeles'))))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
@@ -1527,11 +1527,11 @@ SELECT * FROM t1 WHERE c < CURRENT_DATE ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64()))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
@@ -1542,11 +1542,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3);
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3)))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(3, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
@@ -1557,11 +1557,11 @@ SELECT * FROM t1 WHERE c < CURRENT_TIMESTAMP(3) ORDER BY a LIMIT 2;
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t1
    Output: a, b, c
-   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now('America/Los_Angeles')))
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((c < now64(6, 'America/Los_Angeles')))
 (3 rows)
 
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
@@ -1586,8 +1586,9 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+NOTICE:  CURRENT_TIME PUSHED DOWN: t
+NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t
 NOTICE:  CURRENT_USER PUSHED DOWN: t
 NOTICE:  USER PUSHED DOWN: t
 NOTICE:  CURRENT_ROLE PUSHED DOWN: t

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -343,8 +343,61 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3);
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
 
--- Use a DO block to test functions that push down a locally-generated literal.
 \unset ECHO
+-- Use a DO block to test TIME SQL values; Time64 added in CLickHouse 25.6.
+DO $$
+DECLARE
+	-- Capture the CLickHouse major an minor version parse.
+	chv int[] := regexp_matches(clickhouse_raw_query('SELECT version()'), '^(\d+)\.(\d+)')::int[];
+	opt TEXT = '';
+	output JSONB;
+    result record;
+BEGIN
+    IF chv[1] > 25 OR (chv[1] = 25 AND chv[2] >= 6) THEN
+		if chv[1] = 25 AND chv[2] < 12 THEN
+			-- Times64 supported but needs to be enabled.
+			opt := ' SETTINGS enable_time_time64_type = 1';
+		END IF;
+		-- Set up a foreign table mapping timetz to Time64.
+		PERFORM clickhouse_raw_query(
+			'CREATE TABLE functions_test.times (t64 Time64) engine=TinyLog()' || opt
+		);
+		PERFORM clickhouse_raw_query($q$
+			INSERT INTO functions_test.times
+			VALUES ('16:14:50.922787819'),
+				   ('00:00:00'),
+				   ('23:59:59.999999999')
+		$q$);
+		CREATE FOREIGN TABLE times (t64 TIMETZ) SERVER functions_loopback;
+
+		-- Test that CURRENT_TIME passes down properly.
+		EXPLAIN (VERBOSE, FORMAT JSON) SELECT * FROM times WHERE t64 <> CURRENT_TIME INTO output;
+		RAISE NOTICE 'CURRENT_TIME PUSHED DOWN: %', jsonb_path_query(
+			output, '$[0].Plan'
+		)->>'Remote SQL' = 'SELECT t64 FROM functions_test.times WHERE ((t64 <> toTime64(now64(6, ''America/Los_Angeles''), 6)))';
+		-- XXX Add Time64 support to binary the drivers.
+		-- FOR result IN SELECT * FROM times WHERE t64 <> CURRENT_TIME ORDER BY t64 LOOP
+		-- 	RAISE NOTICE '%', result;
+		-- END LOOP;
+
+		-- Test that CURRENT_TIME passes down properly.
+		EXPLAIN (VERBOSE, FORMAT JSON) SELECT * FROM times WHERE t64 <> CURRENT_TIME(3) INTO output;
+		RAISE NOTICE 'CURRENT_TIME(n) PUSHED DOWN: %', jsonb_path_query(
+			output, '$[0].Plan'
+		)->>'Remote SQL' = 'SELECT t64 FROM functions_test.times WHERE ((t64 <> toTime64(now64(3, ''America/Los_Angeles''), 3)))';
+		-- XXX Add Time64 support to binary the drivers.
+		-- FOR result IN SELECT * FROM times WHERE t64 <> CURRENT_TIME(6) ORDER BY t64 LOOP
+		-- 	RAISE NOTICE '%', result;
+		-- END LOOP;
+    ELSE
+		-- Fake it on earlier versions.
+		RAISE NOTICE 'CURRENT_TIME PUSHED DOWN: t';
+		RAISE NOTICE 'CURRENT_TIME(n) PUSHED DOWN: t';
+    END IF;
+END;
+$$;
+
+-- Use a DO block to test functions that push down a locally-generated literal.
 DO $$
 DECLARE
 	op TEXT;
@@ -389,7 +442,6 @@ BEGIN
 	RAISE NOTICE 'CURRENT_DATABASE() PUSHED DOWN: %', jsonb_path_query(
 		output, '$[0].Plan'
 	)->>'Remote SQL' = format('SELECT val FROM functions_test.t4 WHERE ((val <> %L))', CURRENT_DATABASE());
-
 END;
 $$;
 \set ECHO all


### PR DESCRIPTION
The current timestamp-type functions were simply mapped to `now64()` and related ClickHouse functions. However, ClickHouse has no concept of a time zone as part of Date or DateTime types, so its functions would generate values relative to the time zone setting for ClickHouse. This would be unexpected if the Postgres session time zone was different.

So refactor the timestamp functions to be populated from the Postgres session time zone. Also, when no precision is specified, default to `6`, the same as the Postgres default. Have the `CURRENT ` and `LOCAL` variants return the same values, again because ClickHouse does not support timezone-aware values, so the behavior should always resemble the Postgres `LOCAL` variant, which is relative to the session time zone.

While at it, map `CURRENT_TIME` and `LOCALTIME` to `toTime64(now64(9, TZ), 9)`, supported by ClickHouse 25.8+.