### PR TITLE
Add `pg_clickhouse.pushdown_regex` GUC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this project will be documented in this file. It uses the
 *   All regular expression functions with compatible flags and all regular
     expression operators now push down prepended with `(?-s)` unless the `s`
     flag is set, so that the behavior mimics that of Postgres.
+*   Added the `pg_clickhouse.pushdown_regex` setting to prevent regular
+    expressions from being pushed down.
 
 ### ⬆️ Dependency Updates
 

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -235,6 +235,7 @@ extern void chfdw_report_error(int elevel, ch_connection conn,
 
 /* in option.c */
 extern kv_list * chfdw_get_session_settings(void);
+bool		chfdw_pushdown_regex_ok(void);
 
 extern void
 			chfdw_extract_options(List * defelems, char **driver, char **host, int *port,

--- a/src/option.c
+++ b/src/option.c
@@ -70,6 +70,7 @@ static const ChFdwOption ch_options[] =
  */
 static char *ch_session_settings = NULL;
 static kv_list * ch_session_settings_list = NULL;
+static bool ch_pushdown_regex = true;
 
 /*
  * Helper functions
@@ -509,6 +510,15 @@ chfdw_get_session_settings()
 }
 
 /*
+ * Return the current value of the `pushdown_regex` GUC.
+ */
+bool
+chfdw_pushdown_regex_ok()
+{
+	return ch_pushdown_regex;
+}
+
+/*
  * Validates the provided settings key/value pairs.
  */
 static bool
@@ -581,6 +591,23 @@ _PG_init(void)
 							   chfdw_check_settings_guc,
 							   chfdw_settings_assign_hook,
 							   NULL);
+
+	DefineCustomBoolVariable("pg_clickhouse.pushdown_regex",
+							 "Whether to push down regular expression operations.",
+							 "By default, pg_clickhouse attempts to push down regular "
+							 "expression functions and operations, which is fine for "
+							 "simple expressions. However, ClickHouse and Postgres use "
+							 "fundamentally different regular expression engines, so it "
+							 "may not make sense to push them all down. Set this option "
+							 "to false to prevent the Postgres regular expression functions "
+							 "and operators from pushing down to ClickHouse.",
+							 &ch_pushdown_regex,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 
 #if PG_VERSION_NUM >= 150000
 	MarkGUCPrefixReserved("pg_clickhouse");

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -208,7 +208,19 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 		CustomObjectDef *cdef = chfdw_check_for_custom_operator(objectId, NULL);
 
 		if (cdef)
-			return (cdef->cf_type != CF_UNSHIPPABLE);
+		{
+			switch (cdef->cf_type)
+			{
+				case CF_REGEX_MATCH:
+				case CF_REGEX_NO_MATCH:
+				case CF_REGEX_ICASE_MATCH:
+				case CF_REGEX_ICASE_NO_MATCH:
+					/* Don't pushdown regular expressions if the GUC is false. */
+					return chfdw_pushdown_regex_ok();
+				default:
+					return (cdef->cf_type != CF_UNSHIPPABLE);
+			}
+		}
 	}
 
 	/*
@@ -247,6 +259,13 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 				case CF_SPLIT_BY_REGEX:
 				case CF_REPLACE_REGEX:
 					{
+						/*
+						 * Don't pushdown regular expressions if the GUC is
+						 * false.
+						 */
+						if (!chfdw_pushdown_regex_ok())
+							return false;
+
 						/* Unshippable if using unsupported or dynamic flags */
 						FuncExpr   *fn = (FuncExpr *) node;
 						int			flags_idx = cdef->cf_type == CF_REPLACE_REGEX ? 3 : 2;
@@ -303,8 +322,6 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 		return (cdef && cdef->cf_type != CF_UNSHIPPABLE);
 	}
 	else if (classId == TypeRelationId && chfdw_check_for_custom_type(objectId) != NULL)
-		return true;
-	else if (classId == OperatorRelationId && chfdw_check_for_custom_operator(objectId, NULL) != NULL)
 		return true;
 
 	/* Otherwise, give up if user hasn't specified any shippable extensions. */

