### PR TITLE
test: add misbehaving mock ClickHouse harness (#194)

### DIFF
--- a/test/mock/README.md
+++ b/test/mock/README.md
@@ -1,0 +1,68 @@
+# Misbehaving Mock ClickHouse
+
+Tests that exercise pg_clickhouse against intentionally malformed ClickHouse
+HTTP responses. Companion to issue [#194].
+
+## What it covers
+
+The real ClickHouse server is well-behaved, so the parser (`src/parser.c`)
+and HTTP transport (`src/http.c`, `src/http_streaming.c`) rarely see invalid
+input in CI. PR [#188] showed there are real bugs lurking when the bytes on
+the wire are not the bytes we expect. This mock returns those bytes on
+demand so we can lock the behavior down.
+
+Behaviors covered:
+
+- `http_500` — ClickHouse-style server error with `X-ClickHouse-Exception-Code`.
+- `http_503` — Service unavailable with no body.
+- `invalid_array` — TSV row whose final field opens an array literal but
+  never closes it (the bug class fixed in #188).
+- `truncated_chunked` — chunked transfer that promises 32 bytes and ships 5,
+  then closes without the terminating chunk.
+- `slow_headers` — delays the first byte to exercise client-side timeouts.
+- `invalid_json` — `application/json` content type with a truncated JSON body.
+- `drop_during_body` — sends a `Content-Length` then drops the socket
+  partway through the body.
+- `trailing_garbage` — valid TSV followed by 32 bytes of binary smear and no
+  trailing newline.
+- `unterminated_string` — array field with an open quote and no closing quote.
+- `backslash_at_eof` — field that ends with a lone backslash (escape with no
+  escapee).
+- `wrong_content_length` — `Content-Length` larger than the body actually
+  delivered.
+
+## Running the tests
+
+The mock and its tests are pure-Python and have no PostgreSQL or ClickHouse
+dependency.
+
+```sh
+# from the repo root
+pip install pytest
+python3 -m pytest test/mock -v
+```
+
+To run the mock standalone (e.g. when wiring it into a future regression
+test):
+
+```sh
+python3 test/mock/mock_clickhouse.py --port 18123
+```
+
+Then point pg_clickhouse at it:
+
+```sql
+SELECT clickhouse_raw_query(
+    '-- BEHAVIOR=http_500
+SELECT 1',
+    'host=127.0.0.1 port=18123'
+);
+```
+
+The pg-side regression test that drives the mock through `clickhouse_raw_query()`
+lives at `test/mock/mock_misbehaving.sql`. It is *not* part of the default
+`make installcheck` schedule (the mock server has to be running first); see
+the comment at the top of that file for how to opt in.
+
+[#188]: https://github.com/ClickHouse/pg_clickhouse/pull/188
+[#194]: https://github.com/ClickHouse/pg_clickhouse/issues/194

--- a/test/mock/conftest.py
+++ b/test/mock/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration: add this directory to ``sys.path`` so the test file
+can ``import mock_clickhouse`` without an installed package."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)

--- a/test/mock/mock_clickhouse.py
+++ b/test/mock/mock_clickhouse.py
@@ -1,0 +1,326 @@
+"""Mock ClickHouse HTTP server that misbehaves on demand.
+
+The real ClickHouse HTTP interface always returns well-formed responses, so
+the pg_clickhouse parser and HTTP transport rarely see the kinds of invalid
+input that bug #194 (and the parser fix in #188) imply they should handle
+gracefully. This mock is a small standalone HTTP server that intentionally
+returns malformed, partial, slow, or dropped responses so the extension can be
+exercised against them.
+
+The mock dispatches on a marker that callers embed in the SQL body of the
+request:
+
+    -- BEHAVIOR=<name>
+    SELECT 1
+
+Supported behaviors are defined in :data:`BEHAVIORS`. A request without a
+marker is answered with a single tab-separated row so simple round-trip tests
+keep working.
+
+Run standalone:
+
+    python3 test/mock/mock_clickhouse.py --port 18123
+
+Or import :class:`MockClickHouseServer` from a test and start it in a thread.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+from urllib.parse import parse_qs, urlparse
+
+# A small TSV body that looks like a real ClickHouse text response.
+HAPPY_BODY = b"1\thello\n"
+
+# Pattern used to extract the BEHAVIOR marker from a request body or query
+# string. Matches '-- BEHAVIOR=<name>' on its own line, or 'behavior=<name>'
+# in the query string.
+_BEHAVIOR_RE = re.compile(rb"--\s*BEHAVIOR\s*=\s*([A-Za-z0-9_-]+)")
+
+
+class _RawHandler(BaseHTTPRequestHandler):
+    """HTTP handler that emits a configured misbehavior per request."""
+
+    server_version = "MockClickHouse/0.1"
+
+    # Silence the default per-request stderr logging; tests will inspect the
+    # captured behavior log instead.
+    def log_message(self, format, *args):  # noqa: A002 - signature from BaseHTTPRequestHandler
+        return
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _pick_behavior(self, body: bytes) -> str:
+        # Body marker wins; fall back to query string for GET-style probes.
+        match = _BEHAVIOR_RE.search(body or b"")
+        if match:
+            return match.group(1).decode("ascii")
+        qs = parse_qs(urlparse(self.path).query)
+        if "behavior" in qs and qs["behavior"]:
+            return qs["behavior"][0]
+        return "happy"
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        self._dispatch(self._read_body())
+
+    def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        self._dispatch(self._read_body())
+
+    def _dispatch(self, body: bytes):
+        behavior = self._pick_behavior(body)
+        handler = BEHAVIORS.get(behavior, _happy)
+        # Record what we did so tests can assert dispatch happened.
+        self.server.behaviors_seen.append(behavior)  # type: ignore[attr-defined]
+        try:
+            handler(self)
+        except (BrokenPipeError, ConnectionResetError):
+            # The client may have closed the socket on us (the dropped-body
+            # behaviors are designed to provoke this); swallow so the server
+            # thread keeps serving.
+            pass
+
+
+# --- Behavior implementations -------------------------------------------------
+#
+# Each behavior takes the request handler and is responsible for producing the
+# full response (status, headers, body). They deliberately bypass the helper
+# `send_response` flow when they need to emit malformed bytes the API would
+# otherwise reject.
+
+
+def _happy(h: _RawHandler) -> None:
+    """Well-formed 200 response with a single TSV row."""
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(HAPPY_BODY)))
+    h.end_headers()
+    h.wfile.write(HAPPY_BODY)
+
+
+def _http_500(h: _RawHandler) -> None:
+    """ClickHouse-style 500 with the error text in the body."""
+    body = b"Code: 60. DB::Exception: Table mock.t does not exist.\n"
+    h.send_response(500)
+    h.send_header("Content-Type", "text/plain; charset=UTF-8")
+    h.send_header("X-ClickHouse-Exception-Code", "60")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _http_503(h: _RawHandler) -> None:
+    """Service unavailable, no body."""
+    h.send_response(503)
+    h.send_header("Content-Length", "0")
+    h.end_headers()
+
+
+def _invalid_array(h: _RawHandler) -> None:
+    """200 OK with an unterminated array literal that the parser must reject.
+
+    Mirrors the kind of corruption fixed in PR #188 -- the parser previously
+    walked off the end of the buffer when the final field omitted its closing
+    bracket.
+    """
+    body = b"1\t['unterminated\n"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _truncated_chunked(h: _RawHandler) -> None:
+    """Chunked transfer that announces more bytes than it delivers.
+
+    Sends one chunk header promising 32 bytes, then writes only 5 and closes
+    the connection without the terminating 0-chunk.
+    """
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Transfer-Encoding", "chunked")
+    h.end_headers()
+    h.wfile.write(b"20\r\n")  # 0x20 = 32 bytes promised
+    h.wfile.write(b"1\the")  # only 5 bytes actually written
+    h.wfile.flush()
+    # Close the underlying socket abruptly. libcurl should surface a transport
+    # error rather than emitting a partial row to the parser.
+    try:
+        h.connection.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    h.connection.close()
+
+
+def _slow_headers(h: _RawHandler) -> None:
+    """Delay before the first byte. Used to exercise client-side timeouts."""
+    delay = float(getattr(h.server, "slow_seconds", 0.5))  # type: ignore[attr-defined]
+    time.sleep(delay)
+    body = b"1\tlate\n"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _invalid_json(h: _RawHandler) -> None:
+    """JSON-flavored response with truncated body + JSON content-type."""
+    body = b'{"meta":[{"name":"x"}],"data":[{"x":1'
+    h.send_response(200)
+    h.send_header("Content-Type", "application/json")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _drop_during_body(h: _RawHandler) -> None:
+    """Send headers + a few bytes then drop the connection mid-body."""
+    body_prefix = b"1\thel"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    # Lie about length so the client knows there is more coming.
+    h.send_header("Content-Length", "1024")
+    h.end_headers()
+    h.wfile.write(body_prefix)
+    h.wfile.flush()
+    try:
+        h.connection.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    h.connection.close()
+
+
+def _trailing_garbage(h: _RawHandler) -> None:
+    """Otherwise valid TSV body followed by binary garbage and no newline."""
+    body = b"1\tok\n2\tnext" + bytes(range(0, 32))
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _unterminated_string(h: _RawHandler) -> None:
+    """Array literal with an open quote and no closing quote."""
+    body = b"1\t['hello world\n"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _backslash_at_eof(h: _RawHandler) -> None:
+    """Field that ends with a lone backslash (escape with no escapee)."""
+    body = b"1\tfoo\\"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body)))
+    h.end_headers()
+    h.wfile.write(body)
+
+
+def _wrong_content_length(h: _RawHandler) -> None:
+    """Content-Length larger than the body we actually write."""
+    body = b"1\tshort\n"
+    h.send_response(200)
+    h.send_header("Content-Type", "text/tab-separated-values; charset=UTF-8")
+    h.send_header("Content-Length", str(len(body) + 64))
+    h.end_headers()
+    h.wfile.write(body)
+    # Close before satisfying the announced length.
+    try:
+        h.connection.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    h.connection.close()
+
+
+BEHAVIORS: dict[str, Callable[[_RawHandler], None]] = {
+    "happy": _happy,
+    "http_500": _http_500,
+    "http_503": _http_503,
+    "invalid_array": _invalid_array,
+    "truncated_chunked": _truncated_chunked,
+    "slow_headers": _slow_headers,
+    "invalid_json": _invalid_json,
+    "drop_during_body": _drop_during_body,
+    "trailing_garbage": _trailing_garbage,
+    "unterminated_string": _unterminated_string,
+    "backslash_at_eof": _backslash_at_eof,
+    "wrong_content_length": _wrong_content_length,
+}
+
+
+class MockClickHouseServer(ThreadingHTTPServer):
+    """Threaded HTTP server with a record of the behaviors it has served."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address: tuple[str, int], slow_seconds: float = 0.5):
+        super().__init__(address, _RawHandler)
+        self.behaviors_seen: list[str] = []
+        self.slow_seconds = slow_seconds
+
+    @classmethod
+    def start(
+        cls, host: str = "127.0.0.1", port: int = 0, slow_seconds: float = 0.5
+    ) -> "MockClickHouseServer":
+        """Start a server in a background thread and return it.
+
+        Use ``server.server_address`` to discover the assigned port when
+        ``port=0``.
+        """
+        server = cls((host, port), slow_seconds=slow_seconds)
+        thread = threading.Thread(
+            target=server.serve_forever, name="mock-clickhouse", daemon=True
+        )
+        thread.start()
+        server._thread = thread  # type: ignore[attr-defined]
+        return server
+
+    def stop(self) -> None:
+        self.shutdown()
+        self.server_close()
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18123)
+    parser.add_argument(
+        "--slow-seconds",
+        type=float,
+        default=0.5,
+        help="delay used by the slow_headers behavior",
+    )
+    args = parser.parse_args()
+    server = MockClickHouseServer(
+        (args.host, args.port), slow_seconds=args.slow_seconds
+    )
+    print(
+        f"mock_clickhouse listening on http://{args.host}:{server.server_address[1]}/"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/test/mock/mock_misbehaving.sql
+++ b/test/mock/mock_misbehaving.sql
@@ -1,0 +1,75 @@
+-- Drive pg_clickhouse against the misbehaving mock server defined in
+-- test/mock/mock_clickhouse.py. This file lives outside test/sql/ on purpose
+-- so it does *not* run as part of `make installcheck`: it requires the mock
+-- server to be running on port 18123. To run by hand:
+--
+--     python3 test/mock/mock_clickhouse.py --port 18123 &
+--     psql -d <db> -f test/mock/mock_misbehaving.sql
+--
+-- Each query below is expected to surface a Postgres ERROR (the mock is
+-- intentionally returning bad bytes); the goal is that none of them crash
+-- the backend or hang it. The companion pytest suite at
+-- test/mock/test_mock_clickhouse.py asserts the wire-level behavior of the
+-- mock itself.
+
+\set mock_conn 'host=127.0.0.1 port=18123'
+
+-- Sanity: the mock returns a single happy row for unmarked queries.
+SELECT clickhouse_raw_query('SELECT 1', :'mock_conn');
+
+-- A 500 from ClickHouse must surface as a Postgres ERROR with the upstream
+-- exception text intact (not an empty / generic transport error).
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=http_500\nSELECT 1', :'mock_conn'
+);
+
+-- 503 with no body should still produce an ERROR, not a misleading empty row.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=http_503\nSELECT 1', :'mock_conn'
+);
+
+-- Unterminated array literal: parser must reject, not crash. Regression test
+-- for the class of bugs fixed in PR #188.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=invalid_array\nSELECT 1', :'mock_conn'
+);
+
+-- Open quote inside an array with no close.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=unterminated_string\nSELECT 1', :'mock_conn'
+);
+
+-- Field ends with a lone escape byte.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=backslash_at_eof\nSELECT 1', :'mock_conn'
+);
+
+-- Valid prefix, binary garbage tail, no trailing newline.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=trailing_garbage\nSELECT 1', :'mock_conn'
+);
+
+-- Chunked transfer cut short mid-body.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=truncated_chunked\nSELECT 1', :'mock_conn'
+);
+
+-- Connection dropped after partial body.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=drop_during_body\nSELECT 1', :'mock_conn'
+);
+
+-- Server lies about Content-Length and closes early.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=wrong_content_length\nSELECT 1', :'mock_conn'
+);
+
+-- application/json content-type with a truncated JSON body. The text driver
+-- doesn't expect JSON, but it must not crash on it either.
+SELECT clickhouse_raw_query(
+    E'-- BEHAVIOR=invalid_json\nSELECT 1', :'mock_conn'
+);
+
+-- After every misbehavior, the connection cache must remain usable. Issuing
+-- a happy-path query last verifies we did not leave a broken socket pinned.
+SELECT clickhouse_raw_query('SELECT 1', :'mock_conn');

