### PR TITLE
Add mapping for `regexp_split_to_array()` + flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file. It uses the
     This is the same value visible in `pg_get_loaded_modules()`, but available
     in Postgres versions prior to 18, and without having to load
     pg_clickhouse, first.
+*   Added support for pushing down the flags passed to `regexp_like()` by
+    prepending them to the regular expression (e.g., `(?i)foo`).
+*   Added pushdown for `regexp_split_to_array()` to `splitByRegexp()`,
+    including flags.
 
 ### ⬆️ Dependency Updates
 
@@ -33,6 +37,8 @@ All notable changes to this project will be documented in this file. It uses the
 
 *   Fixed a malformed type name in the error message when the http driver is
     unable to map a ClickHouse type to a Postgres type.
+*   Fixed reversal of the arguments passed to the ClickHouse `match()`
+    function by the mapping from `regexp_like()`.
 
   [v0.1.11]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.10...v0.1.11
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1032,6 +1032,7 @@ maps the following functions:
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 *   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
 *   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
 *   `statement_timestamp`, `transaction_timestamp`, & `clock_timestamp`:
@@ -1159,6 +1160,43 @@ rejects frame specifications on these functions.
   [window functions]: https://www.postgresql.org/docs/current/functions-window.html
     "PostgreSQL Docs: Window Functions"
 
+## Compatibility Notes
+
+### Regular Expressions
+
+While pg_clickhouse pushes down regular expressions to ClickHouse equivalents,
+be aware of the differences between the two.
+
+*   PostgreSQL supports [POSIX Regular Expressions] while ClickHouse supports
+    [RE2 Regular Expressions]. Beware of differences in behavior: write RE2
+    when the regular expression will be evaluated by ClickHouse (e.g., in a
+    `WHERE` clause) and POSIX when it will be evaluated by Postgres (e.g., in
+    a `SELECT` clause).
+*   pg_clickhouse pushes down the Postgres [Regex flags] by prepending them
+    to ClikHouse regular expression inside `(?)`. For example:
+
+    ``` sql
+    regexp_like(val, '^VAL\d', 'i')
+    ```
+
+    Becomes
+
+    ```sql
+    match(val, concat('(?i)', '^VAL\\d'))
+    ```
+
+  The only flags both support, and therefore can be used when evaluated by
+  ClickHouse, are:
+
+  RE2 supports only these flags; don't use any other [Postgres flags]
+
+  *   `i`: case-insensitive
+  *   `m`: multi-line mode:
+  *   `s`: let `.` match `\n`
+
+Postgres parser will reject the one other RE2 flag, `U`, and specifying any
+other [Postgres flags] will trigger an error from ClickHouse.
+
 ## Authors
 
 *   [David E. Wheeler](https://justatheory.com/)
@@ -1256,3 +1294,8 @@ Copyright (c) 2025-2026, ClickHouse.
     "ClickHouse Docs: String"
   [TEXT]: https://www.postgresql.org/docs/current/datatype-character.html
     "PostgreSQL Docs: Character Types"
+  [POSIX Regular Expressions]: https://www.postgresql.org/docs/18/functions-matching.html#FUNCTIONS-POSIX-REGEXP
+    "PostgreSQL Docs: POSIX Regular Expressions"
+  [Postgres flags]: https://www.postgresql.org/docs/18/functions-matching.html#POSIX-EMBEDDED-OPTIONS-TABLE
+    "PostgreSQL Docs: ARE Embedded-Option Letters"
+  [RE2 Regular Expressions]: https://github.com/google/re2/wiki/Syntax "RE2 Syntax"

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -40,6 +40,8 @@
 #define F_ARRAY_AGG_ANYNONARRAY 2335
 #define F_TO_TIMESTAMP_FLOAT8 1158
 #define F_TRANSACTION_TIMESTAMP 2647
+#define F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT 2767
+#define F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT 2768
 
 /*
  * Prior to Postgres 14 EXTRACT mapped directly to DATE_PART.
@@ -52,6 +54,7 @@
 /* regexp_like was added in Postgres 15; Mock it for earlier versions. */
 #if PG_VERSION_NUM < 150000
 #define F_REGEXP_LIKE_TEXT_TEXT 6263
+#define F_REGEXP_LIKE_TEXT_TEXT_TEXT 6264
 #endif
 
 #define STR_STARTS_WITH(str, sub) strncmp(str, sub, strlen(sub)) == 0
@@ -197,6 +200,9 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_BTRIM_TEXT_TEXT:
 			case F_BTRIM_TEXT:
 			case F_REGEXP_LIKE_TEXT_TEXT:
+			case F_REGEXP_LIKE_TEXT_TEXT_TEXT:
+			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT:
+			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT:
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
 			case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
 			case F_ARRAY_AGG_ANYNONARRAY:
@@ -274,9 +280,17 @@ chfdw_check_for_custom_function(Oid funcid)
 					break;
 				}
 			case F_REGEXP_LIKE_TEXT_TEXT:
