### PR TITLE
Test CURRENT_* interactions with `date_trunc()`

### DIFF
--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1604,6 +1604,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1599,6 +1599,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1599,6 +1599,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1592,6 +1592,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1592,6 +1592,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1592,6 +1592,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1592,6 +1592,41 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
  2 | 2 | 2019-01-02 02:00:00
 (2 rows)
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toYear(c) < toYear(cast(toDate(now('America/Los_Angeles')), 'Nullable(DateTime)'))))
+(3 rows)
+
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((toStartOfDay(c) < (toStartOfDay(now64(6, 'America/Los_Angeles')) - 86400))) ORDER BY a ASC NULLS LAST LIMIT 2
+(3 rows)
+
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+ 2 | 2 | 2019-01-02 03:00:00
+ 2 | 3 | 2019-01-02 02:00:00
+(4 rows)
+
 \unset ECHO
 NOTICE:  CURRENT_TIME PUSHED DOWN: t
 NOTICE:  CURRENT_TIME(n) PUSHED DOWN: t

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -345,6 +345,13 @@ SELECT * FROM t1 WHERE c < LOCALTIMESTAMP ORDER BY a LIMIT 2;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3);
 SELECT * FROM t1 WHERE c < LOCALTIMESTAMP(3) ORDER BY a LIMIT 2;
 
+-- Use with other functions.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+SELECT * FROM t1 WHERE date_part('year', c) < date_part('year', CURRENT_DATE);
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a LIMIT 2;
+SELECT * FROM t1 WHERE date_trunc('day', c) < date_trunc('day', CURRENT_TIMESTAMP) - INTERVAL '1 day' ORDER BY a;
+
 \unset ECHO
 -- Use a DO block to test TIME SQL values; Time64 added in CLickHouse 25.6.
 DO $$


### PR DESCRIPTION
Compare values truncated to year or day, even subtracting a day via an interval (which pushes down as `86400`).