### PR TITLE
Make TSV parser column-type-aware for bracket-leading strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file. It uses the
 *   Fixed `EXPLAIN (VERBOSE)` failing with "could not find window clause for
     winref N" when window functions are pushed down to ClickHouse. Thanks to
     Philip Dubé for the PR ([#223]).
+*   Fixed the parsing of strings that start with `[` in the http driver so
+    that it no longer assumes it's the start of an array. Thanks to Kaushik
+    Iska for the PR ([#234]).
 
 ### 📚 Documentation
 

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -63,7 +63,7 @@ char	   *ch_http_last_error(void);
 
 /* read */
 void		ch_http_read_state_init(ch_http_read_state * state, char *data, size_t datalen);
-int			ch_http_read_next(ch_http_read_state * state);
+int			ch_http_read_next(ch_http_read_state * state, bool is_array);
 void		ch_http_response_free(ch_http_response_t * resp);
 
 #endif							/* CLICKHOUSE_HTTP_H */

--- a/src/parser.c
+++ b/src/parser.c
@@ -51,9 +51,15 @@ ch_http_read_state_init(ch_http_read_state * state, char *data, size_t datalen)
  * ClickHouse literals including unquoted strings and arrays. Returns CH_CONT
  * if there are moe fields on the line to read, CH_EOL if it has reached the
  * end of the line, and CH_EOF if it has reached the end of the file.
+ *
+ * `is_array` tells the parser whether the destination Postgres column is an
+ * array. TabSeparated is ambiguous: a `String` value beginning with `[` is not
+ * escaped on the wire and is indistinguishable byte-for-byte from an array
+ * literal until you know the column type. The caller knows the type, so it
+ * makes the call.
  */
 int
-ch_http_read_next(ch_http_read_state * state)
+ch_http_read_next(ch_http_read_state * state, bool is_array)
 {
 	char	   *data = state->data;
 
@@ -66,7 +72,7 @@ ch_http_read_next(ch_http_read_state * state)
 	if (state->curpos >= state->datalen)
 		return ch_http_read_eof(state);
 
-	if (data[state->curpos] == '[')
+	if (is_array && data[state->curpos] == '[')
 		/* Parse array literal. */
 		ch_http_read_array(state);
 	else

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -527,7 +527,7 @@ http_fetch_row_from_state(ChFdwScanRowContext * ctx, ch_http_read_state * state)
 	if (attcount == 0)
 	{
 		Assert(ctx->values && ctx->nulls);
-		rc = ch_http_read_next(state);
+		rc = ch_http_read_next(state, false);
 		if (rc != CH_CONT && http_value_is_null(&state->val))
 		{
 			ctx->nulls[0] = true;
@@ -555,8 +555,11 @@ http_fetch_row_from_state(ChFdwScanRowContext * ctx, ch_http_read_state * state)
 		Assert(ctx->values && ctx->nulls && ctx->attinmeta);
 		foreach(lc, ctx->retrieved_attrs)
 		{
+			Oid			pgtype;
+
 			i = lfirst_int(lc) - 1;
-			rc = ch_http_read_next(state);
+			pgtype = TupleDescAttr(ctx->tupdesc, i)->atttypid;
+			rc = ch_http_read_next(state, type_is_array(pgtype));
 			char_to_datum(ctx, i, state->val.data, state->val.len);
 		}
 	}
@@ -566,7 +569,7 @@ http_fetch_row_from_state(ChFdwScanRowContext * ctx, ch_http_read_state * state)
 		values = palloc(attcount * sizeof(Datum));
 		for (int idx = 0; idx < attcount; idx++)
 		{
-			rc = ch_http_read_next(state);
+			rc = ch_http_read_next(state, false);
 			if (http_value_is_null(&state->val))
 				values[idx] = (Datum) 0;
 			else

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -887,6 +887,78 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 ERROR:  invalid value for option "fetch_size": -1
 HINT:  fetch_size must be greater than or equal to 0
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+SELECT id, term FROM ft_brk ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+ id | tags  |       term       
+----+-------+------------------
+ 1  | {x,y} | [bracket_string]
+ 2  | {}    | []_not_array
+(2 rows)
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -887,6 +887,78 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 ERROR:  invalid value for option "fetch_size": -1
 HINT:  fetch_size must be greater than or equal to 0
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+SELECT id, term FROM ft_brk ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+ id | tags  |       term       
+----+-------+------------------
+ 1  | {x,y} | [bracket_string]
+ 2  | {}    | []_not_array
+(2 rows)
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -887,6 +887,78 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 ERROR:  invalid value for option "fetch_size": -1
 HINT:  fetch_size must be greater than or equal to 0
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+SELECT id, term FROM ft_brk ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+ id | tags  |       term       
+----+-------+------------------
+ 1  | {x,y} | [bracket_string]
+ 2  | {}    | []_not_array
+(2 rows)
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -887,6 +887,78 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 ERROR:  invalid value for option "fetch_size": -1
 HINT:  fetch_size must be greater than or equal to 0
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+SELECT id, term FROM ft_brk ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+ id | tags  |       term       
+----+-------+------------------
+ 1  | {x,y} | [bracket_string]
+ 2  | {}    | []_not_array
+(2 rows)
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -887,6 +887,78 @@ CREATE FOREIGN TABLE ft_bad_fetch (
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 ERROR:  invalid value for option "fetch_size": -1
 HINT:  fetch_size must be greater than or equal to 0
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+SELECT id, term FROM ft_brk ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+ id |               term                
+----+-----------------------------------
+ 1  | [abc_def]_ghi.jkl_mno
+ 2  | plainstring
+ 3  | [just_brackets]
+ 4  | []
+ 5  | [a,b,c]_trailing
+ 6  | leading text [bracketed] trailing
+(6 rows)
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+ id | tags  |       term       
+----+-------+------------------
+ 1  | {x,y} | [bracket_string]
+ 2  | {}    | []_not_array
+(2 rows)
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -294,6 +294,52 @@ CREATE FOREIGN TABLE ft_bad_fetch (
     c3 text
 ) SERVER http_loopback OPTIONS (table_name 't1', fetch_size '-1');
 
+/*
+ * TabSeparated does not escape `[` or `]` in String values, so a value like
+ * `[foo]bar` is wire-indistinguishable from a CH array literal. The parser
+ * uses the destination Postgres column type to decide.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+    (id String, term String) ENGINE = MergeTree ORDER BY id');
+
+CREATE FOREIGN TABLE ft_brk (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk');
+
+INSERT INTO ft_brk VALUES
+    ('1', '[abc_def]_ghi.jkl_mno'),
+    ('2', 'plainstring'),
+    ('3', '[just_brackets]'),
+    ('4', '[]'),
+    ('5', '[a,b,c]_trailing'),
+    ('6', 'leading text [bracketed] trailing');
+
+SELECT id, term FROM ft_brk ORDER BY id;
+
+/* Streaming path with a small fetch_size forces multi-batch parsing. */
+CREATE FOREIGN TABLE ft_brk_stream (id text, term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk', fetch_size '32');
+SELECT id, term FROM ft_brk_stream ORDER BY id;
+
+/*
+ * Mixed row: real Array(String) column alongside a String column whose value
+ * starts with `[`. The parser must stay in sync across columns.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+    (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
+
+CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
+    SERVER http_loopback OPTIONS (table_name 't_brk_mix');
+
+INSERT INTO ft_brk_mix VALUES
+    ('1', ARRAY['x', 'y'], '[bracket_string]'),
+    ('2', ARRAY[]::text[], '[]_not_array');
+
+SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
+
+DROP FOREIGN TABLE ft_brk_mix;
+DROP FOREIGN TABLE ft_brk_stream;
+DROP FOREIGN TABLE ft_brk;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_no_stream;
 DROP SERVER http_no_stream CASCADE;
 


### PR DESCRIPTION
ClickHouse's TabSeparated format does not escape `[` or `]` in String values, so a value like `[foo]bar` is wire-indistinguishable from an array literal. The HTTP TSV parser previously branched into array-mode purely on a leading `[`, which corrupted any String column whose value started with `[` and aborted with:

```
ERROR: unexpected byte (NN) after array
```

when the byte after `]` wasn't `\t` or `\n`.

Plumb the destination Postgres column's array-ness into `ch_http_read_next` so the parser only enters array-mode when the caller actually expects an array. ClickHouse's own TSV parser is schema-aware for the same reason.

## Test plan

- [x] `make tempcheck` passes locally.
- [x] New regression coverage in `test/sql/http.sql`: bracket-leading String values, streaming-fetch path, and a mixed array+string row.
- [ ] CI matrix across CH 23.3 → 26.3.