### PR TITLE
feat: add three-state secure option (on/off/auto) for TLS control

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -37,8 +37,30 @@ jobs:
         run: cd vendor/clickhouse-cpp && touch -d $(git log -1 --format="@%ct" CMakeLists.txt) CMakeLists.txt
       - name: Test DSO
         run: pg-build-test
+      - name: Show regression diffs (DSO)
+        if: failure()
+        run: cat regression.diffs || true
+      - name: Upload actual results (DSO)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-results-pg${{ matrix.pg }}-${{ matrix.os.arch }}-dso
+          path: |
+            regression.diffs
+            results/
       - name: Clean
         run: make clean NO_VENDOR_CLEAN=1
       - name: Test Static
         run: pg-build-test
         env: { CH_BUILD: static }
+      - name: Show regression diffs (Static)
+        if: failure()
+        run: cat regression.diffs || true
+      - name: Upload actual results (Static)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-results-pg${{ matrix.pg }}-${{ matrix.os.arch }}-static
+          path: |
+            regression.diffs
+            results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,17 @@ jobs:
       - name: Test the Bundle
         env: { PGUSER: postgres }
         run: make dist-test
+      - name: Show regression diffs
+        if: failure()
+        run: cat pg_clickhouse-*/regression.diffs || cat regression.diffs || true
+      - name: Upload regression results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-results
+          path: |
+            pg_clickhouse-*/regression.diffs
+            pg_clickhouse-*/results/
       - name: Release on PGXN
         if: startsWith( github.ref, 'refs/tags/v' )
         env:

--- a/src/connection.c
+++ b/src/connection.c
@@ -46,9 +46,11 @@ clickhouse_connect(ForeignServer * server, UserMapping * user)
 	ch_connection_details details = {"127.0.0.1", 0, NULL, NULL, "default"};
 
 	chfdw_extract_options(server->options, &driver, &details.host,
-						  &details.port, &details.dbname, &details.username, &details.password);
+						  &details.port, &details.dbname, &details.username, &details.password,
+						  &details.tls);
 	chfdw_extract_options(user->options, &driver, &details.host,
-						  &details.port, &details.dbname, &details.username, &details.password);
+						  &details.port, &details.dbname, &details.username, &details.password,
+						  &details.tls);
 
 	if (strcmp(driver, "http") == 0)
 	{

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1789,7 +1789,7 @@ deparseRelation(StringInfo buf, Relation rel)
 	ForeignServer *server = chfdw_get_foreign_server(rel);
 	ListCell   *lc;
 
-	chfdw_extract_options(server->options, NULL, NULL, NULL, &dbname, NULL, NULL);
+	chfdw_extract_options(server->options, NULL, NULL, NULL, &dbname, NULL, NULL, NULL);
 
 	/* obtain additional catalog information. */
 	table = GetForeignTable(RelationGetRelid(rel));

--- a/src/http.c
+++ b/src/http.c
@@ -82,8 +82,26 @@ ch_http_connection(ch_connection_details * details)
 	if (!host || !*host)
 		host = "localhost";
 
-	if (!port)
-		port = ch_is_cloud_host(host) ? CLICKHOUSE_TLS_PORT : CLICKHOUSE_PORT;
+	bool		use_tls;
+
+	switch (details->tls)
+	{
+		case CH_TLS_ON:
+			if (!port)
+				port = CLICKHOUSE_TLS_PORT;
+			use_tls = true;
+			break;
+		case CH_TLS_OFF:
+			if (!port)
+				port = CLICKHOUSE_PORT;
+			use_tls = false;
+			break;
+		default:				/* CH_TLS_AUTO */
+			if (!port)
+				port = ch_is_cloud_host(host) ? CLICKHOUSE_TLS_PORT : CLICKHOUSE_PORT;
+			use_tls = (port == CLICKHOUSE_TLS_PORT || port == HTTP_TLS_PORT);
+			break;
+	}
 
 	len += strlen(host) + snprintf(NULL, 0, "%d", port);
 
@@ -103,7 +121,7 @@ ch_http_connection(ch_connection_details * details)
 	if (!connstring)
 		goto cleanup;
 
-	char	   *scheme = port == CLICKHOUSE_TLS_PORT || port == HTTP_TLS_PORT ? "https" : "http";
+	char	   *scheme = use_tls ? "https" : "http";
 
 	if (username && password)
 	{

--- a/src/include/engine.h
+++ b/src/include/engine.h
@@ -6,6 +6,14 @@
 /*
  * ch_connection_details defines the details for connecting to ClickHouse.
  */
+/* TLS mode for the "secure" FDW option (auto=heuristic, on=force, off=never) */
+typedef enum
+{
+	CH_TLS_AUTO = 0,			/* cloud-hostname heuristic (default) */
+	CH_TLS_ON,					/* always HTTPS; default port 8443 */
+	CH_TLS_OFF,					/* always HTTP;  default port 8123 */
+}			ch_tls_mode;
+
 typedef struct
 {
 	char	   *host;
@@ -13,6 +21,7 @@ typedef struct
 	char	   *username;
 	char	   *password;
 	char	   *dbname;
+	ch_tls_mode tls;			/* TLS mode; CH_TLS_AUTO when not specified */
 }			ch_connection_details;
 
 /*

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -239,7 +239,8 @@ bool		chfdw_pushdown_regex_ok(void);
 
 extern void
 			chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
-								  char **dbname, char **username, char **password);
+								  char **dbname, char **username, char **password,
+								  ch_tls_mode * tls);
 extern List * chfdw_parse_options(const char *options, bool with_comma, bool with_equal);
 
 /* in deparse.c */

--- a/src/option.c
+++ b/src/option.c
@@ -58,6 +58,7 @@ static ChFdwOption * clickhouse_fdw_options;
 static const ChFdwOption ch_options[] =
 {
 	{"host", 0, false},
+	{"secure", 0, false},
 	{"port", 0, false},
 	{"dbname", 0, false},
 	{"user", 0, false},
@@ -132,6 +133,22 @@ clickhouse_fdw_validator(PG_FUNCTION_ARGS)
 
 		if (strcmp(def->defname, "fetch_size") == 0)
 			validate_fetch_size_option(def);
+
+		if (strcmp(def->defname, "secure") == 0)
+		{
+			const char *val = defGetString(def);
+
+			if (strcmp(val, "on") != 0 && strcmp(val, "true") != 0 &&
+				strcmp(val, "yes") != 0 && strcmp(val, "1") != 0 &&
+				strcmp(val, "off") != 0 && strcmp(val, "false") != 0 &&
+				strcmp(val, "no") != 0 && strcmp(val, "0") != 0 &&
+				strcmp(val, "auto") != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
+						 errmsg("invalid value for option \"secure\": \"%s\"",
+								val),
+						 errhint("Valid values are: on, off, auto.")));
+		}
 	}
 
 	PG_RETURN_VOID();
@@ -284,7 +301,8 @@ is_ch_option(const char *keyword)
  */
 void
 chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
-					  char **dbname, char **username, char **password)
+					  char **dbname, char **username, char **password,
+					  ch_tls_mode * tls)
 {
 	ListCell   *lc;
 
@@ -313,6 +331,18 @@ chfdw_extract_options(List * defelems, char **driver, char **host, int *port,
 				*dbname = defGetString(def);
 				if (*dbname[0] == '\0')
 					*dbname = DEFAULT_DBNAME;
+			}
+			else if (tls && strcmp(def->defname, "secure") == 0)
+			{
+				const char *val = defGetString(def);
+
+				if (strcmp(val, "on") == 0 || strcmp(val, "true") == 0 ||
+					strcmp(val, "yes") == 0 || strcmp(val, "1") == 0)
+					*tls = CH_TLS_ON;
+				else if (strcmp(val, "off") == 0 || strcmp(val, "false") == 0 ||
+						 strcmp(val, "no") == 0 || strcmp(val, "0") == 0)
+					*tls = CH_TLS_OFF;
+				/* else: "auto" or anything else → CH_TLS_AUTO (already 0) */
 			}
 		}
 	}

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -892,6 +892,29 @@ DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table ft_no_stream
 drop cascades to foreign table ft_override_stream
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -892,6 +892,29 @@ DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table ft_no_stream
 drop cascades to foreign table ft_override_stream
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -892,6 +892,29 @@ DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table ft_no_stream
 drop cascades to foreign table ft_override_stream
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -892,6 +892,29 @@ DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table ft_no_stream
 drop cascades to foreign table ft_override_stream
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -892,6 +892,29 @@ DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table ft_no_stream
 drop cascades to foreign table ft_override_stream
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -802,6 +802,29 @@ SELECT * FROM bad_name;
 ERROR:  pg_clickhouse: unsupported line ending character in database name
 DETAIL:  Invalid database name: 'http_test
 X-My-Header: 123'
+/* ===== secure option tests ===== */
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+ERROR:  invalid value for option "secure": "maybe"
+HINT:  Valid values are: on, off, auto.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -297,6 +297,34 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 
+/* ===== secure option tests ===== */
+
+/* All accepted values for the secure option should pass validation. */
+CREATE SERVER http_secure_on FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'on');
+DROP SERVER http_secure_on;
+
+CREATE SERVER http_secure_off FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'off');
+DROP SERVER http_secure_off;
+
+CREATE SERVER http_secure_auto FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'auto');
+DROP SERVER http_secure_auto;
+
+/* Boolean aliases for on/off must be accepted too. */
+CREATE SERVER http_secure_true FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'true');
+DROP SERVER http_secure_true;
+
+CREATE SERVER http_secure_false FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'false');
+DROP SERVER http_secure_false;
+
+/* An unknown value must be rejected. */
+CREATE SERVER http_secure_bad FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'http_test', driver 'http', secure 'maybe');
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;


### PR DESCRIPTION
Hi!

Today TLS is chosen over non-obvious heuristics. Maybe let's give a user explicit control over it?

(I'll drop changes to .github/workflows/* after discussion, I needed them for debug)