--- a/test/expected/ilike_regex.out
+++ b/test/expected/ilike_regex.out
@@ -418,6 +418,44 @@ SELECT id, name FROM ilike_regex_http.events WHERE name ~* '^page' ORDER BY id;
   3 | PAGE_VIEW
 (3 rows)
 
+-- Ensure no regular expression pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~ '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name ~ '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~ '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name !~ '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~* '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name ~* '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~* '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name !~* '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
 -- Cleanup
 SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
  clickhouse_raw_query 

--- a/test/expected/ilike_regex_1.out
+++ b/test/expected/ilike_regex_1.out
@@ -418,6 +418,44 @@ SELECT id, name FROM ilike_regex_http.events WHERE name ~* '^page' ORDER BY id;
   3 | PAGE_VIEW
 (3 rows)
 
+-- Ensure no regular expression pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~ '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name ~ '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~ '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name !~ '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~* '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name ~* '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~* '^page' ORDER BY id;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on ilike_regex_bin.events
+   Output: id, name, path
+   Filter: (events.name !~* '^page'::text)
+   Remote SQL: SELECT id, name, path FROM ilike_regex_test.events ORDER BY id ASC NULLS LAST
+(4 rows)
+
 -- Cleanup
 SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
  clickhouse_raw_query 

--- a/test/expected/regex.out
+++ b/test/expected/regex.out
@@ -170,6 +170,28 @@ SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
  val1
 (1 row)
 
+-- Ensure no pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_split_to_array(strings.val, ','::text) = '{a,b,c}'::text[])
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_replace(strings.val, '^x'::text, 'y'::text) = 'val2'::text)
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
+\unset ECHO
+NOTICE:  regexp_like: SELECT val FROM regex_test.strings
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE regex_test');
  clickhouse_raw_query 

--- a/test/expected/regex_1.out
+++ b/test/expected/regex_1.out
@@ -169,6 +169,28 @@ SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
  val1
 (1 row)
 
+-- Ensure no pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_split_to_array(strings.val, ','::text) = '{a,b,c}'::text[])
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_replace(strings.val, '^x'::text, 'y'::text) = 'val2'::text)
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
+\unset ECHO
+NOTICE:  regexp_like: SELECT val FROM regex_test.strings
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE regex_test');
  clickhouse_raw_query 

--- a/test/sql/ilike_regex.sql
+++ b/test/sql/ilike_regex.sql
@@ -149,6 +149,13 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id, name FROM ilike_regex_http.events WHERE name ~* '^page' ORDER BY id;
 SELECT id, name FROM ilike_regex_http.events WHERE name ~* '^page' ORDER BY id;
 
+-- Ensure no regular expression pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~ '^page' ORDER BY id;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~ '^page' ORDER BY id;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~* '^page' ORDER BY id;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~* '^page' ORDER BY id;
+
 -- Cleanup
 SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;

--- a/test/sql/regex.sql
+++ b/test/sql/regex.sql
@@ -122,6 +122,29 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
 
+-- Ensure no pushdown when we disable it.
+SET pg_clickhouse.pushdown_regex = 'false';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
+
+\unset ECHO
+-- Use DO to test functions available in Postgres 15+
+-- PG15+: trim_array → match()
+DO $_$
+DECLARE
+	output JSONB;
+BEGIN
+    IF current_setting('server_version_num')::int >= 150000 THEN
+        EXECUTE format($$EXPLAIN (VERBOSE, FORMAT JSON) SELECT val FROM strings WHERE regexp_like(val, '^val\d')$$) INTO output;
+        RAISE NOTICE 'regexp_like: %', jsonb_path_query(output, '$[0].Plan')->>'Remote SQL';
+    ELSE
+        -- Fake it on earlier versions.
+        RAISE NOTICE 'regexp_like: SELECT val FROM regex_test.strings';
+    END IF;
+END;
+$_$;
+\set ECHO all
+
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE regex_test');
 DROP SERVER regex_loopback CASCADE;


### PR DESCRIPTION
Add `pg_clickhouse.pushdown_regex` GUC, set to true by default, but when false it prevents pushdown of regular expression functions and operators. Done by checking its value in `chfdw_is_shippable()`. Add tests to ensure that the existing regular expression functions and operators don't push down when it's set to false.