--- a/test/mock/test_mock_clickhouse.py
+++ b/test/mock/test_mock_clickhouse.py
@@ -1,0 +1,281 @@
+"""Tests for the misbehaving mock ClickHouse server.
+
+These tests do not require PostgreSQL or ClickHouse. They start the in-process
+:class:`MockClickHouseServer`, fire HTTP requests with the marker the
+extension-side regression test will use, and assert the wire-level shape of
+each misbehavior.
+
+The point is to lock down the contract that the SQL regression test
+``test/sql/mock_misbehaving.sql`` relies on: when pg_clickhouse hits the mock
+with a particular ``-- BEHAVIOR=<name>`` marker, the bytes coming back are
+the bytes the parser/transport must cope with. If a future change to the mock
+breaks one of those shapes, these tests fail loudly before the regression
+suite has a chance to mask it.
+
+Run with:
+
+    python3 -m pytest test/mock/test_mock_clickhouse.py -v
+"""
+
+from __future__ import annotations
+
+import http.client
+import socket
+import threading
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+from mock_clickhouse import BEHAVIORS, MockClickHouseServer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def server() -> Iterator[MockClickHouseServer]:
+    srv = MockClickHouseServer(("127.0.0.1", 0), slow_seconds=0.25)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _post(
+    server: MockClickHouseServer, body: bytes, *, timeout: float = 2.0
+) -> tuple[int, dict[str, str], bytes]:
+    """POST ``body`` to the mock and return (status, headers, body).
+
+    Uses :mod:`http.client` directly so chunked transfer / partial reads stay
+    visible -- ``requests`` would re-buffer them away.
+    """
+    host, port = server.server_address
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        conn.request("POST", "/", body=body)
+        resp = conn.getresponse()
+        return resp.status, dict(resp.getheaders()), resp.read()
+    finally:
+        conn.close()
+
+
+@contextmanager
+def _raw_socket(
+    server: MockClickHouseServer, body: bytes, *, timeout: float = 2.0
+) -> Iterator[socket.socket]:
+    """Issue a POST over a raw socket so callers can inspect the wire bytes."""
+    host, port = server.server_address
+    sock = socket.create_connection((host, port), timeout=timeout)
+    try:
+        request = (
+            b"POST / HTTP/1.1\r\n"
+            b"Host: " + host.encode() + b"\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"Connection: close\r\n"
+            b"\r\n" + body
+        )
+        sock.sendall(request)
+        yield sock
+    finally:
+        sock.close()
+
+
+# ---------------------------------------------------------------------------
+# Behavior coverage
+# ---------------------------------------------------------------------------
+
+
+def test_behaviors_registry_is_complete() -> None:
+    """Sanity: each behavior referenced by the SQL test exists in the mock."""
+    expected = {
+        "happy",
+        "http_500",
+        "http_503",
+        "invalid_array",
+        "truncated_chunked",
+        "slow_headers",
+        "invalid_json",
+        "drop_during_body",
+        "trailing_garbage",
+        "unterminated_string",
+        "backslash_at_eof",
+        "wrong_content_length",
+    }
+    assert expected.issubset(set(BEHAVIORS)), "missing behaviors: " + ", ".join(
+        sorted(expected - set(BEHAVIORS))
+    )
+
+
+def test_happy_path(server: MockClickHouseServer) -> None:
+    status, _headers, body = _post(server, b"-- BEHAVIOR=happy\nSELECT 1")
+    assert status == 200
+    assert body == b"1\thello\n"
+    assert server.behaviors_seen == ["happy"]
+
+
+def test_default_when_no_marker(server: MockClickHouseServer) -> None:
+    """Requests without a BEHAVIOR marker fall through to the happy path."""
+    status, _headers, body = _post(server, b"SELECT 1")
+    assert status == 200
+    assert body == b"1\thello\n"
+    assert server.behaviors_seen == ["happy"]
+
+
+def test_http_500_carries_clickhouse_error_text(server: MockClickHouseServer) -> None:
+    status, headers, body = _post(server, b"-- BEHAVIOR=http_500\nSELECT 1")
+    assert status == 500
+    assert headers.get("X-ClickHouse-Exception-Code") == "60"
+    assert b"DB::Exception" in body
+
+
+def test_http_503_no_body(server: MockClickHouseServer) -> None:
+    status, _headers, body = _post(server, b"-- BEHAVIOR=http_503\nSELECT 1")
+    assert status == 503
+    assert body == b""
+
+
+def test_invalid_array_body_is_unterminated(server: MockClickHouseServer) -> None:
+    """The parser bug fixed in #188: a final '[' field with no ']'."""
+    status, _headers, body = _post(server, b"-- BEHAVIOR=invalid_array\nSELECT 1")
+    assert status == 200
+    assert body.endswith(b"['unterminated\n")
+    assert b"]" not in body
+
+
+def test_invalid_json_is_truncated(server: MockClickHouseServer) -> None:
+    status, headers, body = _post(server, b"-- BEHAVIOR=invalid_json\nSELECT 1")
+    assert status == 200
+    assert headers.get("Content-Type") == "application/json"
+    assert b'"data":[{"x":1' in body
+    # No closing brace anywhere -- the body really is truncated.
+    assert body.count(b"}") < body.count(b"{")
+
+
+def test_unterminated_string_in_array(server: MockClickHouseServer) -> None:
+    status, _headers, body = _post(server, b"-- BEHAVIOR=unterminated_string\nSELECT 1")
+    assert status == 200
+    # Open quote, no close.
+    assert b"['hello world" in body
+    assert body.count(b"'") == 1
+
+
+def test_backslash_at_eof(server: MockClickHouseServer) -> None:
+    status, _headers, body = _post(server, b"-- BEHAVIOR=backslash_at_eof\nSELECT 1")
+    assert status == 200
+    assert body.endswith(b"\\")
+
+
+def test_trailing_garbage(server: MockClickHouseServer) -> None:
+    status, _headers, body = _post(server, b"-- BEHAVIOR=trailing_garbage\nSELECT 1")
+    assert status == 200
+    # Starts with valid TSV, ends with binary smear, no terminating newline.
+    assert body.startswith(b"1\tok\n2\tnext")
+    assert not body.endswith(b"\n")
+    assert any(b < 32 for b in body[-32:] if b not in (ord("\t"), ord("\n")))
+
+
+def test_truncated_chunked_drops_connection(server: MockClickHouseServer) -> None:
+    """Chunk header promises 32 bytes but only 5 arrive; socket then closes."""
+    body = b"-- BEHAVIOR=truncated_chunked\nSELECT 1"
+    with _raw_socket(server, body, timeout=2.0) as sock:
+        received = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+            # Bound the read so we never block forever in case of regressions.
+            if len(received) > 4096:
+                break
+    assert b"Transfer-Encoding: chunked" in received
+    assert b"\r\n20\r\n" in received  # the 32-byte promise
+    payload = received.split(b"\r\n20\r\n", 1)[1]
+    # Far less than the promised 32 bytes, no terminating "0\r\n\r\n".
+    assert len(payload) < 32
+    assert b"\r\n0\r\n\r\n" not in received
+
+
+def test_drop_during_body_short_circuits(server: MockClickHouseServer) -> None:
+    body = b"-- BEHAVIOR=drop_during_body\nSELECT 1"
+    with _raw_socket(server, body, timeout=2.0) as sock:
+        received = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+            if len(received) > 4096:
+                break
+    # The mock advertises a 1024-byte body but closes after a few bytes.
+    assert b"Content-Length: 1024" in received
+    headers, _, payload = received.partition(b"\r\n\r\n")
+    assert payload == b"1\thel"
+
+
+def test_wrong_content_length_closes_early(server: MockClickHouseServer) -> None:
+    """Server promises more bytes than it delivers, then drops."""
+    body = b"-- BEHAVIOR=wrong_content_length\nSELECT 1"
+    with _raw_socket(server, body, timeout=2.0) as sock:
+        received = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            received += chunk
+            if len(received) > 4096:
+                break
+    headers, _, payload = received.partition(b"\r\n\r\n")
+    # Content-Length should overstate the body.
+    cl_line = next(
+        line
+        for line in headers.split(b"\r\n")
+        if line.lower().startswith(b"content-length:")
+    )
+    declared = int(cl_line.split(b":", 1)[1].strip())
+    assert declared > len(payload)
+
+
+def test_slow_headers_delays_first_byte(server: MockClickHouseServer) -> None:
+    server.slow_seconds = 0.25
+    start = time.monotonic()
+    status, _headers, body = _post(
+        server, b"-- BEHAVIOR=slow_headers\nSELECT 1", timeout=2.0
+    )
+    elapsed = time.monotonic() - start
+    assert status == 200
+    assert body == b"1\tlate\n"
+    # Generous lower bound -- CI clocks can be jittery.
+    assert elapsed >= 0.2, f"slow_headers returned in {elapsed:.3f}s"
+
+
+def test_query_string_marker_also_works(server: MockClickHouseServer) -> None:
+    """Some callers cannot edit the body; ?behavior=<name> works too."""
+    host, port = server.server_address
+    conn = http.client.HTTPConnection(host, port, timeout=2.0)
+    try:
+        conn.request("POST", "/?behavior=http_500", body=b"SELECT 1")
+        resp = conn.getresponse()
+        assert resp.status == 500
+    finally:
+        conn.close()
+
+
+def test_unknown_behavior_falls_back_to_happy(server: MockClickHouseServer) -> None:
+    """Unknown markers should not crash the mock; default to happy."""
+    status, _headers, body = _post(server, b"-- BEHAVIOR=does_not_exist\nSELECT 1")
+    assert status == 200
+    assert body == b"1\thello\n"
+
+
+def test_server_records_each_request(server: MockClickHouseServer) -> None:
+    _post(server, b"-- BEHAVIOR=happy\nSELECT 1")
+    _post(server, b"-- BEHAVIOR=http_500\nSELECT 1")
+    _post(server, b"-- BEHAVIOR=happy\nSELECT 2")
+    assert server.behaviors_seen == ["happy", "http_500", "happy"]


