### PR TITLE
Fix issues identified by `clang-tidy`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     env: { pg: 18 }
     steps:
       - name: Install Postgres
-        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev
+        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev clang-tidy
       - name: Checkout the Repository
         uses: actions/checkout@v6
       - name: Install pre-commit
@@ -22,6 +22,6 @@ jobs:
       - name: Initialize Submodules
         run: git submodule update --init
       - name: Generate compile_commands.json
-        run: bear -- make all
+        run: make compile_commands.json
       - name: Lint the Code
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,8 @@ lsp: compile_commands.json
 
 # Requires https://github.com/rizsotto/Bear.
 compile_commands.json:
-	$(MAKE) clean
-	bear -- $(MAKE) all
+	$(MAKE) clean -j $$(nproc) NO_VENDOR_CLEAN=$(NO_VENDOR_CLEAN)
+	bear -- $(MAKE) all -j $$(nproc) NO_VENDOR_CLEAN=$(NO_VENDOR_CLEAN)
 
 # ClickHouse Docker Containers
 start-containers: dev/Makefile dev/docker-compose.yml

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2591,7 +2591,6 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 	 * Normal function: display as proname(args). CF_ARRAY_SORT_DESC name
 	 * depends on boolean arg, resolve before printing.
 	 */
-	cdef = chfdw_check_for_custom_function(node->funcid);
 	cdef = appendFunctionName(node->funcid, context);
 
 	if (cdef)

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -19,7 +19,6 @@
 #include "optimizer/restrictinfo.h"
 #include "optimizer/tlist.h"
 #include "parser/parsetree.h"
-#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/palloc.h"
 #include "utils/rel.h"


### PR DESCRIPTION
Speed up the building of `compile_commands.json` and install clang-tidy in the GitHub lint workflow.