### PR TITLE
revoke PUBLIC execute on clickhouse_raw_query

### DIFF
--- a/sql/pg_clickhouse.sql
+++ b/sql/pg_clickhouse.sql
@@ -17,6 +17,14 @@ RETURNS TEXT
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
+-- clickhouse_raw_query accepts an arbitrary connection string, including
+-- any host the caller chooses.  Leaving it executable by PUBLIC would
+-- allow any database user to reach internal services (metadata endpoints,
+-- private APIs, etc.) from the PostgreSQL server — a classic SSRF vector.
+-- Grant it back only to roles that legitimately need ad-hoc ClickHouse
+-- access (e.g. a dedicated clickhouse_admin role).
+REVOKE EXECUTE ON FUNCTION clickhouse_raw_query(text, text) FROM PUBLIC;
+
 CREATE FUNCTION clickhouse_fdw_validator(text[], oid)
 RETURNS VOID
 AS 'MODULE_PATHNAME'


### PR DESCRIPTION
clickhouse_raw_query(sql, connstring) lets the caller specify an arbitrary host in the connection string. With the function executable by PUBLIC any database user could reach internal services such as cloud metadata endpoints (169.254.169.254), private APIs, or other hosts on the server network directly from the PostgreSQL process (SSRF).

Revoke PUBLIC execute. Administrators who need ad-hoc raw access should grant the function explicitly to a trusted role.