### PR TITLE
Improve `regexp_replace()` pushdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this project will be documented in this file. It uses the
     `&&` (`hasAny`).
 *   Array slice syntax (`arr[L:U]`, `arr[:U]`, `arr[L:]`) now pushes down
     as `arraySlice()`.
+*   Added mapping for `regexp_replace(4-arg)` to pushdown to
+    `replaceRegexpAll()` when the `g` flag is set, and to prepend the flags to
+    the pushed down expression.
 
 ### ⬆️ Dependency Updates
 
@@ -52,6 +55,8 @@ All notable changes to this project will be documented in this file. It uses the
     `array_positions`, `array_fill (3-arg)`, `array_sort (3-arg)`, and
     `string_to_array(3-arg)` now evaluate locally instead of being pushed to
     ClickHouse where they would fail.
+*   Changed pushdown for `regexp_replace(3-arg)` from `replaceRegexpAll()` to
+    `replaceRegexpOne()`.
 
 ### 📔 Notes
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1044,6 +1044,7 @@ maps the following functions:
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
 *   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 *   `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
 *   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
@@ -1197,8 +1198,9 @@ be aware of the differences between the two.
     when the regular expression will be evaluated by ClickHouse (e.g., in a
     `WHERE` clause) and POSIX when it will be evaluated by Postgres (e.g., in
     a `SELECT` clause).
+
 *   pg_clickhouse pushes down the Postgres [Regex flags] by prepending them
-    to ClikHouse regular expression inside `(?)`. For example:
+    to ClickHouse regular expression inside `(?)`. For example:
 
     ``` sql
     regexp_like(val, '^VAL\d', 'i')
