### PR TITLE
Install re2 on Postgres 13+

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Start Postgres ${{ matrix.pg }}
         run: pg-start ${{ matrix.pg }} libcurl4-openssl-dev uuid-dev libre2-dev
       - name: Install Extensions
-        if: matrix.pg >= 16
         run: pgxn install re2
       - name: Checkout the Repository
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN make && make install DESTDIR=/dest
 
 # Build the latest stable version of the re2 extension.
-RUN if [ "$PG_MAJOR" -ge "16" ]; then \
-        cd /tmp && pgxn download re2 && unzip re2-*.zip && rm re2-*.zip && cd re2-* && make && make install DESTDIR=/dest; \
-    fi
+RUN cd /tmp && pgxn download re2 && unzip re2-*.zip && rm re2-*.zip && cd re2-* && make && make install DESTDIR=/dest
 
 FROM postgres:$PG_MAJOR-trixie
 


### PR DESCRIPTION
The v0.1.1 release added support back to 13.