### PR TITLE
fix non-terminating backwards scan

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,12 +8,13 @@ Checks: >
   -*,
   bugprone-assert-side-effect,
   bugprone-double-free,
-  bugprone-unchecked-optional-access
+  bugprone-unchecked-optional-access,
   bugprone-unchecked-string-to-number-conversion,
   bugprone-use-after-move,
   clang-analyzer-*,
   -clang-analyzer-optin.performance*,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  clang-diagnostic-tautological-*,
   misc-redundant-expression,
   misc-unused-using-decls,
   readability-duplicate-include,
@@ -23,6 +24,7 @@ WarningsAsErrors: >
   bugprone-double-free,
   bugprone-use-after-move,
   clang-analyzer-core.*,
+  clang-diagnostic-tautological-*,
 
 CheckOptions:
   - key: bugprone-assert-side-effect.AssertMacros

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ PG_LDFLAGS = -lstdc++ -lssl -lcrypto $(shell $(CURL_CONFIG) --libs)
 PG_CXXFLAGS = -std=c++17
 
 # Suppress annoying pre-c99 warning and include curl flags.
-PG_CFLAGS = -Wno-declaration-after-statement $(shell $(CURL_CONFIG) --cflags)
+PG_CFLAGS = -Wno-declaration-after-statement -Werror=type-limits $(shell $(CURL_CONFIG) --cflags)
 
 # We'll need libuuid except on darwin, where it's included in the OS.
 ifneq ($(OS),darwin)

--- a/src/http_streaming.c
+++ b/src/http_streaming.c
@@ -238,7 +238,9 @@ capture_transfer_info(HttpStream * stream)
 
 /* ----------------------------------------------------------------
  * find_batch_end — find a row-aligned split point near fetch_size
- * bytes. Looks forward then backward for nearest newline.
+ * bytes. Looks forward then backward for nearest newline. Never
+ * returns a partial row: if no newline is buffered, returns 0 so
+ * the caller keeps ingesting.
  * ----------------------------------------------------------------
  */
 static size_t
@@ -260,9 +262,9 @@ find_batch_end(const HttpStream * stream)
 			return (found - base) + 1;
 
 		/* Look backward */
-		for (size_t i = stream->fetch_size - 1; i >= 0; i--)
-			if (base[i] == '\n')
-				return i + 1;
+		for (size_t i = stream->fetch_size; i > 0; i--)
+			if (base[i - 1] == '\n')
+				return i;
 	}
 
 	if (stream->transfer_done)


### PR DESCRIPTION
size_t is unsigned, `i >= 0` is always true

add -Werror=type-limits to fail on this sort of error in future

re #220