### PR TITLE
Add pushdown for `split_part()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file. It uses the
     `array_remove`, `array_to_string`, `cardinality`, `array_length`,
     `array_prepend`, `string_to_array`, `trim_array`, `array_fill`,
     `array_reverse`, `array_shuffle`, `array_sample`, `array_sort`.
+*   Added mapping for `split_part()` to pushdown `splitByString()[n]`.
 *   Added pushdown for array operators: `@>` (`hasAll`), `<@` (`hasAll`),
     `&&` (`hasAny`).
 *   Array slice syntax (`arr[L:U]`, `arr[:U]`, `arr[L:]`) now pushes down

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1034,6 +1034,7 @@ maps the following functions:
 *   `array_length` & `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
 *   `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayStringConcat)
 *   `string_to_array`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString)
+*   `split_part`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString) + array subscript
 *   `trim_array`: [arrayResize](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayResize)
 *   `array_fill`: [arrayWithConstant](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayWithConstant)
 *   `array_reverse`: [arrayReverse](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverse)

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -54,6 +54,7 @@
 #define F_TRIM_ARRAY 6172
 #define F_STRING_TO_ARRAY_TEXT_TEXT 394
 #define F_STRING_TO_ARRAY_TEXT_TEXT_TEXT 376
+#define F_SPLIT_PART 2088
 #define F_ARRAY_TO_STRING_ANYARRAY_TEXT 395
 #define F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT 384
 #define F_ARRAY_FILL_ANYELEMENT__INT4 F_ARRAY_FILL
@@ -252,6 +253,7 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_ARRAY_LENGTH:
 			case F_ARRAY_PREPEND:
 			case F_STRING_TO_ARRAY_TEXT_TEXT:
+			case F_SPLIT_PART:
 			case F_TRIM_ARRAY:
 			case F_ARRAY_FILL_ANYELEMENT__INT4:
 			case F_ARRAY_SORT_ANYARRAY_BOOL:
@@ -461,6 +463,10 @@ chfdw_check_for_custom_function(Oid funcid)
 				break;
 			case F_STRING_TO_ARRAY_TEXT_TEXT:
 				entry->cf_type = CF_STRING_TO_ARRAY;
+				strcpy(entry->custom_name, "splitByString");
+				break;
+			case F_SPLIT_PART:
+				entry->cf_type = CF_STRING_TO_ARRAY_PART;
 				strcpy(entry->custom_name, "splitByString");
 				break;
 			case F_TRIM_ARRAY:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2691,6 +2691,7 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 			case CF_TIMEZONE:
 			case CF_ARRAY_PREPEND:
 			case CF_STRING_TO_ARRAY:
+			case CF_STRING_TO_ARRAY_PART:
 				{
 					/* Arguments are reversed. */
 					appendStringInfoChar(buf, '(');
@@ -2698,6 +2699,13 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					appendStringInfoString(buf, ", ");
 					deparseExpr((Expr *) linitial(node->args), context);
 					appendStringInfoChar(buf, ')');
+					if (cdef->cf_type == CF_STRING_TO_ARRAY_PART)
+					{
+						/* Use array subscript to extract item. */
+						appendStringInfoChar(buf, '[');
+						deparseExpr((Expr *) list_nth(node->args, 2), context);
+						appendStringInfoChar(buf, ']');
+					}
 					return;
 				}
 			case CF_MATCH:
@@ -2737,7 +2745,7 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 				return;
 			case CF_ARRAY_SORT_DESC:
 				{
-					/* Determine function name reverse boolean arg. */
+					/* Determine function name from reverse boolean arg. */
 					Const	   *desc_arg = (Const *) list_nth(node->args, 1);
 
 					appendStringInfoString(buf, !desc_arg->constisnull && DatumGetBool(desc_arg->constvalue) ? "arrayReverseSort" : "arraySort");

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -320,6 +320,7 @@ typedef enum
 	CF_ARRAY_PREPEND,			/* array_prepend → arrayPushFront, swap args */
 	CF_STRING_TO_ARRAY,			/* string_to_array → splitByString, swap
 								 * args */
+	CF_STRING_TO_ARRAY_PART,	/* split_part → splitByString()[n] */
 	CF_TRIM_ARRAY,				/* trim_array → arrayResize(arr,
 								 * length(arr)-n) */
 	CF_ARRAY_SORT_DESC,			/* array_sort(arr,desc) →

--- a/test/expected/array_functions.out
+++ b/test/expected/array_functions.out
@@ -194,6 +194,37 @@ SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['Edit','Insert', 'L
   3 | {60} | {f}  | Edit -> Insert -> Line Break
 (1 row)
 
+-- split_part → splitByString
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE split_part(list, '-', 2) = 'bb';
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((splitByString('-', list)[2] = 'bb'))
+(3 rows)
+
+SELECT * FROM t1 WHERE split_part(list, '-', 2) = 'bb';
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE split_part(list, '-', -1) = 'cc';
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((splitByString('-', list)[(-1)] = 'cc'))
+(3 rows)
+
+SELECT * FROM t1 WHERE split_part(list, '-', -1) = 'cc';
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
 \unset ECHO
 NOTICE:  trim_array PUSHED DOWN: t
 NOTICE:  (1,"{10,20,30}","{a,b,c}",aa-bb-cc)

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -88,6 +88,14 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['aa','bb','cc'];
 SELECT * FROM t1 WHERE string_to_array(list, ' -> ') = ARRAY['Edit','Insert', 'Line Break'];
 
+-- split_part → splitByString
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE split_part(list, '-', 2) = 'bb';
+SELECT * FROM t1 WHERE split_part(list, '-', 2) = 'bb';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE split_part(list, '-', -1) = 'cc';
+SELECT * FROM t1 WHERE split_part(list, '-', -1) = 'cc';
+
 \unset ECHO
 -- Use DO to test functions available in Postgres 14+
 -- trim_array → arrayResize(arr, length(arr) - n)


### PR DESCRIPTION
Map `split_part()` to `splitByString()`, just like `string_to_array()`, but append an array subscript to fetch just a single value from the array, as expected by `split_part()`. Test with both a positive and a negative array index value.