+			case F_REGEXP_LIKE_TEXT_TEXT_TEXT:
 				{
 					entry->cf_type = CF_MATCH;
 					strcpy(entry->custom_name, "match");
+					break;
+				}
+			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT:
+			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT:
+				{
+					entry->cf_type = CF_SPLIT_BY_REGEXP;
+					strcpy(entry->custom_name, "splitByRegexp");
 					break;
 				}
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -206,6 +206,7 @@ static void deparseCoalesceExpr(CoalesceExpr * node, deparse_expr_cxt * context)
 static void deparseMinMaxExpr(MinMaxExpr * node, deparse_expr_cxt * context);
 static void deparseRowExpr(RowExpr * node, deparse_expr_cxt * context);
 static void deparseNullIfExpr(NullIfExpr * node, deparse_expr_cxt * context);
+static void appendRegex(List * args, deparse_expr_cxt * context);
 
 /*
  * Helper functions
@@ -2467,6 +2468,34 @@ deparseJsonbExtractPath(FuncExpr * node, deparse_expr_cxt * context,
 }
 
 /*
+ * Utility function used by the regular expression functions to generate the
+ * regular expression argument. It expects the second item in `args` to be the
+ * regular expression, and the third, optional item to be the flags. If there
+ * are no flags it simply appends the regexp expression. If there are flags,
+ * it emits the regular expression as `concat('(?$flags), $regexp)`. This is
+ * safe to do because the Postgres parser validates the flags, which must be a
+ * string constant.
+*/
+static void
+appendRegex(List * args, deparse_expr_cxt * context)
+{
+	if (list_length(args) <= 2)
+	{
+		/* No flags argument, just append the regexp expression. */
+		deparseExpr((Expr *) list_nth(args, 1), context);
+		return;
+	}
+
+	/* Concatenate the flags with the regexp expression. */
+	Const	   *arg = (Const *) list_nth(args, 2);
+	char	   *flags = TextDatumGetCString(arg->constvalue);
+
+	appendStringInfo(context->buf, "concat('(?%s)', ", flags);
+	deparseExpr((Expr *) list_nth(args, 1), context);
+	appendStringInfoChar(context->buf, ')');
+}
+
+/*
  * Deparse a function call.
  */
 static void
@@ -2646,21 +2675,42 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					appendStringInfoChar(buf, ')');
 					return;
 				}
+			case CF_TIMEZONE:
+				{
+					/* Arguments are reversed. */
+					appendStringInfoChar(buf, '(');
+					deparseExpr((Expr *) list_nth(node->args, 1), context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoChar(buf, ')');
+					return;
+				}
+			case CF_MATCH:
+				{
+					/* match(haystack, pattern) */
+					appendStringInfoChar(buf, '(');
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+					appendRegex(node->args, context);
+					appendStringInfoChar(buf, ')');
+					return;
+				}
+			case CF_SPLIT_BY_REGEXP:
+				{
+					/* splitByRegexp(regexp, s) */
+					appendStringInfoChar(buf, '(');
+					appendRegex(node->args, context);
+					appendStringInfoString(buf, ", ");
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoChar(buf, ')');
+					return;
+				}
 			default:
 				break;
 		}
 	}
 
 	appendStringInfoChar(buf, '(');
-	if (cdef && (cdef->cf_type == CF_TIMEZONE || cdef->cf_type == CF_MATCH))
-	{
-		deparseExpr((Expr *) list_nth(node->args, 1), context);
-		appendStringInfoString(buf, ", ");
-		deparseExpr((Expr *) linitial(node->args), context);
-		appendStringInfoChar(buf, ')');
-		return;
-	}
-
 	old_cdef = context->func;
 
 	/* ... and all the arguments */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -302,6 +302,7 @@ typedef enum
 	CF_INTARRAY_IDX,
 	CF_CH_FUNCTION,				/* adapted clickhouse function */
 	CF_MATCH,					/* regexp_match function */
+	CF_SPLIT_BY_REGEXP,			/* regexp_split_to_array → splitByRegexp */
 	CF_REGEX_MATCH,				/* ~ POSIX regex operator */
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,7 +1398,7 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.t4
@@ -1387,12 +1406,70 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val)
    Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
 (3 rows)
 
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
  val  
 ------
  val1
  val2
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, concat('(?i)', '^VAL\\d')))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
@@ -1714,7 +1791,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1723,4 +1800,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,16 +1398,69 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-ERROR:  function regexp_like(unknown, text) does not exist
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+ERROR:  function regexp_like(text, unknown) does not exist
 LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-ERROR:  function regexp_like(unknown, text) does not exist
-LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+ERROR:  function regexp_like(text, unknown) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                  ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ERROR:  function regexp_like(text, unknown, unknown) does not exist
+LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ERROR:  function regexp_like(text, unknown, unknown) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                 ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            
@@ -1709,7 +1781,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1718,4 +1790,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,16 +1398,69 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-ERROR:  function regexp_like(unknown, text) does not exist
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+ERROR:  function regexp_like(text, unknown) does not exist
 LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
                                                              ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-ERROR:  function regexp_like(unknown, text) does not exist
-LINE 1: SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+ERROR:  function regexp_like(text, unknown) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                  ^
 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ERROR:  function regexp_like(text, unknown, unknown) does not exist
+LINE 1: ...AIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_lik...
+                                                             ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ERROR:  function regexp_like(text, unknown, unknown) does not exist
+LINE 1: SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                 ^
+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            
@@ -1709,7 +1781,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1718,4 +1790,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,7 +1398,7 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.t4
@@ -1387,12 +1406,70 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val)
    Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
 (3 rows)
 
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
  val  
 ------
  val1
  val2
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, concat('(?i)', '^VAL\\d')))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
@@ -1702,7 +1779,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1711,3 +1788,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,7 +1398,7 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.t4
@@ -1387,12 +1406,70 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val)
    Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
 (3 rows)
 
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
  val  
 ------
  val1
  val2
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, concat('(?i)', '^VAL\\d')))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
@@ -1702,7 +1779,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1711,3 +1788,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,7 +1398,7 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.t4
@@ -1387,12 +1406,70 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val)
    Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
 (3 rows)
 
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
  val  
 ------
  val1
  val2
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, concat('(?i)', '^VAL\\d')))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
@@ -1702,7 +1779,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1711,3 +1788,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -136,6 +142,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -160,6 +167,18 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
  clickhouse_raw_query 
 ----------------------
@@ -1379,7 +1398,7 @@ SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 (1 row)
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.t4
@@ -1387,12 +1406,70 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val)
    Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, '^val\\d'))
 (3 rows)
 
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
  val  
 ------
  val1
  val2
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE (match(val, concat('(?i)', '^VAL\\d')))
+(3 rows)
+
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(',', val) = ['a','b','c']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+  val  
+-------
+ a,b,c
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+        val        
+-------------------
+ sleep   no   more
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t8
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t8 WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
+(3 rows)
+
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+     val      
+--------------
+ aa-T-bb-t-cc
+(1 row)
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
@@ -1702,7 +1779,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1711,3 +1788,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -35,6 +35,7 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8(val String) engine=TinyLog();');
 
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
@@ -72,6 +73,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (val text) SERVER functions_loopback;
 
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
@@ -89,6 +91,14 @@ SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
+$$);
+
+SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8
+	VALUES ('a,b,c'),
+		   ('foo,bar,baz'),
+		   ('sleep   no   more'),
+		   ('aa-T-bb-t-cc')
 $$);
 
 SELECT clickhouse_raw_query($$
@@ -306,8 +316,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_trunc('quarter', ts) =
 SELECT ts FROM t5 WHERE date_trunc('quarter', ts) = '2027-10-01'::date;
 
 -- check regexp_like.
-EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like('^val\d', val);
-SELECT val FROM t4 WHERE regexp_like('^val\d', val);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+SELECT val FROM t4 WHERE regexp_like(val, '^val\d');
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+SELECT val FROM t4 WHERE regexp_like(val, '^VAL\d', 'i');
+
+-- Check regexp_split_to_array.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+SELECT val FROM t8 WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
 
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;


### PR DESCRIPTION
Map the Postgres `regexp_split_to_array()` function to ClickHouse `splitByRegexp()`. When flags are passed as the optional third argument to `regexp_split_to_array()`, prepend them in `(?)` to the regular expression.

While at it, do the same for `regexp_like()` flags, and fix the bug that reversed the arguments to the ClickHouse `match()` function, which has existed since the mapping was introduced.

Refactor `deparseFuncExpr()` to handle the the `toTimeZone()`, `match()`, and `splitByRegexp()` cases separately, but abstract creating the regular expression with optional flags into the new `appendRegex()` function. Alas, ClickHouse reverses the arguments to `match()` and `splitByRegexp()`, so we can't treat them the same.

Add tests for these behaviors to `functions.sql`, and add some notes on differences in regular expression behavior and flags to the reference documentation.