### PR TITLE
Add `tupdesc` and `attr_nums` to `ch_query`

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -418,7 +418,9 @@ extern "C"
 		for (Block::Iterator bi(*block); bi.IsValid(); bi.Next())
 		{
 			/* Start with the data type from the foreign table. */
-			Oid			pg_type = lfirst_oid(list_nth_cell(state->target_oids, i));
+			Oid pg_type = query->tupdesc
+						  ? TupleDescAttr(query->tupdesc, lfirst_int(list_nth_cell(query->attr_nums, i)) - 1)->atttypid
+						  : InvalidOid;
 			const char *colname = bi.Name().c_str();
 			try
 			{
@@ -832,7 +834,7 @@ extern "C"
 	}
 
 	void
-	ch_binary_read_state_init(ch_binary_read_state_t *state, ch_binary_response_t *resp)
+	ch_binary_read_state_init(ch_binary_read_state_t *state, ch_binary_response_t *resp, const ch_query *query)
 	{
 		state->resp = resp;
 		state->block = 0;
@@ -861,13 +863,22 @@ extern "C"
 				state->coltypes = new Oid[resp->columns_count];
 				state->values = new Datum[resp->columns_count];
 				state->nulls = new bool[resp->columns_count];
-				std::fill(state->coltypes, state->coltypes + resp->columns_count, 0);
 			}
 		}
 		catch (const std::exception &e)
 		{
 			set_state_error(state, e.what());
+			return;
 		}
+
+		/* Initialize coltypes to SELECT types, when provided. */
+		if (query->tupdesc)
+			for (size_t i = 0; i < list_length(query->attr_nums); i++)
+				state->coltypes[i]
+				= TupleDescAttr(query->tupdesc, lfirst_int(list_nth_cell(query->attr_nums, i)) - 1)->atttypid;
+		else
+			for (size_t i = 0; i < resp->columns_count; i++)
+				state->coltypes[i] = InvalidOid;
 	}
 
 	/*
@@ -1234,20 +1245,6 @@ extern "C"
 
 			for (size_t i = 0; i < state->resp->columns_count; i++)
 			{
-				/*
-				 * For the first row we fetch, set the data types to the
-				 * Postgres target columns. make_datum() may replace the type,
-				 * but in general we want to prefer the type that Postgres
-				 * expects. tupdesc describes the Postgres tuple that we're
-				 * selecting from; attrs contains the list of column numbers
-				 * we're selecting from that tuple.
-				 *
-				 * XXX Would be nice to set this up in an earlier callback
-				 * hook.
-				 */
-				if (!state->coltypes[i] && tupdesc && list_length(attrs) > (int)i)
-					state->coltypes[i] = TupleDescAttr(tupdesc, lfirst_int(list_nth_cell(attrs, i)) - 1)->atttypid;
-
 				/* fill value and null arrays */
 				state->values[i] = make_datum(block[i], state->row, &state->coltypes[i], &state->nulls[i]);
 			}

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -97,8 +97,6 @@ enum FdwModifyPrivateIndex
 	FdwModifyPrivateInsertSQL,
 	/* Integer list of target attribute numbers for INSERT/UPDATE */
 	FdwModifyPrivateTargetAttnums,
-	/* List of target attribute OIDs for INSERT/UPDATE */
-	FdwModifyPrivateTargetAttOids,
 	/* Deparsed name of the result table */
 	FdwModifyPrivateTableName,
 };
