### PR TITLE
Upgrade clickhouse-cpp, fix malformed error

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, customer-*]
     tags: ["v*"]
+  pull_request:
 
 permissions:
   contents: write
@@ -116,6 +117,7 @@ jobs:
           fi
 
       - name: Create or Update Release
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file. It uses the
     in Postgres versions prior to 18, and without having to load
     pg_clickhouse, first.
 
+### ⬆️ Dependency Updates
+
+*   Updated vendored clickhouse-cpp library to v2.6.1.
+
+### 🐞 Bug Fixes
+
+*   Fixed a malformed type name in the error message when the http driver is
+    unable to map a ClickHouse type to a Postgres type.
+
   [v0.1.11]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.10...v0.1.11
 
 ## [v0.1.10] — 2026-04-06

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -1175,8 +1175,9 @@ static char *str_types_map[][2] = {
 };
 
 static char *
-parse_type(char *table_name, char *colname, char *typepart, bool *is_nullable, List * *options)
+parse_type(char *table_name, char *colname, char *part, bool *is_nullable, List * *options)
 {
+	char	   *typepart = part;
 	char	   *pos = strstr(typepart, "(");
 
 	if (pos != NULL)
@@ -1263,7 +1264,7 @@ parse_type(char *table_name, char *colname, char *typepart, bool *is_nullable, L
 
 	ereport(ERROR, (errmsg(
 						   "pg_clickhouse: could not map %s.%s type <%s>",
-						   quote_identifier(table_name), quote_identifier(colname), typepart
+						   quote_identifier(table_name), quote_identifier(colname), part
 						   )));
 }
 

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -29,10 +29,10 @@ $$);
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
-ERROR:  pg_clickhouse: could not map things.data type <'json')>
+ERROR:  pg_clickhouse: could not map things.data type <Object('json')>
 \d json_bin.things
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER http_json_loopback INTO json_http;
-ERROR:  pg_clickhouse: could not map things.data type <'json')>
+ERROR:  pg_clickhouse: could not map things.data type <Object('json')>
 \d json_http.things
 -- Fails pending https://github.com/ClickHouse/clickhouse-cpp/issues/422
 INSERT INTO json_bin.things VALUES


### PR DESCRIPTION
Upgrade to the latest clickhouse release, v2.6.1.

Fix an error message when the http driver is unable to map a ClickHouse type to a Postgres type. Where previously it would show a message such as

    pg_clickhouse: could not map default.things <3))>

It will now show something like:

    pg_clickhouse: could not map default.things <Time64(3)>