### PR DESCRIPTION
## Summary
Closes #194. Adds an in-process Python `ThreadingHTTPServer` mock that returns malformed, partial, slow, or dropped HTTP responses, plus a 17-case pytest suite that locks down the wire-level contract of each misbehavior.

## Mock approach (`test/mock/mock_clickhouse.py`)
Dispatches on a `-- BEHAVIOR=<name>` marker embedded in the request body or `?behavior=` query string. Each behavior emits malformed bytes directly to the socket — some bypass `send_response` / `shutdown` mid-body — so the real `libcurl` + `parser.c` paths see the kinds of responses real ClickHouse never produces.

## Behaviors covered
5xx errors with and without `X-ClickHouse-Exception-Code`, unterminated array literals (PR #188 regression class), truncated chunked transfer, slow headers / timeout exercise, truncated JSON, mid-body drops, trailing binary garbage, unterminated quoted strings, backslash at EOF, wrong `Content-Length`, request log.

## Files changed
All new, all under `test/mock/`:
- `mock_clickhouse.py` — server
- `test_mock_clickhouse.py` — pytest (17 cases)
- `conftest.py` — sys.path
- `mock_misbehaving.sql` — opt-in SQL driver, deliberately outside `test/sql/` so `make installcheck` is unaffected
- `README.md` — documentation

761 lines total. **No source code changes.**

## Test plan
- `ruff format` clean, `ruff check` clean, `codespell` clean
- `pytest -v` 17/17 passed in 8.26s
- Verifies the mock's wire-level contract end-to-end without needing PostgreSQL or ClickHouse running