@@ -257,7 +255,6 @@ static CHFdwModifyState * create_foreign_modify(EState * estate,
 												Plan * subplan,
 												char *query,
 												List * target_attrs,
-												List * target_oids,
 												char *table_name);
 static void finish_foreign_modify(CHFdwModifyState * fmstate);
 static void prepare_query_params(PlanState * node,
@@ -302,7 +299,7 @@ Datum
 clickhouse_raw_query(PG_FUNCTION_ARGS)
 {
 	char	   *connstring = text_to_cstring(PG_GETARG_TEXT_P(1));
-	ch_query	query = new_query(text_to_cstring(PG_GETARG_TEXT_P(0)), 0, NULL);
+	ch_query	query = new_query(text_to_cstring(PG_GETARG_TEXT_P(0)), 0, NULL, NULL, NULL);
 
 	ch_connection_details *details = connstring_parse(connstring);
 	ch_connection conn = chfdw_http_connect(details);
@@ -1106,8 +1103,6 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 	TupleTableSlot *slot = node->ss.ss_ScanTupleSlot;
 	struct timeval time1,
 				time2;
-	TupleDesc	tupdesc;
-	ch_query	query = new_query(fsstate->query, fsstate->numParams, fsstate->param_values);
 
 	/* Allow query cancel (e.g. Ctrl+C) between tuple fetches. */
 	CHECK_FOR_INTERRUPTS();
@@ -1116,6 +1111,8 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 	if (fsstate->ch_cursor == NULL)
 	{
 		MemoryContext old = MemoryContextSwitchTo(fsstate->batch_cxt);
+		ch_query	query = new_query(fsstate->query, fsstate->numParams, fsstate->param_values,
+									  fsstate->tupdesc, fsstate->retrieved_attrs);
 
 		/*
 		 * Construct array of query parameter values in text format.  We do
@@ -1152,16 +1149,8 @@ clickhouseIterateForeignScan(ForeignScanState * node)
 		MemoryContextSwitchTo(old);
 	}
 
-	if (fsstate->rel)
-		tupdesc = RelationGetDescr(fsstate->rel);
-	else
-	{
-		Assert(fsstate);
-		tupdesc = node->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
-	}
-
 	gettimeofday(&time1, NULL);
-	tup = fetch_tuple(fsstate, tupdesc);
+	tup = fetch_tuple(fsstate, fsstate->tupdesc);
 	gettimeofday(&time2, NULL);
 	time_used += time_diff(&time1, &time2);
 
@@ -1207,7 +1196,6 @@ clickhousePlanForeignModify(PlannerInfo * root,
 	Relation	rel;
 	StringInfoData sql;
 	List	   *targetAttrs = NIL;
-	List	   *targetTypes = NIL;
 
 	initStringInfo(&sql);
 
@@ -1226,10 +1214,7 @@ clickhousePlanForeignModify(PlannerInfo * root,
 			Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
 			if (!attr->attisdropped)
-			{
 				targetAttrs = lappend_int(targetAttrs, attnum);
-				targetTypes = lappend_oid(targetTypes, attr->atttypid);
-			}
 		}
 	}
 
@@ -1269,7 +1254,7 @@ clickhousePlanForeignModify(PlannerInfo * root,
 	 * Build the fdw_private list that will be available to the executor.
 	 * Items in the list must match enum FdwModifyPrivateIndex, above.
 	 */
-	return list_make4(makeString(sql.data), targetAttrs, targetTypes, makeString(table_name));
+	return list_make3(makeString(sql.data), targetAttrs, makeString(table_name));
 }
 
 /*
@@ -1286,7 +1271,6 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 	CHFdwModifyState *fmstate;
 	char	   *query;
 	List	   *target_attrs = NULL;
-	List	   *target_oids = NULL;
 	RangeTblEntry *rte;
 	char	   *table_name;
 
@@ -1300,7 +1284,6 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 	/* Deconstruct fdw_private data. */
 	query = strVal(list_nth(fdw_private, FdwModifyPrivateInsertSQL));
 	target_attrs = (List *) list_nth(fdw_private, FdwModifyPrivateTargetAttnums);
-	target_oids = (List *) list_nth(fdw_private, FdwModifyPrivateTargetAttOids);
 	table_name = strVal(list_nth(fdw_private, FdwModifyPrivateTableName));
 
 	/* Find RTE. */
@@ -1319,7 +1302,6 @@ clickhouseBeginForeignModify(ModifyTableState * mtstate,
 #endif
 									query,
 									target_attrs,
-									target_oids,
 									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
@@ -1352,7 +1334,6 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 	TupleDesc	tupdesc = RelationGetDescr(rel);
 	int			attnum;
 	List	   *targetAttrs = NIL;
-	List	   *targetTypes = NIL;
 	StringInfoData sql;
 	char	   *table_name;
 
@@ -1362,10 +1343,7 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
 
 		if (!attr->attisdropped)
-		{
 			targetAttrs = lappend_int(targetAttrs, attnum);
-			targetTypes = lappend_oid(targetTypes, attr->atttypid);
-		}
 	}
 
 	/*
@@ -1396,7 +1374,6 @@ clickhouseBeginForeignInsert(ModifyTableState * mtstate,
 									NULL,
 									sql.data,
 									targetAttrs,
-									targetTypes,
 									table_name);
 
 	resultRelInfo->ri_FdwState = fmstate;
@@ -1551,7 +1528,6 @@ create_foreign_modify(EState * estate,
 					  Plan * subplan,
 					  char *query,
 					  List * target_attrs,
-					  List * target_oids,
 					  char *table_name)
 {
 	CHFdwModifyState *fmstate;
@@ -1560,7 +1536,7 @@ create_foreign_modify(EState * estate,
 	UserMapping *user;
 	MemoryContext old_mcxt;
 	Relation	rel = rri->ri_RelationDesc;
-	ch_query	q = new_query(query, 0, NULL);
+	ch_query	q = new_query(query, 0, NULL, RelationGetDescr(rel), target_attrs);
 
 	/* Begin constructing CHFdwModifyState. */
 	fmstate = (CHFdwModifyState *) palloc0(sizeof(CHFdwModifyState));
@@ -1585,7 +1561,7 @@ create_foreign_modify(EState * estate,
 
 	old_mcxt = MemoryContextSwitchTo(PortalContext);
 	fmstate->state = fmstate->conn.methods->prepare_insert(fmstate->conn.conn,
-														   rri, target_attrs, target_oids, &q, table_name);
+														   rri, target_attrs, &q, table_name);
 	MemoryContextSwitchTo(old_mcxt);
 
 	/* Create context for per-query temp workspace. */

--- a/src/include/binary.hh
+++ b/src/include/binary.hh
@@ -56,7 +56,6 @@ extern "C"
 		MemoryContextCallback callback;
 
 		TupleDesc	outdesc;
-		List	   *target_oids;	/* Type of each value in outdesc */
 		ch_insert_block_h *insert_block;	/* clickhouse::Block */
 		size_t		len;
 		void	   *conversion_states;
@@ -78,7 +77,7 @@ extern "C"
 	extern void ch_binary_response_free(ch_binary_response_t * resp);
 
 /* reading */
-	void		ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_response_t * resp);
+	void		ch_binary_read_state_init(ch_binary_read_state_t * state, ch_binary_response_t * resp, const ch_query * query);
 	void		ch_binary_read_state_free(ch_binary_read_state_t * state);
 	bool		ch_binary_read_row(ch_binary_read_state_t * state, TupleDesc tupdesc, List * attrs);
 	Datum		ch_binary_convert_datum(void *state, Datum val);

--- a/src/include/engine.h
+++ b/src/include/engine.h
@@ -2,6 +2,7 @@
 #define CLICKHOUSE_ENGINE_H
 
 #include "kv_list.h"
+#include "access/tupdesc.h"
 
 /*
  * ch_connection_details defines the details for connecting to ClickHouse.
@@ -20,12 +21,20 @@ typedef struct
  */
 typedef struct
 {
+	/* The SQL query. */
 	const char *sql;
+	/* The number of parameters in the query. */
 	const int	num_params;
+	/* The list of parameters to pass when executing the query. */
 	const char **param_values;
+	/* A description of the Tuple for the query. */
+	const		TupleDesc tupdesc;
+	/* The numbers of the attributes in tupdesc that the query selects. */
+	const		List *attr_nums;
+	/* List of settings to pass to ClickHouse upon execution. */
 	const		kv_list *settings;
 }			ch_query;
 
-#define new_query(sql, num, vals) {sql, num, vals, chfdw_get_session_settings()}
+#define new_query(sql, num, vals, tupdesc, attrs) {sql, num, vals, tupdesc, attrs, chfdw_get_session_settings()}
 
 #endif							/* CLICKHOUSE_ENGINE_H */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -72,7 +72,7 @@ typedef void (*check_conn_method) (const char *password, UserMapping * user);
 typedef ch_cursor * (*simple_query_method) (void *conn, const ch_query * query);
 typedef void (*simple_insert_method) (void *conn, const ch_query * query);
 typedef Datum * (*cursor_fetch_row_method) (ChFdwScanRowContext * ctx);
-typedef void *(*prepare_insert_method) (void *conn, ResultRelInfo *, List *, List *,
+typedef void *(*prepare_insert_method) (void *conn, ResultRelInfo *, List *,
 										const ch_query *, char *);
 typedef void (*insert_tuple_method) (void *state, TupleTableSlot * slot);
 typedef ch_cursor * (*streaming_query_method) (void *conn,

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -38,7 +38,7 @@ static Datum * http_fetch_row(ChFdwScanRowContext * ctx);
 static Datum * http_streaming_fetch_row(ChFdwScanRowContext * ctx);
 static Datum * http_fetch_row_from_state(ChFdwScanRowContext * ctx,
 										 ch_http_read_state * state);
-static void *http_prepare_insert(void *, ResultRelInfo *, List *, List *, const ch_query *, char *);
+static void *http_prepare_insert(void *, ResultRelInfo *, List *, const ch_query *, char *);
 static void http_insert_tuple(void *, TupleTableSlot *);
 static void char_to_datum(ChFdwScanRowContext * ctx, int attnum, char *data, size_t len);
 static void report_http_stream_query_failure(void *conn, const ch_query * query,
@@ -62,7 +62,7 @@ static void binary_cursor_free(void *cursor);
 /* static void binary_simple_insert(void *conn, const char *query); */
 static Datum * binary_fetch_row(ChFdwScanRowContext * ctx);
 static void binary_insert_tuple(void *, TupleTableSlot * slot);
-static void *binary_prepare_insert(void *, ResultRelInfo *, List *, List *,
+static void *binary_prepare_insert(void *, ResultRelInfo *, List *,
 								   const ch_query * query, char *table_name);
 static char *ch_escape_string(const char *s, size_t len);
 static void ch_quote_literal_internal(char *dst, const char *src, size_t len);
@@ -187,7 +187,7 @@ kill_query(void *conn, const char *query_id)
 	ch_http_response_t *resp;
 	ch_query	query = new_query(psprintf(
 										   "kill query where query_id=%s",
-										   ch_quote_literal(query_id)), 0, NULL);
+										   ch_quote_literal(query_id)), 0, NULL, NULL, NULL);
 
 	ch_http_set_progress_func(NULL);
 	resp = ch_http_simple_query(conn, &query);
@@ -782,7 +782,7 @@ extend_insert_query(ch_http_insert_state * state, TupleTableSlot * slot)
 }
 
 static void *
-http_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs, List * target_oids,
+http_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs,
 					const ch_query * query, char *table_name)
 {
 	ch_http_insert_state *state = palloc0(sizeof(ch_http_insert_state));
@@ -806,7 +806,7 @@ http_insert_tuple(void *istate, TupleTableSlot * slot)
 	if ((slot == NULL && state->sql.len > 0)
 		|| state->sql.len > (MaxAllocSize / 2 /* 512MB */ ))
 	{
-		ch_query	query = new_query(state->sql.data, 0, NULL);
+		ch_query	query = new_query(state->sql.data, 0, NULL, NULL, NULL);
 
 		http_simple_insert(state->conn, &query);
 		resetStringInfo(&state->sql);
@@ -888,7 +888,7 @@ binary_simple_query(void *conn, const ch_query * query)
 	cursor->query = pstrdup(query->sql);
 	cursor->read_state = state;
 	cursor->columns_count = resp->columns_count;
-	ch_binary_read_state_init(cursor->read_state, resp);
+	ch_binary_read_state_init(cursor->read_state, resp, query);
 	cursor->conversion_states = palloc0(sizeof(uintptr_t) * cursor->columns_count);
 
 	cursor->memcxt = tempcxt;
@@ -1058,7 +1058,7 @@ binary_cursor_free(void *c)
 }
 
 static void *
-binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs, List * target_oids,
+binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs,
 					  const ch_query * query, char *table_name)
 {
 	ch_binary_insert_state *state = NULL;
@@ -1082,7 +1082,6 @@ binary_prepare_insert(void *conn, ResultRelInfo * rri, List * target_attrs, List
 	state->conn = conn;
 	state->table_name = pstrdup(table_name);
 	state->relid = RelationGetRelid(rri->ri_RelationDesc);
-	state->target_oids = target_oids;
 	MemoryContextRegisterResetCallback(tempcxt, &state->callback);
 
 	/* time for c++ stuff */
@@ -1296,7 +1295,7 @@ chfdw_construct_create_tables(ImportForeignSchemaStmt * stmt, ForeignServer * se
 	UserMapping *user = GetUserMapping(userid, server->serverid);
 	ch_connection conn = chfdw_get_connection(user);
 	ch_cursor  *cursor;
-	ch_query	query = new_query(NULL, 0, NULL);
+	ch_query	query = new_query(NULL, 0, NULL, NULL, NULL);
 	List	   *result = NIL;
 	Datum	   *row_values;
 


### PR DESCRIPTION
The way in which the binary driver had to determine target column types (for `SELECT` or `INSERT` statements) introduced with the JSON support in #230 was kind of gross; inconsistent, at the least. For `INSERT`s it was passing around a list of types, while for selects it was setting them before the first row scan. Far preferable would be to calculate them in earlier FDW hooks.

To enable an improved pattern, add `tupdesc` and `attr_nums` to `ch_query`. These fields allow any context that processes `ch_query` objects to access the tuple description and attribute numbers (select columns, insert columns, etc.). Extend the `new_query()` macro to take these arguments to construct a new `ch_query`.

Set these fields in `clickhouseIterateForeignScan()`, then use them in `ch_binary_prepare_insert()` to calculate the Postgres data types for inserted columns. This allows the ugly tracking of column types via the `target_oids` argument (via the `FdwModifyPrivateTargetAttOids` list item) to be removed.

Set the fields in `clickhouseIterateForeignScan()`, as well, then use them in `ch_binary_read_state_init()` to initialize `coltypes` for a select statement, and remove the conditional in `ch_binary_read_row()` that set them before the first row scan.

In passing, use `fsstate->tupdesc` to get the TupleDesc in `clickhouseIterateForeignScan`, rather than perform the same conditionals that were used to set it.