@@ -1210,17 +1212,26 @@ be aware of the differences between the two.
     match(val, concat('(?i)', '^VAL\\d'))
     ```
 
-  The only flags both support, and therefore can be used when evaluated by
-  ClickHouse, are:
+*   The only flags both support, and therefore can be used when evaluated by
+    ClickHouse, are:
 
-  RE2 supports only these flags; don't use any other [Postgres flags]
+    RE2 supports only these flags; don't use any other [Postgres flags]
 
-  *   `i`: case-insensitive
-  *   `m`: multi-line mode:
-  *   `s`: let `.` match `\n`
+    *   `i`: case-insensitive
+    *   `m`: multi-line mode:
+    *   `s`: let `.` match `\n`
 
-Postgres parser will reject the one other RE2 flag, `U`, and specifying any
-other [Postgres flags] will trigger an error from ClickHouse.
+*   The exception is `regexp_replace()`, which also supports the `g` flag.
+    When `g` is set, pg_clickhouse uses `replaceRegexpAll()` instead of
+    `replaceRegexpOne()` and removes the flag before prepending other flags.
+
+*   Postgres parser will reject the one other RE2 flag, `U`, and specifying
+    any other [Postgres flags] will trigger an error from ClickHouse.
+
+*   The replacement argument to Postgres `regexp_replace()` supports `\&` to
+    refer to the entire match, while in ClickHouse supports `\0` for the
+    entire match. Be sure to use `\0` when the function pushes down to
+    ClickHouse.
 
 ## Authors
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -43,6 +43,8 @@
 #define F_TRANSACTION_TIMESTAMP 2647
 #define F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT 2767
 #define F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT 2768
+#define F_REGEXP_REPLACE_TEXT_TEXT_TEXT 2284
+#define F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT 2285
 
 /*
  * Prior to Postgres 14 EXTRACT mapped directly to DATE_PART.
@@ -225,6 +227,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_REGEXP_LIKE_TEXT_TEXT_TEXT:
 			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT:
 			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT:
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
 			case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
 			case F_ARRAY_AGG_ANYNONARRAY:
@@ -342,6 +346,13 @@ chfdw_check_for_custom_function(Oid funcid)
 				{
 					entry->cf_type = CF_SPLIT_BY_REGEXP;
 					strcpy(entry->custom_name, "splitByRegexp");
+					break;
+				}
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT:
+			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT:
+				{
+					entry->cf_type = CF_REPLACE_REGEXP;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2728,6 +2728,61 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					appendStringInfoChar(buf, ')');
 					return;
 				}
+			case CF_REPLACE_REGEXP:
+				{
+					/* replaceRegexpOne() or replaceRegexpAll() */
+					char	   *flags = NULL;
+
+					if (list_length(node->args) >= 4)
+					{
+						/* Determine function name from "g" in flags. */
+						/* XXX May not be a constant. Enforce elsewhere. */
+						Const	   *arg = (Const *) list_nth(node->args, 3);
+
+						flags = TextDatumGetCString(arg->constvalue);
+						char	   *c = strchr(flags, 'g');
+
+						if (c)
+						{
+							appendStringInfoString(buf, "replaceRegexpAll");
+							/* Remove any and all g flags. */
+							while (c[0])
+							{
+								while (c[1] == 'g')
+									++c;
+								c[0] = c[1];
+								++c;
+							}
+						}
+						else
+							appendStringInfoString(buf, "replaceRegexpOne");
+					}
+					else
+						appendStringInfoString(buf, "replaceRegexpOne");
+
+					appendStringInfoChar(buf, '(');
+
+					/* Emit the first string to search ("haystack"). */
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+
+					/* Emit the regular expression. */
+					if (flags && strlen(flags))
+					{
+						/* Concatenate flags. */
+						appendStringInfo(context->buf, "concat('(?%s)', ", flags);
+						deparseExpr((Expr *) list_nth(node->args, 1), context);
+						appendStringInfoChar(buf, ')');
+					}
+					else
+						deparseExpr((Expr *) list_nth(node->args, 1), context);
+
+					/* Emit the replacement string and finish. */
+					appendStringInfoString(buf, ", ");
+					deparseExpr((Expr *) list_nth(node->args, 2), context);
+					appendStringInfoChar(buf, ')');
+					return;
+				}
 			case CF_ARRAY_LENGTH:
 				appendStringInfoChar(buf, '(');
 				deparseExpr((Expr *) linitial(node->args), context);

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -303,6 +303,8 @@ typedef enum
 	CF_CH_FUNCTION,				/* adapted clickhouse function */
 	CF_MATCH,					/* regexp_match function */
 	CF_SPLIT_BY_REGEXP,			/* regexp_split_to_array → splitByRegexp */
+	CF_REPLACE_REGEXP,			/* regexp_replace → replaceRegexpOne or
+								 * replaceRegexpAll */
 	CF_REGEX_MATCH,				/* ~ POSIX regex operator */
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1471,6 +1471,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1461,6 +1461,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1461,6 +1461,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1471,6 +1471,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1471,6 +1471,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1471,6 +1471,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1471,6 +1471,102 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::
  aa-T-bb-t-cc
 (1 row)
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val4'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+ key1 | key2 | val  
+------+------+------
+    4 | key4 | val4
+(1 row)
+
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3_map
+   Output: key1, key2, val
+   Remote SQL: SELECT key1, key2, val FROM functions_test.t3_map WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+(3 rows)
+
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+ key1 | key2 | val  
+------+------+------
+    1 | key1 | val1
+(1 row)
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
                                                            QUERY PLAN                                                            

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -329,6 +329,31 @@ SELECT val FROM t8 WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
 SELECT val FROM t8 WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
 
+-- Check regexp_replace().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+SELECT * FROM t3_map WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
+-- No replace returns unmodified string.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+SELECT * FROM t3_map WHERE regexp_replace(val, '^x', 'y') = 'val4';
+-- Case-insensitive, refer to capture.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+SELECT * FROM t3_map WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
+-- Replace all case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+SELECT * FROM t3_map WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
+-- Refer to full match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+SELECT * FROM t3_map WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+
 -- Check hashing functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT key1, val FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;


### PR DESCRIPTION
Previously pg_clickhouse pushed down `regexp_replace()` without modification, which would work for simple cases. However, `regexp_replace()` in ClickHouse is an alias for `replaceRegexpAll()`, but Postgres `regexp_replace()` doesn't replace all unless the `g` flag is passed.

Add an explicit mapping for `regexp_replace(text, text, text)` and `regexp_replace(text, text, text, text)`. In `deparseFuncExpr`, determine whether flags are present and, if so, parse and remove any and all `g`s. If there are any, push down to `replaceRegexpAll()`; otherwise push down to `replaceRegexOne()` to match the default Postgres behavior.

As for the other supported regular expression functions, prepend the flags (sans `g`s) to the matching string as `(?$flags)`.

Add tests for these behaviors.