### PR TITLE
Test re2 function pushdown execution

### DIFF
--- a/.github/workflows/clickhouse.yml
+++ b/.github/workflows/clickhouse.yml
@@ -26,7 +26,9 @@ jobs:
     container: pgxn/pgxn-tools
     steps:
       - name: Start Postgres
-        run: pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev
+        run: pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev libre2-dev
+      - name: Install Extensions
+        run: pgxn install re2
       - name: Checkout the Repository
         uses: actions/checkout@v6
         with: { submodules: true }

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -18,7 +18,10 @@ jobs:
     container: pgxn/pgxn-tools
     steps:
       - name: Start Postgres ${{ matrix.pg }}
-        run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev uuid-dev
+        run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev uuid-dev libre2-dev
+      - name: Install Extensions
+        if: matrix.pg >= 16
+        run: pgxn install re2
       - name: Checkout the Repository
         uses: actions/checkout@v6
         with: { submodules: true }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,24 @@ All notable changes to this project will be documented in this file. It uses the
 
 ### ⚡ Improvements
 
-*   Added pushdown for [pg_re2] functions to their ClickHouse equivalents
-    (e.g., `re2match` → `match`, `re2extractall` → `extractAll`). Thanks to
-    Philip Dubé for the PR ([#204]).
+*   Added pushdown for [re2 extension] functions, if available, to their
+    ClickHouse equivalents (e.g., `re2match` → `match`, `re2extractall` →
+    `extractAll`). Thanks to Philip Dubé for the PR ([#204]).
 
 ### 📚 Documentation
 
 *   Added "Extensions Pushdown" section to the [reference
     docs](doc/pg_clickhouse.md), covering re2 and intarray support.
+*   Added recommendation to the [reference docs](doc/pg_clickhouse.md) to
+    consider using the [re2 extension] and disabling Postgres regular
+    expression pushdown.
+
+### 🚀 Distribution
+
+*   Added the [re2 extension] to the OCI images.
 
   [v0.2.1]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.2.0...v0.2.1
-  [pg_re2]: https://github.com/ClickHouse/pg_re2
+  [re2 extension]: https://github.com/ClickHouse/pg_re2
     "pg_re2: ClickHouse-compatible regex functions using RE2"
 
 ## [v0.2.0] — 2026-04-13

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     cmake \
     libssl-dev \
+    libre2-dev \
+    pgxnclient \
+    unzip \
     g++
 
 RUN make && make install DESTDIR=/dest
 
+# Build the latest stable version of the re2 extension.
+RUN if [ "$PG_MAJOR" -ge "16" ]; then \
+        cd /tmp && pgxn download re2 && unzip re2-*.zip && rm re2-*.zip && cd re2-* && make && make install DESTDIR=/dest; \
+    fi
+
 FROM postgres:$PG_MAJOR-trixie
 
 # Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends libcurl4t64 uuid \
+RUN apt-get update && apt-get install -y --no-install-recommends libcurl4t64 uuid libre2-11 \
     && apt-get clean \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ SQL. It supports PostgreSQL 13 and later and ClickHouse v23 and later.
 ## Getting Started
 
 The simplest way to try pg_clickhouse is the [Docker image][🐳], which
-contains the standard PostgreSQL Docker image with the pg_clickhouse
-extension:
+contains the standard PostgreSQL Docker image with the pg_clickhouse and [re2]
+extensions:
 
 ```sh
 docker run --name pg_clickhouse -e POSTGRES_PASSWORD=my_pass \
@@ -298,6 +298,7 @@ adding DML features. Our road map:
   [CMake]: https://cmake.org/ "CMake: A Powerful Software Build System"
   [LibSSL]: https://openssl-library.org "OpenSSL Library"
   [TPC-H]: https://www.tpc.org/tpch/
+  [re2]: https://github.com/ClickHouse/pg_re2 "pg_re2: ClickHouse-compatible regex functions using RE2"
 
   [Query 1]: https://github.com/ClickHouse/pg_clickhouse/blob/main/dev/tpch/queries/1.sql
   [Query 2]: https://github.com/ClickHouse/pg_clickhouse/blob/main/dev/tpch/queries/2.sql

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -16,7 +16,8 @@ PostgreSQL 13 and higher and ClickHouse 23 and higher.
 ## Getting Started
 
 The simplest way to try pg_clickhouse is the [Docker image], which contains
-the standard PostgreSQL Docker image with the pg_clickhouse extension:
+the standard PostgreSQL Docker image with the pg_clickhouse and [re2][re2
+extension] extensions:
 
 ```sh
 docker run --name pg_clickhouse -e POSTGRES_PASSWORD=my_pass \
@@ -1239,10 +1240,10 @@ default), and makes an effort to ensure a basic level of compatibility, be
 aware of the differences between the two and how pg_clickhouse handles them.
 
 *   PostgreSQL supports [POSIX Regular Expressions] while ClickHouse supports
-    [RE2 Regular Expressions]. Beware of differences in behavior: write RE2
-    when the regular expression will be evaluated by ClickHouse (e.g., in a
-    `WHERE` clause) and POSIX when it will be evaluated by Postgres (e.g., in
-    a `SELECT` clause).
+    [RE2 Regular Expressions][RE2]. Beware of differences in behavior: write
+    RE2 when the regular expression will be evaluated by ClickHouse (e.g., in
+    a `WHERE` clause) and POSIX when it will be evaluated by Postgres (e.g.,
+    in a `SELECT` clause).
 
 *   pg_clickhouse pushes down the Postgres [Regex flags] by prepending them
     to ClickHouse regular expression inside `(?)`. For example:
@@ -1285,6 +1286,12 @@ aware of the differences between the two and how pg_clickhouse handles them.
     refer to the entire match, while in ClickHouse supports `\0` for the
     entire match. Be sure to use `\0` when the function pushes down to
     ClickHouse.
+
+To avoid all ambiguity, consider setting
+[pg_clickhouse.pushdown_regex](pg_clickhousepushdown_regex) to prevent
+Postgres regular expression from pushing down to ClickHouse, and using the
+[re2 extension], for which pg_clickhouse supports [direct pushdown](#re2)
+of ClickHouse-compatible [RE2] regular expressions.
 
 ## Authors
 
@@ -1387,7 +1394,7 @@ Copyright (c) 2025-2026, ClickHouse.
     "PostgreSQL Docs: POSIX Regular Expressions"
   [Postgres flags]: https://www.postgresql.org/docs/18/functions-matching.html#POSIX-EMBEDDED-OPTIONS-TABLE
     "PostgreSQL Docs: ARE Embedded-Option Letters"
-  [RE2 Regular Expressions]: https://github.com/google/re2/wiki/Syntax "RE2 Syntax"
+  [RE2]: https://github.com/google/re2/wiki/Syntax "RE2 Syntax"
   [re2 extension]: https://github.com/ClickHouse/pg_re2
     "pg_re2: ClickHouse-compatible regex functions using RE2"
   [intarray]: https://www.postgresql.org/docs/current/intarray.html

--- a/test/expected/re2_functions.out
+++ b/test/expected/re2_functions.out
@@ -1,5 +1,8 @@
-SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS have_re2 \gset
-\if :have_re2
+SELECT NOT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS no_re2 \gset
+\if :no_re2
+\echo 'SKIP: re2 extension not available'
+\quit
+\endif
 CREATE SERVER re2_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 're2_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER re2_svr;
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS re2_test');
@@ -40,7 +43,8 @@ CREATE SCHEMA re2_test;
 IMPORT FOREIGN SCHEMA re2_test FROM SERVER re2_svr INTO re2_test;
 SET search_path = re2_test, public;
 CREATE EXTENSION re2;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2match(val, 're2');
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2match(val, 're2');
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -48,7 +52,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2match(val, 're2');
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE (match(val, 're2'))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
+SELECT * FROM t1 WHERE re2match(val, 're2');
+ id |           val            
+----+--------------------------
+  2 | re2 uses finite automata
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -56,7 +67,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extract(val, '(re2)') = '
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((extract(val, '(re2)') = 're2'))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
+SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
+ id |           val            
+----+--------------------------
+  2 | re2 uses finite automata
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -64,7 +82,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+')
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((extractAll(val, '[A-Z]+') = ['POSIX','BRE','ERE']))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
+SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
+ id |          val           
+----+------------------------
+  1 | POSIX uses BRE and ERE
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -72,7 +97,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((regexpExtract(val, '(re2)', 1) = 're2'))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
+SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
+ id |           val            
+----+--------------------------
+  2 | re2 uses finite automata
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -80,7 +112,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractgroups(val, '(POSI
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((extractGroups(val, '(POSIX) uses (BRE)') = ['POSIX','BRE']))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
+SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
+ id |          val           
+----+------------------------
+  1 | POSIX uses BRE and ERE
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -88,7 +127,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpone(val, 'PO
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((replaceRegexpOne(val, 'POSIX', 're2') = 're2 uses BRE and ERE'))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
+SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
+ id |          val           
+----+------------------------
+  1 | POSIX uses BRE and ERE
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -96,7 +142,14 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpall(val, ' '
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((replaceRegexpAll(val, ' ', '-') = 're2-uses-finite-automata'))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
+SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
+ id |           val            
+----+--------------------------
+  2 | re2 uses finite automata
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -104,7 +157,15 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((countMatches(val, 'e') > 0))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
+SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
+ id |           val            
+----+--------------------------
+  1 | POSIX uses BRE and ERE
+  2 | re2 uses finite automata
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -112,7 +173,16 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatchescaseinsensiti
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((countMatchesCaseInsensitive(val, 'E') > 0))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
+SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
+ id |            val             
+----+----------------------------
+  1 | POSIX uses BRE and ERE
+  2 | re2 uses finite automata
+  3 | PCRE supports backtracking
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -120,7 +190,31 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE (multiMatchAny(val, ['POSIX','PCRE']))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
+ id |            val             
+----+----------------------------
+  1 | POSIX uses BRE and ERE
+  3 | PCRE supports backtracking
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchany(val, VARIADIC ARRAY['POSIX','PCRE']);
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on re2_test.t1
+   Output: id, val
+   Remote SQL: SELECT id, val FROM re2_test.t1 WHERE (multiMatchAny(val, ['POSIX','PCRE']))
+(3 rows)
+
+SELECT * FROM t1 WHERE re2multimatchany(val, VARIADIC ARRAY['POSIX','PCRE']);
+ id |            val             
+----+----------------------------
+  1 | POSIX uses BRE and ERE
+  3 | PCRE supports backtracking
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
@@ -128,13 +222,58 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchanyindex(val, '
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((multiMatchAnyIndex(val, ['POSIX','PCRE']) > 0))
 (3 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+ id |            val             
+----+----------------------------
+  1 | POSIX uses BRE and ERE
+  3 | PCRE supports backtracking
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, VARIADIC ARRAY['POSIX','PCRE']) > 0;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on re2_test.t1
+   Output: id, val
+   Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((multiMatchAnyIndex(val, ['POSIX','PCRE']) > 0))
+(3 rows)
+
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+ id |            val             
+----+----------------------------
+  1 | POSIX uses BRE and ERE
+  3 | PCRE supports backtracking
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
    Output: id, val
    Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((multiMatchAllIndices(val, ['POSIX','PCRE']) = [1]))
 (3 rows)
+
+SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
+ id |          val           
+----+------------------------
+  1 | POSIX uses BRE and ERE
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchallindices(val, VARIADIC ARRAY['POSIX','PCRE']) = ARRAY[1];
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on re2_test.t1
+   Output: id, val
+   Remote SQL: SELECT id, val FROM re2_test.t1 WHERE ((multiMatchAllIndices(val, ['POSIX','PCRE']) = [1]))
+(3 rows)
+
+SELECT * FROM t1 WHERE re2multimatchallindices(val, VARIADIC ARRAY['POSIX','PCRE']) = ARRAY[1];
+ id |          val           
+----+------------------------
+  1 | POSIX uses BRE and ERE
+(1 row)
 
 DROP EXTENSION re2;
 DROP USER MAPPING FOR CURRENT_USER SERVER re2_svr;
@@ -146,6 +285,3 @@ SELECT clickhouse_raw_query('DROP DATABASE re2_test');
 
 DROP SERVER re2_svr CASCADE;
 NOTICE:  drop cascades to foreign table t1
-\else
-\echo 'SKIP: re2 extension not available'
-\endif

--- a/test/expected/re2_functions_1.out
+++ b/test/expected/re2_functions_1.out
@@ -1,42 +1,5 @@
-SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS have_re2 \gset
-\if :have_re2
-CREATE SERVER re2_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 're2_test');
-CREATE USER MAPPING FOR CURRENT_USER SERVER re2_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS re2_test');
-SELECT clickhouse_raw_query('CREATE DATABASE re2_test');
-SELECT clickhouse_raw_query($$
-    CREATE TABLE re2_test.t1 (
-        id   Int32,
-        val  String
-    ) ENGINE = MergeTree ORDER BY id
-$$);
-SELECT clickhouse_raw_query($$
-    INSERT INTO re2_test.t1 VALUES
-        (1, 'POSIX uses BRE and ERE'),
-        (2, 're2 uses finite automata'),
-        (3, 'PCRE supports backtracking')
-$$);
-CREATE SCHEMA re2_test;
-IMPORT FOREIGN SCHEMA re2_test FROM SERVER re2_svr INTO re2_test;
-SET search_path = re2_test, public;
-CREATE EXTENSION re2;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2match(val, 're2');
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
-DROP EXTENSION re2;
-DROP USER MAPPING FOR CURRENT_USER SERVER re2_svr;
-SELECT clickhouse_raw_query('DROP DATABASE re2_test');
-DROP SERVER re2_svr CASCADE;
-\else
+SELECT NOT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS no_re2 \gset
+\if :no_re2
 \echo 'SKIP: re2 extension not available'
 SKIP: re2 extension not available
-\endif
+\quit

--- a/test/sql/re2_functions.sql
+++ b/test/sql/re2_functions.sql
@@ -1,5 +1,8 @@
-SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS have_re2 \gset
-\if :have_re2
+SELECT NOT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS no_re2 \gset
+\if :no_re2
+\echo 'SKIP: re2 extension not available'
+\quit
+\endif
 
 CREATE SERVER re2_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 're2_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER re2_svr;
@@ -25,24 +28,64 @@ SET search_path = re2_test, public;
 
 CREATE EXTENSION re2;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2match(val, 're2');
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
-EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2match(val, 're2');
+SELECT * FROM t1 WHERE re2match(val, 're2');
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
+SELECT * FROM t1 WHERE re2extract(val, '(re2)') = 're2';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
+SELECT * FROM t1 WHERE re2extractall(val, '[A-Z]+') = ARRAY['POSIX','BRE','ERE'];
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
+SELECT * FROM t1 WHERE re2regexpextract(val, '(re2)', 1) = 're2';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
+SELECT * FROM t1 WHERE re2extractgroups(val, '(POSIX) uses (BRE)') = ARRAY['POSIX','BRE'];
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
+SELECT * FROM t1 WHERE re2replaceregexpone(val, 'POSIX', 're2') = 're2 uses BRE and ERE';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
+SELECT * FROM t1 WHERE re2replaceregexpall(val, ' ', '-') = 're2-uses-finite-automata';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
+SELECT * FROM t1 WHERE re2countmatches(val, 'e') > 0;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
+SELECT * FROM t1 WHERE re2countmatchescaseinsensitive(val, 'E') > 0;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
+SELECT * FROM t1 WHERE re2multimatchany(val, 'POSIX','PCRE');
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchany(val, VARIADIC ARRAY['POSIX','PCRE']);
+SELECT * FROM t1 WHERE re2multimatchany(val, VARIADIC ARRAY['POSIX','PCRE']);
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, VARIADIC ARRAY['POSIX','PCRE']) > 0;
+SELECT * FROM t1 WHERE re2multimatchanyindex(val, 'POSIX','PCRE') > 0;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
+SELECT * FROM t1 WHERE re2multimatchallindices(val, 'POSIX','PCRE') = ARRAY[1];
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE re2multimatchallindices(val, VARIADIC ARRAY['POSIX','PCRE']) = ARRAY[1];
+SELECT * FROM t1 WHERE re2multimatchallindices(val, VARIADIC ARRAY['POSIX','PCRE']) = ARRAY[1];
 
 DROP EXTENSION re2;
 DROP USER MAPPING FOR CURRENT_USER SERVER re2_svr;
 SELECT clickhouse_raw_query('DROP DATABASE re2_test');
 DROP SERVER re2_svr CASCADE;
-
-\else
-\echo 'SKIP: re2 extension not available'
-\endif


### PR DESCRIPTION
Ensure that it works properly for all functions, including variadic functions. Install it into the Postgres and ClickHouse test workflows, too, for robust, ongoing validation, but omit it from the release test, to ensure that tests also past when re2's not installed.

Simplify the logic in the test to output only a couple lines if re2 isn't installed.

Add the re2 extension to the OCI images and a suggestion in the documentation that re2 be used in preference to Postgres regular expression pushdown.