### PR TITLE
Migrate CI runners to 16-core Depot instances

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   bake:
     name: 🍪 Bake with Postgres ${{ matrix.pgv }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     if: ${{ github.repository == 'ClickHouse/pg_clickhouse' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -22,7 +22,7 @@ jobs:
           - 23.8.16.40-lts
           - 23.3.22.3-lts
     name: 🏠 ClickHouse ${{ matrix.ch }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     container: pgxn/pgxn-tools
     steps:
       - name: Start Postgres

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint:
     name: 🔎 Lint Code
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     container: pgxn/pgxn-tools
     env: { pg: 18 }
     steps:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         pg: [18, 17, 16, 15, 14, 13]
         os:
-          - { icon: 🐧, arch: amd64, on: ubuntu-latest }
-          # - { icon: 🐧, arch: arm64, on: ubuntu-24.04-arm } # XXX
+          - { icon: 🐧, arch: amd64, on: depot-ubuntu-24.04-16 }
+          # - { icon: 🐧, arch: arm64, on: depot-ubuntu-24.04-arm-16 } # XXX
     name: 🐘 PostgreSQL ${{ matrix.pg }} ${{ matrix.os.icon }} ${{ matrix.os.arch }}
     runs-on: ${{ matrix.os.on }}
     container: pgxn/pgxn-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ permissions:
 jobs:
   release:
     name: Release on GitHub and PGXN
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     container: pgxn/pgxn-tools
     steps:
       - name: Check out the repo


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions workflows from default GitHub-hosted runners to Depot 16-core runners (`depot-ubuntu-24.04-16`, `depot-ubuntu-22.04-16`, `depot-ubuntu-22.04-arm-16`)
- Covers all 6 workflows: bake, clickhouse, postgres, release, lint, and deb

## Test plan
- [ ] Verify CI jobs pick up Depot runners and complete successfully