### PR TITLE
Test that `concat_ws()` successfully pushes down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,14 @@ All notable changes to this project will be documented in this file. It uses the
     `string_to_array(3-arg)` now evaluate locally instead of being pushed to
     ClickHouse where they would fail.
 
+### 📔 Notes
+
+*   Added tests to ensure that `concat_ws()` successfully pushes down to the
+    compatible function of the same name (an alias for [concatWithSeparator]).
+
   [v0.1.11]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.10...v0.1.11
+  [concatWithSeparator]: https://clickhouse.com/docs/sql-reference/functions/string-functions#concatWithSeparator
+
 
 ## [v0.1.10] — 2026-04-06
 

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1783,6 +1783,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1773,6 +1773,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1773,6 +1773,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1771,6 +1771,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1771,6 +1771,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1771,6 +1771,37 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1771,6 +1771,34 @@ SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
  val2
 (2 rows)
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((concat_ws('/', key2, val) = 'key4/val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b, c
+   Remote SQL: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+(3 rows)
+
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument 2 of function concatWithSeparator: While processing concatWithSeparator(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'
+DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -484,6 +484,15 @@ SELECT * FROM t4 WHERE val <> CURRENT_SCHEMA();
 SELECT * FROM t4 WHERE val <> CURRENT_CATALOG;
 SELECT * FROM t4 WHERE val <> CURRENT_DATABASE();
 
+-- Test concat_ws.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+SELECT * FROM t3_map WHERE concat_ws('/', key2, val) = 'key4/val4';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;


### PR DESCRIPTION
No need to map it, `concat_ws()` is a ClickHouse alias for its [`concatWithSeparator()`] function and works properly with all supported versions of ClickHouse. The only issue is that Postgres omits any `NULL` arguments while ClickHouse's `concat_ws()` returns `NULL` if any of its arguments is `NULL`. Otherwise, ClickHouse 24.1 added support for arguments of any type, whereas previous versions supported only string types.

  [`concatWithSeparator()`]: https://clickhouse.com/docs/sql-reference/functions/string-functions#concatWithSeparator