### PR TITLE
Support mapping to Postgres JSON type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     Philip Dubé for the PR ([#210]).
 *   Added mapping for `JSON` => `jsonb` to the binary driver (requires
     ClickHouse 24.10 or later).
+*   Added support for ClickHouse `JSON` mapped to Postgres `json`, supporting
+    all the same operators and functions as the `jsonb` mapping.
 
 ### 🐞 Bug Fixes
 
@@ -56,6 +58,12 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     expression pushdown.
 *   Documented the `column_name` foreign-table column option in the [reference
     docs](doc/pg_clickhouse.md).
+*   Added `jsonb_extract_path_text()` and `jsonb_extract_path()` to the list
+    of push down functions in the [reference docs](doc/pg_clickhouse.md),
+    along with `json_extract_path_text()` and `json_extract_path()`, which are
+    new in this release.
+*   Fixed the reversed descriptions of `->>` and `->` in the list of pushed
+    down operators in the [reference docs](doc/pg_clickhouse.md).
 
 ### 🚀 Distribution
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -828,7 +828,7 @@ cluster to be restart when the library is updated.
 ## Data Types
 
 pg_clickhouse maps the following ClickHouse data types to PostgreSQL data
-types. [IMPORT FOREIGN SCHEMA](#import-foreign-schema) use the first type in
+types. [IMPORT FOREIGN SCHEMA](#import-foreign-schema) uses the first type in
 the PostgreSQL column when importing columns; additional types may be used in
 [CREATE FOREIGN TABLE](#create-foreign-table) statements:
 
@@ -847,7 +847,7 @@ the PostgreSQL column when importing columns; additional types may be used in
 | Int32      | integer          |                               |
 | Int64      | bigint           |                               |
 | Int8       | smallint         |                               |
-| JSON       | jsonb            |                               |
+| JSON       | jsonb, json      |                               |
 | String     | text, bytea      |                               |
 | UInt16     | integer          |                               |
 | UInt32     | bigint           |                               |
@@ -1082,6 +1082,10 @@ maps the following functions:
 *   `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 *   `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
 *   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
+*   `json_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `json_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
 *   `statement_timestamp`, `transaction_timestamp`, & `clock_timestamp`:
     [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
@@ -1114,8 +1118,8 @@ maps the following functions:
 *   `!~` (regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `~*` (case insensitive regexp no match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `!~*` (case insensitive regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
-*   `->` (JSON extract element): [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
-*   `->>` (JSON extract element as text): [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `->>` (JSON/JSONB extract element as text): [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `->` (JSON/JSONB extract): [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 
 ### Custom Functions
 

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -286,8 +286,13 @@ extern "C"
 		return resp;
 	}
 
+	/*
+	 * Given TypeRef for the value returned by a clickhouse-cpp query and the
+	 * Postgres data type from the corresponding column in the foreign table,
+	 * return the Oid of the type that should be created for the TypeRef.
+	 */
 	static Oid
-	get_corr_postgres_type(const TypeRef &type)
+	get_corr_postgres_type(const TypeRef &type, Oid pg_type)
 	{
 		switch (type->GetCode())
 		{
@@ -317,7 +322,7 @@ extern "C"
 			case Type::Code::String:
 				return TEXTOID;
 			case Type::Code::LowCardinality:
-				return get_corr_postgres_type(type->As<LowCardinalityType>()->GetNestedType());
+				return get_corr_postgres_type(type->As<LowCardinalityType>()->GetNestedType(), pg_type);
 			case Type::Code::Date:
 			case Type::Code::Date32:
 				return DATEOID;
@@ -329,8 +334,8 @@ extern "C"
 				return UUIDOID;
 			case Type::Code::Array:
 			{
-				Oid array_type
-				= get_array_type(get_corr_postgres_type(type->As<clickhouse::ArrayType>()->GetItemType()));
+				Oid array_type = get_array_type(
+				get_corr_postgres_type(type->As<clickhouse::ArrayType>()->GetItemType(), get_element_type(pg_type)));
 				if (array_type == InvalidOid)
 					throw std::runtime_error("pg_clickhouse: could not find array "
 											 " type for column type "
@@ -341,12 +346,13 @@ extern "C"
 			case Type::Code::Tuple:
 				return RECORDOID;
 			case Type::Code::Nullable:
-				return get_corr_postgres_type(type->As<NullableType>()->GetNestedType());
+				return get_corr_postgres_type(type->As<NullableType>()->GetNestedType(), pg_type);
 			case Type::Code::IPv4:
 			case Type::Code::IPv6:
 				return INETOID;
 			case Type::Code::JSON:
-				return JSONBOID;
+				/* We support json and default to jsonb. */
+				return pg_type == JSONOID ? JSONOID : JSONBOID;
 			default:
 				throw std::runtime_error("pg_clickhouse: unsupported column type " + type->GetName());
 		}
@@ -411,12 +417,17 @@ extern "C"
 		AttrNumber i = 0;
 		for (Block::Iterator bi(*block); bi.IsValid(); bi.Next())
 		{
-			Oid			pg_type;
-			const char *colname;
+			/* Start with the data type from the foreign table. */
+			Oid			pg_type = lfirst_oid(list_nth_cell(state->target_oids, i));
+			const char *colname = bi.Name().c_str();
 			try
 			{
-				/* Determine the Postgres column type. */
-				pg_type = get_corr_postgres_type(bi.Type());
+				/*
+				 * Determine the Postgres type to which to convert values so
+				 * that column_append() knows how to append it to a ClickHouse
+				 * column.
+				 */
+				pg_type = get_corr_postgres_type(bi.Type(), pg_type);
 				colname = bi.Name().c_str();
 			}
 			catch (const std::exception &e)
@@ -440,6 +451,12 @@ extern "C"
 		state->insert_block = (ch_insert_block_h *)block;
 	}
 
+	/*
+	 * Append val to col. If isnull is true and val is nullable, append a
+	 * null. Otherwise, determine how to convert val, of type valtype, to a
+	 * value appropriate to col, and append that value. Raises an exception if
+	 * valtype is not compatible with col's type.
+	 */
 	static void
 	column_append(clickhouse::ColumnRef col, Datum val, Oid valtype, bool isnull)
 	{
@@ -742,11 +759,15 @@ extern "C"
 			break;
 			default:
 			{
-				THROW_UNEXPECTED_COLUMN(std::to_string(valtype), col);
+				THROW_UNEXPECTED_COLUMN(format_type_extended(valtype, -1, FORMAT_TYPE_ALLOW_INVALID), col);
 			}
 		}
 	}
 
+	/*
+	 * Append state->values[colidx] to state->insert_block[colidx] or raise an
+	 * exception.
+	 */
 	void
 	ch_binary_column_append_data(ch_binary_insert_state *state, size_t colidx)
 	{
@@ -756,8 +777,9 @@ extern "C"
 			auto col = (*block)[colidx];
 
 			Datum val = state->values[colidx];
-			Oid	  valtype = TupleDescAttr(state->outdesc, colidx)->atttypid;
-			bool  isnull = state->nulls[colidx];
+
+			Oid	 valtype = TupleDescAttr(state->outdesc, colidx)->atttypid;
+			bool isnull = state->nulls[colidx];
 
 			column_append(col, val, valtype, isnull);
 		}
@@ -839,6 +861,7 @@ extern "C"
 				state->coltypes = new Oid[resp->columns_count];
 				state->values = new Datum[resp->columns_count];
 				state->nulls = new bool[resp->columns_count];
+				std::fill(state->coltypes, state->coltypes + resp->columns_count, 0);
 			}
 		}
 		catch (const std::exception &e)
@@ -848,14 +871,20 @@ extern "C"
 	}
 
 	/*
-	 * This function is preparing values for `convert_datum` which is called in upper
-	 * code.
+	 * This function prepares values for `convert_datum` which is called in
+	 * upper code.
 	 *
 	 * This function calls postgres functions, which can call `palloc` so we can end up
 	 * with elog(ERROR) and longjmp to upper postgres code with leaking c++ memory.
 	 *
 	 * There is not an adequate (without huge overheads) solution, we just consider
 	 * this state unfixable.
+	 *
+	 * Expects `valtype` to already be set to the type of the foreign table
+	 * column for the value, but it may replace it with another type that will
+	 * later be cast to valtype.
+	 *
+	 * Always sets `is_null`.
 	 */
 	static Datum
 	make_datum(clickhouse::ColumnRef col, size_t row, Oid *valtype, bool *is_null)
@@ -865,7 +894,6 @@ extern "C"
 	nested_col:
 		auto type_code = col->Type()->GetCode();
 
-		*valtype = InvalidOid;
 		*is_null = false;
 
 		switch (type_code)
@@ -1092,7 +1120,7 @@ extern "C"
 				size_t len = arr->Size();
 				auto   slot = (ch_binary_array_t *)exc_palloc(sizeof(ch_binary_array_t));
 
-				Oid item_type = get_corr_postgres_type(arr->Type());
+				Oid item_type = get_corr_postgres_type(arr->Type(), get_element_type(*valtype));
 				Oid array_type = get_array_type(item_type);
 
 				if (array_type == InvalidOid)
@@ -1179,8 +1207,12 @@ extern "C"
 		return ret;
 	}
 
+	/*
+	 * Read a row from state->block and fill state->values with the
+	 * corresponding values.
+	 */
 	bool
-	ch_binary_read_row(ch_binary_read_state_t *state)
+	ch_binary_read_row(ch_binary_read_state_t *state, TupleDesc tupdesc, List *attrs)
 	{
 		/* coltypes is NULL means there are no blocks */
 		bool res = false;
@@ -1202,6 +1234,20 @@ extern "C"
 
 			for (size_t i = 0; i < state->resp->columns_count; i++)
 			{
+				/*
+				 * For the first row we fetch, set the data types to the
+				 * Postgres target columns. make_datum() may replace the type,
+				 * but in general we want to prefer the type that Postgres
+				 * expects. tupdesc describes the Postgres tuple that we're
+				 * selecting from; attrs contains the list of column numbers
+				 * we're selecting from that tuple.
+				 *
+				 * XXX Would be nice to set this up in an earlier callback
+				 * hook.
+				 */
+				if (!state->coltypes[i] && tupdesc && list_length(attrs) > (int)i)
+					state->coltypes[i] = TupleDescAttr(tupdesc, lfirst_int(list_nth_cell(attrs, i)) - 1)->atttypid;
+
 				/* fill value and null arrays */
 				state->values[i] = make_datum(block[i], state->row, &state->coltypes[i], &state->nulls[i]);
 			}

--- a/src/convert.c
+++ b/src/convert.c
@@ -1,3 +1,7 @@
+/*
+ * Conversion functions for the binary driver.
+*/
+
 #include "postgres.h"
 
 #include "funcapi.h"
@@ -188,10 +192,16 @@ ch_binary_convert_datum(void *state, Datum val)
 }
 
 /* input */
+
+/*
+ * Convert val from intype to outtype. No conversion for binary-compatible
+ * types or when intype and outtype are the same. All others converted via the
+ * appropriate CAST function.
+*/
 void	   *
 ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype)
 {
-	/* make_datum() binary.cpp copies all bytes, no cast needed. */
+	/* make_datum() copies all bytes, no cast needed. */
 	if (intype == TEXTOID && outtype == BYTEAOID)
 		return NULL;
 
@@ -360,8 +370,15 @@ init_output_convert_state(ch_convert_output_state * state)
 	if (state->outtype == state->intype)
 		return;
 
-	/* column_append() binary.cpp copies all bytes, no cast needed. */
+	/* column_append() copies all bytes, no cast needed. */
 	if (state->intype == BYTEAOID && state->outtype == TEXTOID)
+		return;
+
+	/* column_append() handles both JSON and JSONB, so no need to convert. */
+	if (
+		(state->intype == JSONBOID && state->outtype == JSONOID)
+		|| (state->intype == JSONOID && state->outtype == JSONBOID)
+		)
 		return;
 
 	/* Postgres has no cast from bool to INT16, so provide our own. */
@@ -471,6 +488,14 @@ ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc, Oid relid)
 	return states;
 }
 
+/*
+ * For each value to be output, convert it, if necessary, from the Postgres
+ * Datum type defined for the foreign table to a Datum that column_append() in
+ * binary.cpp knows how to convert to a ClickHouse type. No conversion for
+ * binary-compatible types; other types require a CAST.
+ * ch_binary_make_tuple_map() makes this determination for each type, stored
+ * in insert_state->conversion_states)
+*/
 void
 ch_binary_do_output_conversion(ch_binary_insert_state * insert_state,
 							   TupleTableSlot * slot)

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -271,6 +271,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_TO_TIMESTAMP_FLOAT8:
 			case F_JSONB_EXTRACT_PATH:
 			case F_JSONB_EXTRACT_PATH_TEXT:
+			case F_JSON_EXTRACT_PATH:
+			case F_JSON_EXTRACT_PATH_TEXT:
 			case F_NOW:
 			case F_STATEMENT_TIMESTAMP:
 			case F_TRANSACTION_TIMESTAMP:
@@ -419,14 +421,16 @@ chfdw_check_for_custom_function(Oid funcid)
 					break;
 				}
 			case F_JSONB_EXTRACT_PATH_TEXT:
+			case F_JSON_EXTRACT_PATH_TEXT:
 				{
-					entry->cf_type = CF_JSONB_EXTRACT_PATH_TEXT;
+					entry->cf_type = CF_JSON_EXTRACT_PATH_TEXT;
 					entry->custom_name[0] = '\1';
 					break;
 				}
 			case F_JSONB_EXTRACT_PATH:
+			case F_JSON_EXTRACT_PATH:
 				{
-					entry->cf_type = CF_JSONB_EXTRACT_PATH;
+					entry->cf_type = CF_JSON_EXTRACT_PATH;
 					entry->custom_name[0] = '\1';
 					break;
 				}
@@ -608,6 +612,8 @@ chfdw_check_for_custom_type(Oid typeoid)
 #define OID_TEXT_IREGEX_NE_OP		1229
 #define OID_JSONB_FETCHVAL_OP		3211
 #define OID_JSONB_FETCHVAL_TEXT_OP	3477
+#define OID_JSON_FETCHVAL_OP		3962
+#define OID_JSON_FETCHVAL_TEXT_OP	3963
 
 /*
  * Map a builtin operator OID to its custom_object_type. Returns CF_USUAL
@@ -627,9 +633,11 @@ classify_builtin_operator(Oid opoid)
 		case OID_TEXT_IREGEX_NE_OP:
 			return CF_REGEX_ICASE_NO_MATCH;
 		case OID_JSONB_FETCHVAL_OP:
-			return CF_JSONB_FETCHVAL;
+		case OID_JSON_FETCHVAL_OP:
+			return CF_JSON_FETCHVAL;
 		case OID_JSONB_FETCHVAL_TEXT_OP:
-			return CF_JSONB_FETCHVAL_TEXT;
+		case OID_JSON_FETCHVAL_TEXT_OP:
+			return CF_JSON_FETCHVAL_TEXT;
 		case OID_ARRAY_CONTAINS_OP:
 			return CF_ARRAY_CONTAINS;
 		case OID_ARRAY_CONTAINED_OP:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -425,14 +425,14 @@ foreign_expr_walker(Node * node,
 					return false;
 
 				/*
-				 * jsonb_extract_path_text / jsonb_extract_path are always
+				 * jsonb?_extract_path_text / jsonb?_extract_path are always
 				 * presented by the planner in variadic form: two args where
 				 * the second is a text[] constant.  Allow them through the
 				 * variadic gate; only recurse on the column argument.
 				 */
 				if (cdef &&
-					(cdef->cf_type == CF_JSONB_EXTRACT_PATH_TEXT ||
-					 cdef->cf_type == CF_JSONB_EXTRACT_PATH))
+					(cdef->cf_type == CF_JSON_EXTRACT_PATH_TEXT ||
+					 cdef->cf_type == CF_JSON_EXTRACT_PATH))
 				{
 					if (list_length(fe->args) != 2 ||
 						!IsA(lsecond(fe->args), Const) ||
@@ -2598,11 +2598,11 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 		/* Special casses. */
 		switch (cdef->cf_type)
 		{
-			case CF_JSONB_EXTRACT_PATH_TEXT:
-			case CF_JSONB_EXTRACT_PATH:
+			case CF_JSON_EXTRACT_PATH_TEXT:
+			case CF_JSON_EXTRACT_PATH:
 				{
 					deparseJsonbExtractPath(node, context,
-											cdef->cf_type == CF_JSONB_EXTRACT_PATH);
+											cdef->cf_type == CF_JSON_EXTRACT_PATH);
 					return;
 				}
 			case CF_CURRENT_DATABASE:
@@ -3209,8 +3209,8 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 					goto cleanup;
 				}
 				break;
-			case CF_JSONB_FETCHVAL:
-			case CF_JSONB_FETCHVAL_TEXT:
+			case CF_JSON_FETCHVAL:
+			case CF_JSON_FETCHVAL_TEXT:
 				{
 					Expr	   *arg1 = linitial(node->args);
 					Expr	   *arg2 = lsecond(node->args);
@@ -3230,7 +3230,7 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 						{
 							char	   *keyval = TextDatumGetCString(key->constvalue);
 
-							if (cdef->cf_type == CF_JSONB_FETCHVAL)
+							if (cdef->cf_type == CF_JSON_FETCHVAL)
 								appendStringInfoString(buf, "toJSONString(");
 
 							deparseExpr(arg1, context);
@@ -3238,7 +3238,7 @@ deparseOpExpr(OpExpr * node, deparse_expr_cxt * context)
 							appendStringInfoString(buf,
 												   quote_identifier(keyval));
 
-							if (cdef->cf_type == CF_JSONB_FETCHVAL)
+							if (cdef->cf_type == CF_JSON_FETCHVAL)
 								appendStringInfoChar(buf, ')');
 
 							pfree(keyval);

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -97,6 +97,8 @@ enum FdwModifyPrivateIndex
 	FdwModifyPrivateInsertSQL,
 	/* Integer list of target attribute numbers for INSERT/UPDATE */
 	FdwModifyPrivateTargetAttnums,
+	/* List of target attribute OIDs for INSERT/UPDATE */
+	FdwModifyPrivateTargetAttOids,
 	/* Deparsed name of the result table */
 	FdwModifyPrivateTableName,
 };
@@ -255,6 +257,7 @@ static CHFdwModifyState * create_foreign_modify(EState * estate,
 												Plan * subplan,
 												char *query,
 												List * target_attrs,
+												List * target_oids,
 												char *table_name);
 static void finish_foreign_modify(CHFdwModifyState * fmstate);
 static void prepare_query_params(PlanState * node,
@@ -1204,6 +1207,7 @@ clickhousePlanForeignModify(PlannerInfo * root,
 	Relation	rel;
 	StringInfoData sql;
 	List	   *targetAttrs = NIL;
+	List	   *targetTypes = NIL;
 
 	initStringInfo(&sql);
 
@@ -1222,7 +1226,10 @@ clickhousePlanForeignModify(PlannerInfo * root,
 			Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
 			if (!attr->attisdropped)
+			{
 				targetAttrs = lappend_int(targetAttrs, attnum);
+				targetTypes = lappend_oid(targetTypes, attr->atttypid);
+			}
 		}
 	}
 
@@ -1258,12 +1265,11 @@ clickhousePlanForeignModify(PlannerInfo * root,
 
 	table_close_compat(rel, NoLock);
 
-
 	/*
 	 * Build the fdw_private list that will be available to the executor.
 	 * Items in the list must match enum FdwModifyPrivateIndex, above.
 	 */
-	return list_make3(makeString(sql.data), targetAttrs, makeString(table_name));
+	return list_make4(makeString(sql.data), targetAttrs, targetTypes, makeString(table_name));
 }
 
 /*
@@ -1280,6 +1286,7 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 	CHFdwModifyState *fmstate;
 	char	   *query;
 	List	   *target_attrs = NULL;
+	List	   *target_oids = NULL;
 	RangeTblEntry *rte;
 	char	   *table_name;
 
@@ -1293,6 +1300,7 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 	/* Deconstruct fdw_private data. */
 	query = strVal(list_nth(fdw_private, FdwModifyPrivateInsertSQL));
 	target_attrs = (List *) list_nth(fdw_private, FdwModifyPrivateTargetAttnums);
+	target_oids = (List *) list_nth(fdw_private, FdwModifyPrivateTargetAttOids);
 	table_name = strVal(list_nth(fdw_private, FdwModifyPrivateTableName));
 
 	/* Find RTE. */
@@ -1311,6 +1319,7 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 #endif
 									query,
 									target_attrs,
+									target_oids,
 									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
@@ -1343,6 +1352,7 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	int			attnum;
 	List	   *targetAttrs = NIL;
+	List	   *targetTypes = NIL;
 	StringInfoData sql;
 	char	   *table_name;
 
@@ -1352,7 +1362,10 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
 		if (!attr->attisdropped)
+		{
 			targetAttrs = lappend_int(targetAttrs, attnum);
+			targetTypes = lappend_oid(targetTypes, attr->atttypid);
+		}
 	}
 
 	/*
@@ -1383,6 +1396,7 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 									NULL,
 									sql.data,
 									targetAttrs,
+									targetTypes,
 									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
@@ -1537,6 +1551,7 @@ create_foreign_modify(EState * estate,
 					  Plan * subplan,
 					  char *query,
 					  List * target_attrs,
+					  List * target_oids,
 					  char *table_name)
 {
 	CHFdwModifyState *fmstate;
@@ -1570,7 +1585,7 @@ create_foreign_modify(EState * estate,
 
 	old_mcxt = MemoryContextSwitchTo(PortalContext);
 	fmstate->state = fmstate->conn.methods->prepare_insert(fmstate->conn.conn,
-														   rri, target_attrs, &q, table_name);
+														   rri, target_attrs, target_oids, &q, table_name);
 	MemoryContextSwitchTo(old_mcxt);
 
 	/* Create context for per-query temp workspace. */

--- a/src/include/binary.hh
+++ b/src/include/binary.hh
@@ -56,6 +56,7 @@ extern "C"
 		MemoryContextCallback callback;
 
 		TupleDesc	outdesc;
+		List	   *target_oids;	/* Type of each value in outdesc */
 		ch_insert_block_h *insert_block;	/* clickhouse::Block */
 		size_t		len;
 		void	   *conversion_states;
@@ -79,7 +80,7 @@ extern "C"
 /* reading */
 	void		ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_response_t * resp);
 	void		ch_binary_read_state_free(ch_binary_read_state_t * state);
-	bool		ch_binary_read_row(ch_binary_read_state_t * state);
+	bool		ch_binary_read_row(ch_binary_read_state_t * state, TupleDesc tupdesc, List * attrs);
 	Datum		ch_binary_convert_datum(void *state, Datum val);
 	void	   *ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype);
 	void		ch_binary_free_convert_state(void *);

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -72,7 +72,7 @@ typedef void (*check_conn_method) (const char *password, UserMapping * user);
 typedef ch_cursor * (*simple_query_method) (void *conn, const ch_query * query);
 typedef void (*simple_insert_method) (void *conn, const ch_query * query);
 typedef Datum * (*cursor_fetch_row_method) (ChFdwScanRowContext * ctx);
-typedef void *(*prepare_insert_method) (void *conn, ResultRelInfo *, List *,
+typedef void *(*prepare_insert_method) (void *conn, ResultRelInfo *, List *, List *,
 										const ch_query *, char *);
 typedef void (*insert_tuple_method) (void *state, TupleTableSlot * slot);
 typedef ch_cursor * (*streaming_query_method) (void *conn,
@@ -310,10 +310,11 @@ typedef enum
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */
 	CF_REGEX_ICASE_NO_MATCH,	/* !~* case-insensitive regex operator */
-	CF_JSONB_FETCHVAL,			/* -> operator on jsonb */
-	CF_JSONB_FETCHVAL_TEXT,		/* ->> operator on jsonb */
-	CF_JSONB_EXTRACT_PATH_TEXT, /* jsonb_extract_path_text() → col."k1"."k2" */
-	CF_JSONB_EXTRACT_PATH,		/* jsonb_extract_path() →
+	CF_JSON_FETCHVAL,			/* -> operator on json & jsonb */
+	CF_JSON_FETCHVAL_TEXT,		/* ->> operator on json & jsonb */
+	CF_JSON_EXTRACT_PATH_TEXT,	/* jsonb?_extract_path_text() →
+								 * col."k1"."k2" */
+	CF_JSON_EXTRACT_PATH,		/* json?_extract_path() →
 								 * toJSONString(col."k1"."k2") */
 	CF_STRING_AGG,				/* string_agg → groupConcat(delim)(expr) */
 	CF_CURRENT_DATABASE,		/* CURRENT_DATABASE → string literal */

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -38,7 +38,7 @@ static Datum * http_fetch_row(ChFdwScanRowContext * ctx);
 static Datum * http_streaming_fetch_row(ChFdwScanRowContext * ctx);
 static Datum * http_fetch_row_from_state(ChFdwScanRowContext * ctx,
 										 ch_http_read_state * state);
-static void *http_prepare_insert(void *, ResultRelInfo *, List *, const ch_query *, char *);
+static void *http_prepare_insert(void *, ResultRelInfo *, List *, List *, const ch_query *, char *);
 static void http_insert_tuple(void *, TupleTableSlot *);
 static void char_to_datum(ChFdwScanRowContext * ctx, int attnum, char *data, size_t len);
 static void report_http_stream_query_failure(void *conn, const ch_query * query,
@@ -62,7 +62,7 @@ static void binary_cursor_free(void *cursor);
 /* static void binary_simple_insert(void *conn, const char *query); */
 static Datum * binary_fetch_row(ChFdwScanRowContext * ctx);
 static void binary_insert_tuple(void *, TupleTableSlot * slot);
-static void *binary_prepare_insert(void *, ResultRelInfo *, List *,
+static void *binary_prepare_insert(void *, ResultRelInfo *, List *, List *,
 								   const ch_query * query, char *table_name);
 static char *ch_escape_string(const char *s, size_t len);
 static void ch_quote_literal_internal(char *dst, const char *src, size_t len);
@@ -782,7 +782,7 @@ extend_insert_query(ch_http_insert_state * state, TupleTableSlot * slot)
 }
 
 static void *
-http_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs,
+http_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs, List * target_oids,
 					const ch_query * query, char *table_name)
 {
 	ch_http_insert_state *state = palloc0(sizeof(ch_http_insert_state));
@@ -933,7 +933,7 @@ binary_fetch_row(ChFdwScanRowContext * ctx)
 	Datum	   *values = ctx->values;
 	bool	   *nulls = ctx->nulls;
 	ch_binary_read_state_t *state = cursor->read_state;
-	bool		have_data = ch_binary_read_row(state);
+	bool		have_data = ch_binary_read_row(state, tupdesc, attrs);
 	size_t		attcount = list_length(attrs);
 
 	if (state->error)
@@ -980,7 +980,6 @@ binary_fetch_row(ChFdwScanRowContext * ctx)
 			bool		isnull = state->nulls[j];
 			intptr_t	convstate;
 
-
 			if (isnull)
 				values[i - 1] = (Datum) 0;
 			else
@@ -1002,6 +1001,17 @@ binary_fetch_row(ChFdwScanRowContext * ctx)
 							 * it.
 							 */
 							old_mcxt = MemoryContextSwitchTo(cursor->memcxt);
+
+							/*
+							 * Convert the Postgres Datum, stored by
+							 * ch_binary_read_row() as the type defined by by
+							 * state->coltypes[j], to the type defined by the
+							 * foreign table. No conversion if they're binary
+							 * compatible, but required to allow a static
+							 * ClickHouse type (which maps to a well-known
+							 * Postgres type) to be converted to a compatible
+							 * Postgres value via a CAST.
+							 */
 							s = ch_binary_init_convert_state(state->values[j],
 															 state->coltypes[j], outtype);
 							MemoryContextSwitchTo(old_mcxt);
@@ -1048,7 +1058,7 @@ binary_cursor_free(void *c)
 }
 
 static void *
-binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs,
+binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs, List * target_oids,
 					  const ch_query * query, char *table_name)
 {
 	ch_binary_insert_state *state = NULL;
@@ -1072,6 +1082,7 @@ binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs,
 	state->conn = conn;
 	state->table_name = pstrdup(table_name);
 	state->relid = RelationGetRelid(rri->ri_RelationDesc);
+	state->target_oids = target_oids;
 	MemoryContextRegisterResetCallback(tempcxt, &state->callback);
 
 	/* time for c++ stuff */
@@ -1097,8 +1108,16 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 			MemoryContext old_mcxt;
 
 			old_mcxt = MemoryContextSwitchTo(state->memcxt);
-			state->conversion_states = ch_binary_make_tuple_map(
-																slot->tts_tupleDescriptor, state->outdesc, state->relid);
+
+			/*
+			 * Set up conversion states so that Postgres Datums of types
+			 * defined by the foreign table can be converted to a well-known
+			 * Postgres type that column_append() in binary.cpp knows how to
+			 * convert to the appropriate ClickHouse type. Binary compatible
+			 * types don't convert; others require a CAST. Fails if there is
+			 * no cast.
+			 */
+			state->conversion_states = ch_binary_make_tuple_map(slot->tts_tupleDescriptor, state->outdesc, state->relid);
 			MemoryContextSwitchTo(old_mcxt);
 		}
 
@@ -1139,7 +1158,7 @@ binary_insert_tuple(void *istate, TupleTableSlot * slot)
 		('UUID',     'uuid',             ''),
 		('IPv4',     'inet',             ''),
 		('IPv6',     'inet',             ''),
-		('JSON',     'jsonb',            '')
+		('JSON',     'jsonb, json',      '')
 	) AS v(\"ClickHouse\", \"PostgreSQL\", \"Notes\")
 	ORDER BY \"ClickHouse\";
 	" | perl -ne 'my $m = $.%2; print $buf[$m] if defined $buf[$m]; $buf[$m] = s/\+/|/gr if $.>1' | pbcopy

--- a/test/expected/json.out
+++ b/test/expected/json.out
@@ -74,6 +74,41 @@ SELECT * FROM json_http.things ORDER BY id;
   4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
 (4 rows)
 
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+SELECT * FROM json_bin.json_things ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":4,"name":"doodad","size":"large","stocked":false}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(6 rows)
+
+SELECT * FROM json_http.json_things ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":4,"name":"doodad","size":"large","stocked":false}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(6 rows)
+
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -94,7 +129,9 @@ SELECT data['name'] FROM json_http.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data['name'] FROM json_bin.things;
@@ -112,7 +149,9 @@ SELECT data['name'] FROM json_bin.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 -- DISTINCT forces an ORDER BY or HashAgg; the subscript must stay local.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -171,8 +210,8 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
    data   | count 
 ----------+-------
- "medium" |     1
- "small"  |     1
+ "medium" |     2
+ "small"  |     2
  "large"  |     2
 (3 rows)
 
@@ -191,15 +230,12 @@ SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
    data   | count 
 ----------+-------
- "medium" |     1
- "small"  |     1
+ "medium" |     2
+ "small"  |     2
  "large"  |     2
 (3 rows)
 
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -216,7 +252,9 @@ SELECT data ->> 'name' FROM json_http.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_bin.things;
@@ -234,9 +272,52 @@ SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
                                      QUERY PLAN                                     
@@ -267,7 +348,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
                                      QUERY PLAN                                      
@@ -298,7 +410,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -333,7 +476,42 @@ SELECT * FROM json_bin.things
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -372,49 +550,127 @@ SELECT * FROM json_bin.things
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
 (2 rows)
 
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_http.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
 CONTEXT:  HTTP status code: 400
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_bin.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
  id |                              data                              
 ----+----------------------------------------------------------------
-  4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": 6, "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
  id |                              data                              
 ----+----------------------------------------------------------------
-  4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": 6, "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
 SET pg_clickhouse.session_settings TO '';
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
+CONTEXT:  HTTP status code: 400
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                          data                           
+----+---------------------------------------------------------
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                          data                           
+----+---------------------------------------------------------
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SET pg_clickhouse.session_settings TO '';
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -431,7 +687,9 @@ SELECT data -> 'name' FROM json_http.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_bin.things;
@@ -449,9 +707,51 @@ SELECT data -> 'name' FROM json_bin.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
                                              QUERY PLAN                                             
@@ -482,7 +782,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
                                             QUERY PLAN                                             
@@ -498,7 +829,8 @@ SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY 
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
   2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
-(3 rows)
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb;
@@ -515,10 +847,48 @@ SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY i
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
   2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
+
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
 (3 rows)
 
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
                                              QUERY PLAN                                             
@@ -544,6 +914,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 (3 rows)
 
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
  id |                             data                              
 ----+---------------------------------------------------------------
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
@@ -569,6 +971,10 @@ INSERT INTO json_http.special_keys
 VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -600,6 +1006,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
@@ -614,6 +1050,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
  id |                               data                                
 ----+-------------------------------------------------------------------
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                               data                                
+----+-------------------------------------------------------------------
+  1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
 (1 row)
 
 -- Key that is a SQL reserved word.
@@ -647,6 +1128,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -661,6 +1172,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                           data                                                                            
+----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing a backslash.
@@ -694,6 +1250,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -723,6 +1309,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing an apostrophe / single quote.
@@ -756,6 +1372,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -787,6 +1433,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -816,6 +1492,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- =======================================================================
@@ -1046,6 +1752,211 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -1055,12 +1966,18 @@ SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_bin.things
+drop cascades to foreign table json_bin.json_things
 drop cascades to foreign table json_bin.special_keys
+drop cascades to foreign table json_bin.json_special_keys
 drop cascades to foreign table json_bin.events
+drop cascades to foreign table json_bin.json_events
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.json_things
 drop cascades to foreign table json_http.special_keys
+drop cascades to foreign table json_http.json_special_keys
 drop cascades to foreign table json_http.events
+drop cascades to foreign table json_http.json_events

--- a/test/expected/json_1.out
+++ b/test/expected/json_1.out
@@ -74,6 +74,41 @@ SELECT * FROM json_http.things ORDER BY id;
   4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
 (4 rows)
 
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+SELECT * FROM json_bin.json_things ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":4,"name":"doodad","size":"large","stocked":false}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(6 rows)
+
+SELECT * FROM json_http.json_things ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":4,"name":"doodad","size":"large","stocked":false}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(6 rows)
+
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -110,10 +145,7 @@ SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 ERROR:  cannot subscript type jsonb because it is not an array
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 ERROR:  cannot subscript type jsonb because it is not an array
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -130,7 +162,9 @@ SELECT data ->> 'name' FROM json_http.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_bin.things;
@@ -148,9 +182,52 @@ SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
                                      QUERY PLAN                                     
@@ -181,7 +258,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
                                      QUERY PLAN                                      
@@ -212,7 +320,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -247,7 +386,42 @@ SELECT * FROM json_bin.things
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -286,49 +460,127 @@ SELECT * FROM json_bin.things
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
 (2 rows)
 
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_http.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
 CONTEXT:  HTTP status code: 400
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_bin.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
  id |                              data                              
 ----+----------------------------------------------------------------
-  4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": 6, "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
  id |                              data                              
 ----+----------------------------------------------------------------
-  4 | {"id": 4, "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": 6, "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
 SET pg_clickhouse.session_settings TO '';
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
+CONTEXT:  HTTP status code: 400
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                          data                           
+----+---------------------------------------------------------
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                          data                           
+----+---------------------------------------------------------
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+  6 | {"id":6,"name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SET pg_clickhouse.session_settings TO '';
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -345,7 +597,9 @@ SELECT data -> 'name' FROM json_http.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_bin.things;
@@ -363,9 +617,51 @@ SELECT data -> 'name' FROM json_bin.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
                                              QUERY PLAN                                             
@@ -396,7 +692,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                          data                          
+----+--------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
                                             QUERY PLAN                                             
@@ -412,7 +739,8 @@ SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY 
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
   2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
-(3 rows)
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb;
@@ -429,10 +757,48 @@ SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY i
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
   2 | {"id": 2, "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": 3, "name": "gizmo", "size": "medium", "stocked": true}
+  5 | {"id": 5, "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
+
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
 (3 rows)
 
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":1,"name":"widget","size":"large","stocked":true}
+  2 | {"id":2,"name":"sprocket","size":"small","stocked":true}
+  3 | {"id":3,"name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":5,"name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
                                              QUERY PLAN                                             
@@ -458,6 +824,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 (3 rows)
 
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ id |                             data                              
+----+---------------------------------------------------------------
+  1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
  id |                             data                              
 ----+---------------------------------------------------------------
   1 | {"id": 1, "name": "widget", "size": "large", "stocked": true}
@@ -483,6 +881,10 @@ INSERT INTO json_http.special_keys
 VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -514,6 +916,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
@@ -528,6 +960,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
  id |                               data                                
 ----+-------------------------------------------------------------------
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                               data                                
+----+-------------------------------------------------------------------
+  1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
 (1 row)
 
 -- Key that is a SQL reserved word.
@@ -561,6 +1038,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -575,6 +1082,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                           data                                                                            
+----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing a backslash.
@@ -608,6 +1160,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -637,6 +1219,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing an apostrophe / single quote.
@@ -670,6 +1282,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -701,6 +1343,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -730,6 +1402,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
  id |                                                                           data                                                                            
 ----+-----------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": 42, "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                      data                                                                      
+----+------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":42,"back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- =======================================================================
@@ -960,6 +1662,211 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -969,12 +1876,18 @@ SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_bin.things
+drop cascades to foreign table json_bin.json_things
 drop cascades to foreign table json_bin.special_keys
+drop cascades to foreign table json_bin.json_special_keys
 drop cascades to foreign table json_bin.events
+drop cascades to foreign table json_bin.json_events
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.json_things
 drop cascades to foreign table json_http.special_keys
+drop cascades to foreign table json_http.json_special_keys
 drop cascades to foreign table json_http.events
+drop cascades to foreign table json_http.json_events

--- a/test/expected/json_2.out
+++ b/test/expected/json_2.out
@@ -74,6 +74,41 @@ SELECT * FROM json_http.things ORDER BY id;
   4 | {"id": "4", "name": "doodad", "size": "large", "stocked": false}
 (4 rows)
 
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+SELECT * FROM json_bin.json_things ORDER BY id;
+ id |                            data                            
+----+------------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  2 | {"id":"2","name":"sprocket","size":"small","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":"4","name":"doodad","size":"large","stocked":false}
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+(6 rows)
+
+SELECT * FROM json_http.json_things ORDER BY id;
+ id |                            data                            
+----+------------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  2 | {"id":"2","name":"sprocket","size":"small","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":"4","name":"doodad","size":"large","stocked":false}
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+(6 rows)
+
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -94,7 +129,9 @@ SELECT data['name'] FROM json_http.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data['name'] FROM json_bin.things;
@@ -112,7 +149,9 @@ SELECT data['name'] FROM json_bin.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 -- DISTINCT forces an ORDER BY or HashAgg; the subscript must stay local.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -171,8 +210,8 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
    data   | count 
 ----------+-------
- "medium" |     1
- "small"  |     1
+ "medium" |     2
+ "small"  |     2
  "large"  |     2
 (3 rows)
 
@@ -191,15 +230,12 @@ SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
    data   | count 
 ----------+-------
- "medium" |     1
- "small"  |     1
+ "medium" |     2
+ "small"  |     2
  "large"  |     2
 (3 rows)
 
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -216,7 +252,9 @@ SELECT data ->> 'name' FROM json_http.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_bin.things;
@@ -234,9 +272,52 @@ SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
  sprocket
  gizmo
  doodad
-(4 rows)
+ bauble
+ curio
+(6 rows)
 
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+ ?column? 
+----------
+ widget
+ sprocket
+ gizmo
+ doodad
+ bauble
+ curio
+(6 rows)
+
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
                                      QUERY PLAN                                     
@@ -267,7 +348,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
                                      QUERY PLAN                                      
@@ -298,7 +410,38 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -333,7 +476,42 @@ SELECT * FROM json_bin.things
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -372,49 +550,127 @@ SELECT * FROM json_bin.things
   3 | {"id": "3", "name": "gizmo", "size": "medium", "stocked": true}
 (2 rows)
 
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(2 rows)
+
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_http.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
 CONTEXT:  HTTP status code: 400
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_bin.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
  id |                               data                               
 ----+------------------------------------------------------------------
-  4 | {"id": "4", "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": "5", "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": "6", "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
  id |                               data                               
 ----+------------------------------------------------------------------
-  4 | {"id": "4", "name": "doodad", "size": "large", "stocked": false}
-  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+  5 | {"id": "5", "name": "bauble", "size": "small", "stocked": true}
+  6 | {"id": "6", "name": "curio", "size": "medium", "stocked": false}
 (2 rows)
 
 SET pg_clickhouse.session_settings TO '';
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: Code: 44. DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it. (ILLEGAL_COLUMN)
+CONTEXT:  HTTP status code: 400
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: DB::Exception: Data types Variant/Dynamic are not allowed in ORDER BY keys, because it can lead to unexpected results. Consider using a subcolumn with a specific data type instead (for example 'column.Int64' or 'json.some.path.:Int64' if its a JSON path subcolumn) or casting this column to a specific data type. Set setting allow_suspicious_types_in_order_by = 1 in order to allow it
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                           data                            
+----+-----------------------------------------------------------
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+ id |                           data                            
+----+-----------------------------------------------------------
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+(2 rows)
+
+SET pg_clickhouse.session_settings TO '';
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -431,7 +687,9 @@ SELECT data -> 'name' FROM json_http.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_bin.things;
@@ -449,9 +707,51 @@ SELECT data -> 'name' FROM json_bin.things ORDER BY id;
  "sprocket"
  "gizmo"
  "doodad"
-(4 rows)
+ "bauble"
+ "curio"
+(6 rows)
 
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+  ?column?  
+------------
+ "widget"
+ "sprocket"
+ "gizmo"
+ "doodad"
+ "bauble"
+ "curio"
+(6 rows)
+
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
                                              QUERY PLAN                                             
@@ -482,7 +782,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
 (1 row)
 
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+ id |                           data                           
+----+----------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+(1 row)
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
                                             QUERY PLAN                                             
@@ -498,7 +829,8 @@ SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY 
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
   2 | {"id": "2", "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": "3", "name": "gizmo", "size": "medium", "stocked": true}
-(3 rows)
+  5 | {"id": "5", "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb;
@@ -515,10 +847,48 @@ SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY i
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
   2 | {"id": "2", "name": "sprocket", "size": "small", "stocked": true}
   3 | {"id": "3", "name": "gizmo", "size": "medium", "stocked": true}
+  5 | {"id": "5", "name": "bauble", "size": "small", "stocked": true}
+(4 rows)
+
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
 (3 rows)
 
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                            data                            
+----+------------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  2 | {"id":"2","name":"sprocket","size":"small","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                            data                            
+----+------------------------------------------------------------
+  1 | {"id":"1","name":"widget","size":"large","stocked":true}
+  2 | {"id":"2","name":"sprocket","size":"small","stocked":true}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+  5 | {"id":"5","name":"bauble","size":"small","stocked":true}
+(4 rows)
+
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
                                              QUERY PLAN                                             
@@ -544,6 +914,38 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 (3 rows)
 
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ id |                              data                               
+----+-----------------------------------------------------------------
+  1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
  id |                              data                               
 ----+-----------------------------------------------------------------
   1 | {"id": "1", "name": "widget", "size": "large", "stocked": true}
@@ -569,6 +971,10 @@ INSERT INTO json_http.special_keys
 VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -600,6 +1006,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
@@ -614,6 +1050,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
  id |                               data                                
 ----+-------------------------------------------------------------------
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                               data                                
+----+-------------------------------------------------------------------
+  1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
 (1 row)
 
 -- Key that is a SQL reserved word.
@@ -647,6 +1128,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -661,6 +1172,51 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
  id |                                                                            data                                                                             
 ----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                            data                                                                             
+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing a backslash.
@@ -694,6 +1250,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -723,6 +1309,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
  id |                                                                            data                                                                             
 ----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- Key containing an apostrophe / single quote.
@@ -756,6 +1372,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -787,6 +1433,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -816,6 +1492,36 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
  id |                                                                            data                                                                             
 ----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
   2 | {"it's": "apos", "dotted": {"key": "dot"}, "123numeric": "num", "back\\slash": "bs", "The \"meaning\" of life": "42", "key/with!special@chars#": "special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id |                                                                       data                                                                       
+----+--------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"123numeric":"num","The \"meaning\" of life":"42","back\\slash":"bs","dotted":{"key":"dot"},"it's":"apos","key\/with!special@chars#":"special"}
 (1 row)
 
 -- =======================================================================
@@ -1046,6 +1752,211 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -1055,12 +1966,18 @@ SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_bin.things
+drop cascades to foreign table json_bin.json_things
 drop cascades to foreign table json_bin.special_keys
+drop cascades to foreign table json_bin.json_special_keys
 drop cascades to foreign table json_bin.events
+drop cascades to foreign table json_bin.json_events
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.json_things
 drop cascades to foreign table json_http.special_keys
+drop cascades to foreign table json_http.json_special_keys
 drop cascades to foreign table json_http.events
+drop cascades to foreign table json_http.json_events

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -67,6 +67,31 @@ SELECT * FROM json_http.things ORDER BY id;
   4 | {"id": "4", "name": "doodad", "size": "large", "stocked": false}
 (2 rows)
 
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+ERROR:  pg_clickhouse: could not finish INSERT - DB::Exception: Invalid version for Object structure serialization.
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+SELECT * FROM json_bin.json_things ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY id ASC NULLS LAST
+SELECT * FROM json_http.json_things ORDER BY id;
+ id |                           data                            
+----+-----------------------------------------------------------
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+  4 | {"id":"4","name":"doodad","size":"large","stocked":false}
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+(3 rows)
+
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -85,7 +110,8 @@ SELECT data['name'] FROM json_http.things ORDER BY id;
 ----------
  "gizmo"
  "doodad"
-(2 rows)
+ "curio"
+(3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data['name'] FROM json_bin.things;
@@ -150,7 +176,7 @@ SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_http.things GROUP BY data['size'];
    data   | count 
 ----------+-------
- "medium" |     1
+ "medium" |     2
  "large"  |     1
 (2 rows)
 
@@ -169,10 +195,7 @@ SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT data FROM json_test.things
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -187,7 +210,8 @@ SELECT data ->> 'name' FROM json_http.things ORDER BY id;
 ----------
  gizmo
  doodad
-(2 rows)
+ curio
+(3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_bin.things;
@@ -201,7 +225,37 @@ SELECT data ->> 'name' FROM json_bin.things;
 SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY id ASC NULLS LAST
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+ ?column? 
+----------
+ gizmo
+ doodad
+ curio
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY id ASC NULLS LAST
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
                                      QUERY PLAN                                     
@@ -230,7 +284,36 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
 ----+------
 (0 rows)
 
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
                                      QUERY PLAN                                      
@@ -256,7 +339,33 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
 SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
 ERROR:  pg_clickhouse: DB::Exception: Illegal type Dynamic of argument of function like: In scope SELECT id, data FROM json_test.things WHERE data.name LIKE 'wid%'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+ERROR:  pg_clickhouse: Code: 43. DB::Exception: Illegal type Dynamic of argument of function like: In scope SELECT id, data FROM json_test.things WHERE data.name LIKE 'wid%'. (ILLEGAL_TYPE_OF_ARGUMENT)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+CONTEXT:  HTTP status code: 500
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Dynamic of argument of function like: In scope SELECT id, data FROM json_test.things WHERE data.name LIKE 'wid%'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -289,7 +398,40 @@ SELECT * FROM json_bin.things
 ----+------
 (0 rows)
 
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -319,46 +461,114 @@ SELECT * FROM json_bin.things
   ORDER BY id;
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(1 row)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_http.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
  id |                               data                               
 ----+------------------------------------------------------------------
+  6 | {"id": "6", "name": "curio", "size": "medium", "stocked": false}
   4 | {"id": "4", "name": "doodad", "size": "large", "stocked": false}
   3 | {"id": "3", "name": "gizmo", "size": "medium", "stocked": true}
-(2 rows)
+(3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Foreign Scan on json_bin.things
-   Output: id, data, (data ->> 'size'::text)
-   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 (3 rows)
 
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
 ERROR:  pg_clickhouse: Code: 115. DB::Exception: Setting allow_suspicious_types_in_order_by is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings. (UNKNOWN_SETTING)
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST LIMIT 2
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
 CONTEXT:  HTTP status code: 404
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
 ERROR:  pg_clickhouse: DB::Exception: Unknown setting 'allow_suspicious_types_in_order_by'
-DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.size ASC NULLS LAST LIMIT 2
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
 SET pg_clickhouse.session_settings TO '';
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+ id |                           data                            
+----+-----------------------------------------------------------
+  6 | {"id":"6","name":"curio","size":"medium","stocked":false}
+  4 | {"id":"4","name":"doodad","size":"large","stocked":false}
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+ERROR:  pg_clickhouse: Code: 115. DB::Exception: Setting allow_suspicious_types_in_order_by is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings. (UNKNOWN_SETTING)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
+CONTEXT:  HTTP status code: 404
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+ERROR:  pg_clickhouse: DB::Exception: Unknown setting 'allow_suspicious_types_in_order_by'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
+SET pg_clickhouse.session_settings TO '';
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
                    QUERY PLAN                    
@@ -373,7 +583,8 @@ SELECT data -> 'name' FROM json_http.things ORDER BY id;
 ----------
  "gizmo"
  "doodad"
-(2 rows)
+ "curio"
+(3 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_bin.things;
@@ -387,7 +598,36 @@ SELECT data -> 'name' FROM json_bin.things;
 SELECT data -> 'name' FROM json_bin.things ORDER BY id;
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY id ASC NULLS LAST
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+ ?column? 
+----------
+ "gizmo"
+ "doodad"
+ "curio"
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY id ASC NULLS LAST
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
                                              QUERY PLAN                                             
@@ -416,7 +656,36 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
 ----+------
 (0 rows)
 
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
                                             QUERY PLAN                                             
@@ -444,8 +713,36 @@ SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb;
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((toJSONString(data.stocked) = 'true')) ORDER BY id ASC NULLS LAST
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id |                           data                           
+----+----------------------------------------------------------
+  3 | {"id":"3","name":"gizmo","size":"medium","stocked":true}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true')) ORDER BY id ASC NULLS LAST
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
                                              QUERY PLAN                                             
@@ -474,6 +771,36 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 ----+------
 (0 rows)
 
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
 -- Edge cases: JSON keys that require identifier quoting.
 SELECT clickhouse_raw_query($$
     CREATE TABLE json_test.special_keys (
@@ -495,6 +822,10 @@ VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
 ERROR:  pg_clickhouse: could not finish INSERT - DB::Exception: Invalid version for Object structure serialization.
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -523,6 +854,33 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
@@ -539,6 +897,45 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
   1 | {"select": "reserved", "my field": "hello", "CamelCase": "world"}
 (1 row)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
 -- Key that is a SQL reserved word.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
@@ -567,6 +964,33 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+ id |                             data                             
+----+--------------------------------------------------------------
+  1 | {"CamelCase":"world","my field":"hello","select":"reserved"}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -578,6 +1002,48 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
  id | data 
 ----+------
 (0 rows)
@@ -611,6 +1077,34 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
 ----+------
 (0 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ id | data 
+----+------
+(0 rows)
+
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -636,6 +1130,34 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
  id | data 
 ----+------
 (0 rows)
@@ -669,6 +1191,34 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
 ----+------
 (0 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ id | data 
+----+------
+(0 rows)
+
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -698,6 +1248,34 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
 ----+------
 (0 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ id | data 
+----+------
+(0 rows)
+
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -723,6 +1301,34 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
  id | data 
 ----+------
 (0 rows)
@@ -943,6 +1549,199 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ C100
+ C200
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, props FROM json_test.events ORDER BY id ASC NULLS LAST
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+ json_extract_path_text 
+------------------------
+ Paris
+ London
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT id, props FROM json_test.events ORDER BY id ASC NULLS LAST
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+       json_extract_path        
+--------------------------------
+ {"city":"Paris","zip":"75001"}
+ {"city":"London","zip":"SW1A"}
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+ERROR:  pg_clickhouse: Unsupported JSON serialization version. Make sure output_format_native_write_json_as_string=1 is set.
+DETAIL:  Remote Query: SELECT props FROM json_test.events
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -952,12 +1751,18 @@ SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_bin.things
+drop cascades to foreign table json_bin.json_things
 drop cascades to foreign table json_bin.special_keys
+drop cascades to foreign table json_bin.json_special_keys
 drop cascades to foreign table json_bin.events
+drop cascades to foreign table json_bin.json_events
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table json_http.things
+drop cascades to foreign table json_http.json_things
 drop cascades to foreign table json_http.special_keys
+drop cascades to foreign table json_http.json_special_keys
 drop cascades to foreign table json_http.events
+drop cascades to foreign table json_http.json_events

--- a/test/expected/json_5.out
+++ b/test/expected/json_5.out
@@ -56,6 +56,26 @@ SELECT * FROM json_http.things ORDER BY id;
 ERROR:  relation "json_http.things" does not exist
 LINE 1: SELECT * FROM json_http.things ORDER BY id;
                       ^
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+ERROR:  pg_clickhouse: could not prepare insert - unsupported column type: Object('json')
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+SELECT * FROM json_bin.json_things ORDER BY id;
+ERROR:  type json is not composite
+SELECT * FROM json_http.json_things ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -116,10 +136,7 @@ SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT data['size'], count(*) FROM json_bin.things GROUP BY ...
                                            ^
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
 ERROR:  relation "json_http.things" does not exist
@@ -138,7 +155,32 @@ SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
                                     ^
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data ->> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+ERROR:  type json is not composite
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
 ERROR:  relation "json_http.things" does not exist
@@ -157,7 +199,36 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widge...
                       ^
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name = 'widget'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
 ERROR:  relation "json_http.things" does not exist
@@ -176,7 +247,36 @@ SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wi...
                       ^
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.name LIKE 'wid%'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -199,7 +299,36 @@ SELECT * FROM json_bin.things
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things
                       ^
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ERROR:  pg_clickhouse: Code: 53. DB::Exception: Cannot convert string true to type UInt8: while executing 'FUNCTION equals(data.stocked : 2, 'true' : 5) -> equals(data.stocked, 'true') UInt8 : 7'. (TYPE_MISMATCH)
+CONTEXT:  HTTP status code: 400
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+ERROR:  pg_clickhouse: DB::Exception: Cannot convert string true to type UInt8: while executing 'FUNCTION equals(data.stocked : 2, 'true' : 5) -> equals(data.stocked, 'true') UInt8 : 7'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -225,37 +354,102 @@ SELECT * FROM json_bin.things
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things
                       ^
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE (((data.name = 'widget') OR (data.name = 'gizmo'))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id | data 
+----+------
+(0 rows)
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+ id | data 
+----+------
+(0 rows)
+
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 ERROR:  relation "json_http.things" does not exist
-LINE 2: SELECT * FROM json_http.things ORDER BY data ->> 'size';
+LINE 2: SELECT * FROM json_http.things ORDER BY data ->> 'name';
                       ^
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 ERROR:  relation "json_http.things" does not exist
-LINE 1: SELECT * FROM json_http.things ORDER BY data ->> 'size';
+LINE 1: SELECT * FROM json_http.things ORDER BY data ->> 'name';
                       ^
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  relation "json_bin.things" does not exist
-LINE 2: SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+LINE 2: SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                       ^
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 ERROR:  relation "json_bin.things" does not exist
-LINE 1: SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+LINE 1: SELECT * FROM json_bin.things ORDER BY data ->> 'name';
                       ^
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
 ERROR:  relation "json_http.things" does not exist
-LINE 1: SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMI...
+LINE 1: SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMI...
                       ^
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
 ERROR:  relation "json_bin.things" does not exist
-LINE 1: SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT...
+LINE 1: SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT...
                       ^
 SET pg_clickhouse.session_settings TO '';
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data, (data ->> 'name'::text)
+   Remote SQL: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST
+(3 rows)
+
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+ERROR:  type json is not composite
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+ERROR:  pg_clickhouse: Code: 115. DB::Exception: Setting allow_suspicious_types_in_order_by is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings. (UNKNOWN_SETTING)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
+CONTEXT:  HTTP status code: 404
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+ERROR:  pg_clickhouse: DB::Exception: Unknown setting allow_suspicious_types_in_order_by
+DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
+SET pg_clickhouse.session_settings TO '';
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
 ERROR:  relation "json_http.things" does not exist
@@ -274,7 +468,31 @@ SELECT data -> 'name' FROM json_bin.things ORDER BY id;
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT data -> 'name' FROM json_bin.things ORDER BY id;
                                    ^
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: (data -> 'name'::text)
+   Remote SQL: SELECT data FROM json_test.things
+(3 rows)
+
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+ERROR:  type json is not composite
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
 ERROR:  relation "json_http.things" does not exist
@@ -293,7 +511,36 @@ SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE data -> 'name' = '"widge...
                       ^
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.name) AS String) = '"widget"'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
 ERROR:  relation "json_http.things" does not exist
@@ -312,8 +559,37 @@ SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY i
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'tru...
                       ^
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id | data 
+----+------
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_things
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.things WHERE ((CAST(toJSONString(data.stocked) AS String) = 'true'))
+(3 rows)
+
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+ id | data 
+----+------
+(0 rows)
+
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
 ERROR:  relation "json_http.things" does not exist
@@ -331,6 +607,26 @@ LINE 2: SELECT * FROM json_bin.things WHERE data -> 'name' = '"widge...
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE data -> 'name' = '"widge...
+                      ^
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ERROR:  relation "json_http.things" does not exist
+LINE 2: SELECT * FROM json_http.things WHERE (data -> 'name')::text ...
+                      ^
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+ERROR:  relation "json_http.things" does not exist
+LINE 1: SELECT * FROM json_http.things WHERE (data -> 'name')::text ...
+                      ^
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+ERROR:  relation "json_bin.things" does not exist
+LINE 2: SELECT * FROM json_bin.things WHERE (data -> 'name')::text =...
+                      ^
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+ERROR:  relation "json_bin.things" does not exist
+LINE 1: SELECT * FROM json_bin.things WHERE (data -> 'name')::text =...
                       ^
 -- Edge cases: JSON keys that require identifier quoting.
 SELECT clickhouse_raw_query($$
@@ -353,6 +649,10 @@ VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
 ERROR:  pg_clickhouse: could not prepare insert - unsupported column type: Object('json')
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -379,6 +679,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."my field" = 'hello'))
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
@@ -393,6 +718,43 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
 ERROR:  invalid input syntax for type json
 DETAIL:  Token "(" is invalid.
 CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."CamelCase" = 'world'))
 -- Key that is a SQL reserved word.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'select' = 'reserved';
@@ -419,6 +781,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+ERROR:  pg_clickhouse: unsupported column type: Tuple(CamelCase String, `my field` String, select String)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."select" = 'reserved'))
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -433,6 +820,43 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
 ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 -- Key containing a backslash.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
@@ -457,6 +881,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
 ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
 -- Key containing a dot (must not be confused with nested access).
@@ -485,6 +934,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
 ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
 -- Key containing an apostrophe / single quote.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
@@ -509,6 +983,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
 ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
 -- Key with slashes, bangs, at-signs, etc.
@@ -537,6 +1036,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
 SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
 ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -561,6 +1085,31 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
+DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+CONTEXT:  HTTP status code: 404
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_special_keys
+   Output: id, data
+   Remote SQL: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
+(3 rows)
+
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 -- =======================================================================
@@ -767,6 +1316,187 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{customerId}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+ERROR:  type json is not composite
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path_text(props, VARIADIC '{address,city}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+ERROR:  type json is not composite
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+ERROR:  invalid input syntax for type json
+DETAIL:  Token "(" is invalid.
+CONTEXT:  JSON data, line 1: (...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: json_extract_path(props, VARIADIC '{address}'::text[])
+   Remote SQL: SELECT props FROM json_test.events
+(3 rows)
+
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+ERROR:  type json is not composite
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props."customerId" = 'C100'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((props.address.city = 'Paris'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+ id 
+----
+  1
+(1 row)
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on json_bin.json_events
+   Output: id
+   Remote SQL: SELECT id FROM json_test.events WHERE ((CAST(toJSONString(props.address.city) AS String) = '"Paris"'))
+(3 rows)
+
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+ id 
+----
+  1
+(1 row)
+
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 
 ----------------------
@@ -776,10 +1506,16 @@ SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to foreign table json_bin.special_keys
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to foreign table json_bin.json_things
+drop cascades to foreign table json_bin.special_keys
+drop cascades to foreign table json_bin.json_special_keys
 drop cascades to foreign table json_bin.events
+drop cascades to foreign table json_bin.json_events
 DROP SERVER http_json_loopback CASCADE;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to foreign table json_http.special_keys
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to foreign table json_http.json_things
+drop cascades to foreign table json_http.special_keys
+drop cascades to foreign table json_http.json_special_keys
 drop cascades to foreign table json_http.events
+drop cascades to foreign table json_http.json_events

--- a/test/expected/json_6.out
+++ b/test/expected/json_6.out
@@ -312,7 +312,7 @@ SELECT * FROM json_http.json_things
 
 SELECT * FROM json_http.json_things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
-ERROR:  pg_clickhouse: Code: 53. DB::Exception: Cannot convert string true to type UInt8. (TYPE_MISMATCH)
+ERROR:  pg_clickhouse: Code: 53. DB::Exception: Cannot convert string true to type UInt8: while executing 'FUNCTION equals(data.stocked : 2, 'true' : 5) -> equals(data.stocked, 'true') UInt8 : 7'. (TYPE_MISMATCH)
 CONTEXT:  HTTP status code: 400
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.json_things
@@ -326,7 +326,7 @@ SELECT * FROM json_bin.json_things
 
 SELECT * FROM json_bin.json_things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
-ERROR:  pg_clickhouse: DB::Exception: Cannot convert string true to type UInt8
+ERROR:  pg_clickhouse: DB::Exception: Cannot convert string true to type UInt8: while executing 'FUNCTION equals(data.stocked : 2, 'true' : 5) -> equals(data.stocked, 'true') UInt8 : 7'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things WHERE ((data.size = 'large')) AND ((data.stocked = 'true'))
 -- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -442,11 +442,11 @@ SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
 ERROR:  type json is not composite
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
 SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
-ERROR:  pg_clickhouse: Code: 115. DB::Exception: Setting allow_suspicious_types_in_order_by is neither a builtin setting nor started with the prefix 'SQL_' registered for user-defined settings. (UNKNOWN_SETTING)
+ERROR:  pg_clickhouse: Code: 115. DB::Exception: Unknown setting allow_suspicious_types_in_order_by. (UNKNOWN_SETTING)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
 CONTEXT:  HTTP status code: 404
 SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown setting 'allow_suspicious_types_in_order_by'
+ERROR:  pg_clickhouse: DB::Exception: Unknown setting allow_suspicious_types_in_order_by
 DETAIL:  Remote Query: SELECT id, data FROM json_test.things ORDER BY data.name ASC NULLS LAST LIMIT 2
 SET pg_clickhouse.session_settings TO '';
 -- The jsonb -> operator runs locally when used in SELECT target lists.
@@ -817,7 +817,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '4
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.The "meaning" of life' in scope SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -830,7 +830,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.The "meaning" of life' in scope SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
@@ -842,7 +842,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life'
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.The "meaning" of life' in scope SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -855,7 +855,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' 
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.The "meaning" of life' in scope SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.The "meaning" of life' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`The "meaning" of life` = '42'', required columns: 'id' 'data' 'data.The "meaning" of life', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."The ""meaning"" of life" = '42'))
 -- Key containing a backslash.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -868,7 +868,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'back\slash' = 'bs';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.back\slash' in scope SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -881,7 +881,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.back\slash' in scope SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
@@ -893,7 +893,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.back\slash' in scope SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -906,7 +906,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.back\slash' in scope SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.back\slash' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`back\\slash` = 'bs'', required columns: 'id' 'data' 'data.back\slash', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."back\slash" = 'bs'))
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -919,7 +919,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.dotted.key' in scope SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -932,7 +932,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.dotted.key' in scope SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -944,7 +944,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.dotted.key' in scope SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -957,7 +957,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.dotted.key' in scope SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.dotted.key' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`dotted.key` = 'dot'', required columns: 'id' 'data' 'data.dotted.key', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."dotted.key" = 'dot'))
 -- Key containing an apostrophe / single quote.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -970,7 +970,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'it''s' = 'apos';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.it's' in scope SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -983,7 +983,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.it's' in scope SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
@@ -995,7 +995,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.it's' in scope SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1008,7 +1008,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.it's' in scope SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.it's' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`it's` = 'apos'', required columns: 'id' 'data' 'data.it's', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."it's" = 'apos'))
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1021,7 +1021,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.key/with!special@chars#' in scope SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1034,7 +1034,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = '
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.key/with!special@chars#' in scope SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -1046,7 +1046,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.key/with!special@chars#' in scope SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1059,7 +1059,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.key/with!special@chars#' in scope SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.key/with!special@chars#' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`key/with!special@chars#` = 'special'', required columns: 'id' 'data' 'data.key/with!special@chars#', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."key/with!special@chars#" = 'special'))
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1072,7 +1072,7 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.123numeric' in scope SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1085,7 +1085,7 @@ SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.123numeric' in scope SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
@@ -1097,7 +1097,7 @@ SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
-ERROR:  pg_clickhouse: Code: 47. DB::Exception: Unknown expression or function identifier 'data.123numeric' in scope SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'. (UNKNOWN_IDENTIFIER)
+ERROR:  pg_clickhouse: Code: 47. DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'. (UNKNOWN_IDENTIFIER)
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 CONTEXT:  HTTP status code: 404
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1110,7 +1110,7 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 (3 rows)
 
 SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
-ERROR:  pg_clickhouse: DB::Exception: Unknown expression or function identifier 'data.123numeric' in scope SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'
+ERROR:  pg_clickhouse: DB::Exception: Missing columns: 'data.123numeric' while processing query: 'SELECT id, data FROM json_test.special_keys WHERE data.`123numeric` = 'num'', required columns: 'id' 'data' 'data.123numeric', maybe you meant: 'id' or 'data'
 DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data."123numeric" = 'num'))
 -- =======================================================================
 -- jsonb_extract_path_text / jsonb_extract_path pushdown

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -159,7 +159,8 @@ json.sql
  24.10-25.3 | json_2.out
  24.8-24.9  | json_3.out
  24.3       | json_4.out
- 23         | json_5.out
+ 23.8       | json_5.out
+ 23.3       | json_6.out
 
 param.sql
 ---------

--- a/test/sql/json.sql
+++ b/test/sql/json.sql
@@ -33,6 +33,26 @@ INSERT INTO json_http.things VALUES
 SELECT * FROM json_bin.things ORDER BY id;
 SELECT * FROM json_http.things ORDER BY id;
 
+-- Should also support JSON mapping.
+CREATE FOREIGN TABLE json_bin.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER binary_json_loopback OPTIONS (table_name 'things');
+
+CREATE FOREIGN TABLE json_http.json_things (
+    id   integer NOT NULL,
+    data json    NOT NULL
+) SERVER http_json_loopback OPTIONS (table_name 'things');
+
+INSERT INTO json_bin.json_things
+VALUES (5, '{"id": 5, "name": "bauble", "size": "small", "stocked": true}');
+
+INSERT INTO json_http.json_things
+VALUES (6, '{"id": 6, "name": "curio", "size": "medium", "stocked": false}');
+
+SELECT * FROM json_bin.json_things ORDER BY id;
+SELECT * FROM json_http.json_things ORDER BY id;
+
 -- Subscript access on JSON columns must not be pushed down to ClickHouse.
 -- ClickHouse JSON does not support the jsonb `column['key']` syntax (it
 -- requires dot notation), so subscripts must be evaluated locally by
@@ -63,10 +83,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 SELECT data['size'], count(*) FROM json_bin.things GROUP BY data['size'];
 
--- The jsonb ->> operator is pushed down in WHERE / ORDER BY clauses, but
--- target-list expressions are evaluated locally (PostgreSQL fetches the whole
--- column and applies the operator after). This query runs -> locally.
--- N.B.: Binary driver JSON data not yet supported.
+-- The jsonb ->> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_http.things;
 SELECT data ->> 'name' FROM json_http.things ORDER BY id;
@@ -75,7 +92,16 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data ->> 'name' FROM json_bin.things;
 SELECT data ->> 'name' FROM json_bin.things ORDER BY id;
 
--- WHERE clause with ->> equality must be pushed down.
+-- The json ->> operator runs locally when used in SELECT target lists.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_http.json_things;
+SELECT data ->> 'name' FROM json_http.json_things ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data ->> 'name' FROM json_bin.json_things;
+SELECT data ->> 'name' FROM json_bin.json_things ORDER BY id;
+
+-- WHERE clause with jsonb ->> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
 SELECT * FROM json_http.things WHERE data ->> 'name' = 'widget';
@@ -84,7 +110,16 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
 SELECT * FROM json_bin.things WHERE data ->> 'name' = 'widget';
 
--- WHERE clause with ->> and LIKE.
+-- WHERE clause with json ->> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+SELECT * FROM json_http.json_things WHERE data ->> 'name' = 'widget';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' = 'widget';
+
+-- WHERE clause with jsonb ->> and LIKE.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
 SELECT * FROM json_http.things WHERE data ->> 'name' LIKE 'wid%';
@@ -93,7 +128,16 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
 SELECT * FROM json_bin.things WHERE data ->> 'name' LIKE 'wid%';
 
--- WHERE with multiple ->> conditions (AND).
+-- WHERE clause with json ->> and LIKE.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+SELECT * FROM json_http.json_things WHERE data ->> 'name' LIKE 'wid%';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+SELECT * FROM json_bin.json_things WHERE data ->> 'name' LIKE 'wid%';
+
+-- WHERE with multiple jsonb ->> conditions (AND).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
@@ -106,7 +150,20 @@ SELECT * FROM json_bin.things
 SELECT * FROM json_bin.things
   WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
 
--- WHERE with ->> in an OR condition.
+-- WHERE with multiple json ->> conditions (AND).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'size' = 'large' AND data ->> 'stocked' = 'true';
+
+-- WHERE with jsonb ->> in an OR condition.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
@@ -122,22 +179,50 @@ SELECT * FROM json_bin.things
   WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
   ORDER BY id;
 
--- ORDER BY with ->> pushdown.
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
-SELECT * FROM json_http.things ORDER BY data ->> 'size';
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+SELECT * FROM json_http.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+SELECT * FROM json_bin.json_things
+  WHERE data ->> 'name' = 'widget' OR data ->> 'name' = 'gizmo'
+  ORDER BY id;
+
+-- ORDER BY with jsonb ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
+SELECT * FROM json_http.things ORDER BY data ->> 'name';
 
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
-SELECT * FROM json_bin.things ORDER BY data ->> 'size';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
+SELECT * FROM json_bin.things ORDER BY data ->> 'name';
 
 SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
-SELECT * FROM json_http.things ORDER BY data ->> 'size' LIMIT 2;
-SELECT * FROM json_bin.things ORDER BY data ->> 'size' LIMIT 2;
+SELECT * FROM json_http.things ORDER BY data ->> 'name' LIMIT 2;
+SELECT * FROM json_bin.things ORDER BY data ->> 'name' LIMIT 2;
 SET pg_clickhouse.session_settings TO '';
 
--- The jsonb -> operator: target-list expressions are evaluated locally
--- (same as ->>). This query evaluates `->` locally.
+-- ORDER BY with json ->> pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name';
+
+SET pg_clickhouse.session_settings TO 'allow_suspicious_types_in_order_by 1';
+SELECT * FROM json_http.json_things ORDER BY data ->> 'name' LIMIT 2;
+SELECT * FROM json_bin.json_things ORDER BY data ->> 'name' LIMIT 2;
+SET pg_clickhouse.session_settings TO '';
+
+-- The jsonb -> operator runs locally when used in SELECT target lists.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_http.things;
 SELECT data -> 'name' FROM json_http.things ORDER BY id;
@@ -146,7 +231,15 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT data -> 'name' FROM json_bin.things;
 SELECT data -> 'name' FROM json_bin.things ORDER BY id;
 
--- WHERE clause with -> equality must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_http.json_things;
+SELECT data -> 'name' FROM json_http.json_things ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT data -> 'name' FROM json_bin.json_things;
+SELECT data -> 'name' FROM json_bin.json_things ORDER BY id;
+
+-- WHERE clause with jsonb -> equality must be pushed down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"';
@@ -155,7 +248,16 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"';
 
--- WHERE clause with -> JSON boolean literal must push down.
+-- WHERE clause with json -> cast to text must be pushed down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+SELECT * FROM json_http.json_things WHERE (data -> 'name')::text = '"widget"';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+SELECT * FROM json_bin.json_things WHERE (data -> 'name')::text = '"widget"';
+
+-- WHERE clause with jsonb -> JSON boolean literal must push down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb;
 SELECT * FROM json_http.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
@@ -164,8 +266,17 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb;
 SELECT * FROM json_bin.things WHERE data -> 'stocked' = 'true'::jsonb ORDER BY id;
 
--- WHERE clause with -> wraps the dot notation in toJSONString() so that the
--- result is a proper JSON value (-> returns jsonb, not text like ->>).
+-- WHERE clause with json -> JSON boolean literal must push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true';
+SELECT * FROM json_http.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true';
+SELECT * FROM json_bin.json_things WHERE (data -> 'stocked')::text = 'true' ORDER BY id;
+
+-- WHERE clause with jsonb -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns jsonb).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
 SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
@@ -173,6 +284,16 @@ SELECT * FROM json_http.things WHERE data -> 'name' = '"widget"'::jsonb;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
 SELECT * FROM json_bin.things WHERE data -> 'name' = '"widget"'::jsonb;
+
+-- WHERE clause with json -> wraps the dot notation in toJSONString() so the
+-- result is a proper JSON value (->, unlike ->>, returns json).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+SELECT * FROM json_http.things WHERE (data -> 'name')::text = '"widget"';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
+SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 
 -- Edge cases: JSON keys that require identifier quoting.
 SELECT clickhouse_raw_query($$
@@ -194,6 +315,12 @@ VALUES (1, '{"my field": "hello", "CamelCase": "world", "select": "reserved"}');
 INSERT INTO json_bin.special_keys
 VALUES (2, E'{"The \\"meaning\\" of life": 42, "back\\\\slash": "bs", "dotted.key": "dot", "it''s": "apos", "key/with!special@chars#": "special", "123numeric": "num"}');
 
+CREATE FOREIGN TABLE json_http.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+
+CREATE FOREIGN TABLE json_bin.json_special_keys (id integer NOT NULL, data json NOT NULL)
+  SERVER binary_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
+
 -- Key with a space: must be quoted in the remote SQL.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'my field' = 'hello';
@@ -203,10 +330,30 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'my field' = 'hello';
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'my field' = 'hello';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'my field' = 'hello';
+
 -- Key with mixed case.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
 SELECT * FROM json_http.special_keys WHERE data ->> 'CamelCase' = 'world';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+SELECT * FROM json_bin.special_keys WHERE data ->> 'CamelCase' = 'world';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'CamelCase' = 'world';
 
 -- Key that is a SQL reserved word.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -217,10 +364,30 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'select' = 'reserved';
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'select' = 'reserved';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'select' = 'reserved';
+
 -- Key containing embedded double quotes.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
 SELECT * FROM json_http.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+SELECT * FROM json_bin.special_keys WHERE data ->> 'The "meaning" of life' = '42';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'The "meaning" of life' = '42';
 
 -- Key containing a backslash.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -231,6 +398,14 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'back\slash' = 'bs';
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'back\slash' = 'bs';
+
 -- Key containing a dot (must not be confused with nested access).
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
@@ -239,6 +414,14 @@ SELECT * FROM json_http.special_keys WHERE data ->> 'dotted.key' = 'dot';
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'dotted.key' = 'dot';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'dotted.key' = 'dot';
 
 -- Key containing an apostrophe / single quote.
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -249,6 +432,14 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'it''s' = 'apos';
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'it''s' = 'apos';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'it''s' = 'apos';
+
 -- Key with slashes, bangs, at-signs, etc.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
@@ -258,6 +449,14 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
 SELECT * FROM json_bin.special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+SELECT * FROM json_http.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> 'key/with!special@chars#' = 'special';
+
 -- Key that starts with a digit.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
@@ -266,6 +465,14 @@ SELECT * FROM json_http.special_keys WHERE data ->> '123numeric' = 'num';
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
 SELECT * FROM json_bin.special_keys WHERE data ->> '123numeric' = 'num';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+SELECT * FROM json_http.json_special_keys WHERE data ->> '123numeric' = 'num';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
+SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 
 -- =======================================================================
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
@@ -350,6 +557,75 @@ SELECT id FROM json_http.events WHERE jsonb_extract_path(props, 'address', 'city
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
 SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
+
+-- =======================================================================
+-- json_extract_path_text / json_extract_path pushdown
+-- =======================================================================
+CREATE FOREIGN TABLE json_http.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER http_json_loopback OPTIONS (table_name 'events');
+
+CREATE FOREIGN TABLE json_bin.json_events (
+    id         integer,
+    event_name text,
+    props      json
+) SERVER binary_json_loopback OPTIONS (table_name 'events');
+
+-- Target-list: json_extract_path_text is evaluated locally (like -> / ->>).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events;
+SELECT json_extract_path_text(props, 'customerId') FROM json_http.json_events ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events;
+SELECT json_extract_path_text(props, 'customerId') FROM json_bin.json_events ORDER BY id;
+
+-- Target-list: multi-level path, still evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events;
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_http.json_events ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events;
+SELECT json_extract_path_text(props, 'address', 'city') FROM json_bin.json_events ORDER BY id;
+
+-- Target-list: json_extract_path (returns json, not text), evaluated locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+SELECT json_extract_path(props, 'address') FROM json_http.json_events;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+SELECT json_extract_path(props, 'address') FROM json_bin.json_events;
+
+-- WHERE: single-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'customerId') = 'C100';
+
+-- WHERE: multi-level json_extract_path_text pushes down as dot notation.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+SELECT id FROM json_http.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+SELECT id FROM json_bin.json_events WHERE json_extract_path_text(props, 'address', 'city') = 'Paris';
+
+-- WHERE: json_extract_path pushes down with toJSONString wrapping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;


### PR DESCRIPTION
In addition to the JSONB type mapping, add support for the use of the Postgres JSON type mapped to the ClickHouse JSON type. It already worked for the JSON driver, just hadn't been tested. But adding it to the binary driver required a bit more work.

Mainly that work encompasses making the binary type handling functions aware of the Postgres type used in columns. By default, the binary driver supports a short list of types that map to ClickHouse types, but allows for other types by exercising the functions in `convert.c` to convert between compatible types. These conversion require casts. And while Postgres supports casts between JSON and JSONB, they're `COERCION_PATH_COERCEVIAIO` casts, which `convert.c` doesn't handle.

We could consider adding support for these conversions, but since it requires using the _in and _out functions to do the conversion, and since for JSON all we really need is the text version, this seems unnecessarily wasteful in terms of CPU cycles and memory.

Instead, refactor things so that the binary conversion functions are aware of not only explicitly supported type mappings provided by `get_corr_postgres_type()`, but also the types used for the columns in the foreign tables. Then teach `get_corr_postgres_type()` to inspect these values in the context of the ClickHouse JSON type and allow both.

For fetches (selects), on the first call to `ch_binary_read_row()`, populate `coltypes` with the actual column types and teach `make_datum()` to examine it when considering JSON types. This requires that the `List` of attributes be passed to `ch_binary_read_row`, and also that `coltypes` be initialized with zero values. Ideally `coltypes` would be populated by an earlier hook, before fetching starts, but this will do for now.

For updates (inserts), on the other hand, create a new `List` and populate it with the requisite types in `clickhouseBeginForeignInsert` and `clickhousePlanForeignModify` (not sure why it needs both, but it follows the pattern of setting column attribute numbers, which are also in both places). THen pass it as a new argument to the `prepare_insert` function, now with an updated signature (the HTTP version currently ignores the new argument). Then fetch the types from it in `ch_binary_prepare_insert()` to pass to `get_corr_postgres_type()`.

Teach `init_output_convert_state()` not to try to convert between `JSON` and `JSONB` types, and add comments to explain what's happening with all this type management stuff.

Finally, update the function and operator pushdown functions to support the `->` and `->>` operators for JSON, as well as the `json_extract_path_text()` and `json_extract_path()` functions. Rename the relevant constants to `JSON_*` instead of `JSONB_*`, since they now handle both, and `JSON_*` is the more generic.

Expand the JSON tests to cover all the same patterns for JSON that were previously covered for JSONB, for both the binary and http drivers. This requires additional alternate expected output files due to minor changes to earlier ClickHouse versions that did not support JSON and returned varying error messages about it.

Document the support for JSON, as well as the operators and functions. In fact, the `jsonb_()` functions weren't previously documented, so add them, too. Also fix reversed descriptions for the `->` and `->>` operators and mention that they work for both JSON and JSONB.

While at it, update the exception raised when `column_append()` can't handle a specific Postgres type to emit the name of the unsupported type.