### PR TITLE
Security: revoke PUBLIC execute on clickhouse_raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.2.1] — Unreleased
+## [v0.3.0] — Unreleased
+
+This release makes binary-compatible changes to the v0.2 releases. Once
+installed, any existing use of pg_clickhouse v0.2 will benefit from its
+improvements on reload. The only change that requires an upgrade revokes
+`EXECUTE` from `clickhouse_raw_query()`. We recommend running this command
+make this security-sensitive change:
+
+```sql
+ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
+```
 
 ### ⚡ Improvements
 
@@ -50,7 +60,17 @@ All notable changes to this project will be documented in this file. It uses the
 *   Added the [ca-certificates package] and the [re2 extension] to the OCI
     (née Docker) images.
 
-  [v0.2.1]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.2.0...v0.2.1
+### 🚨 Security Fixes
+
+*   Added SQL to revoke `EXECUTE` permission on `clickhouse_raw_query()` from
+    `PUBLIC`. Leaving it executable by `PUBLIC` would allow any database user
+    to reach internal services (metadata endpoints, private APIs, etc.) from
+    the PostgreSQL server — a classic SSRF vector. This ensures that admins
+    can limit access only those who legitimately need to execute ad-hoc
+    ClickHouse queries (e.g., a dedicated ClickHouse admin role). Thanks to
+    Andrey Borodin for the PR ([#228]).
+
+  [v0.3.0]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.2.0...v0.3.0
   [ca-certificates package]: https://packages.debian.org/source/trixie/ca-certificates
     "Debian Packages: Common CA certificates"
   [re2 extension]: https://github.com/ClickHouse/pg_re2
@@ -69,6 +89,10 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#235 Detect TSV NULL marker before unescaping"
   [#231]: https://github.com/ClickHouse/pg_clickhouse/pull/231
     "ClickHouse/pg_clickhouse#231 Fix column_name option not being respected by inserts"
+  [#223]: https://github.com/ClickHouse/pg_clickhouse/pull/223
+    "pg_clickhouse#223 Fix EXPLAIN (VERBOSE) for window functions"
+  [#228]: https://github.com/ClickHouse/pg_clickhouse/pull/228
+    "pg_clickhouse#228 Security: revoke PUBLIC execute on clickhouse_raw_query"
 
 ## [v0.2.0] — 2026-04-13
 

--- a/META.json
+++ b/META.json
@@ -27,7 +27,7 @@
       "abstract": "Interfaces to query ClickHouse databases from Postgres",
       "docfile": "doc/pg_clickhouse.md",
       "file": "pg_clickhouse.control",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   },
   "resources": {
@@ -49,5 +49,5 @@
     "pushdown",
     "aggregate"
   ],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1,4 +1,4 @@
-pg_clickhouse 0.2.0
+pg_clickhouse 0.3.0
 ===================
 
 ## Synopsis
@@ -1005,6 +1005,14 @@ parameters are:
 *   `username`: The username to connect as; defaults to `default`
 *   `password`: The password to use to authenticate; defaults to no password
 
+By default, no role has `EXECUTE` access to this function; consider [GRANT]ing
+access only to roles that legitimately need to execute ad-hoc ClickHouse
+queries, e.g., a dedicated ClickHouse admin role:
+
+```sql
+GRANT EXECUTE ON FUNCTION clickhouse_raw_query(text, text) TO ch_admin;
+```
+
 Useful for queries that return no records, but queries that do return values
 will be returned as a single text value:
 
@@ -1407,6 +1415,8 @@ Copyright (c) 2025-2026, ClickHouse.
     "ClickHouse/ClickHouse#85570 fix HTTP with multipart"
   [BYTEA]: https://www.postgresql.org/docs/current/datatype-binary.html
     "PostgreSQL Docs: Binary Data Types"
+  [GRANT]: https://www.postgresql.org/docs/current/sql-grant.html
+    "PostgreSQL Docs: GRANT"
   [String]: https://clickhouse.com/docs/sql-reference/data-types/string
     "ClickHouse Docs: String"
   [TEXT]: https://www.postgresql.org/docs/current/datatype-character.html

--- a/sql/pg_clickhouse--0.2--0.3 sql
+++ b/sql/pg_clickhouse--0.2--0.3 sql
@@ -1,0 +1,1 @@
+REVOKE EXECUTE ON FUNCTION clickhouse_raw_query(text, text) FROM PUBLIC;

--- a/sql/pg_clickhouse.sql
+++ b/sql/pg_clickhouse.sql
@@ -17,6 +17,10 @@ RETURNS TEXT
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
+-- Make sure PUBLIC can't call clickhouse_raw_query(); roles must be granted
+-- explicit access.
+REVOKE EXECUTE ON FUNCTION clickhouse_raw_query(text, text) FROM PUBLIC;
+
 CREATE FUNCTION clickhouse_fdw_validator(text[], oid)
 RETURNS VOID
 AS 'MODULE_PATHNAME'


### PR DESCRIPTION
`clickhouse_raw_query(sql, connstring)` lets the caller specify an arbitrary host in the connection string. With the function executable by `PUBLIC` any database user could reach internal services such as cloud metadata endpoints (`169.254.169.254`), private APIs, or other hosts on the server network directly from the PostgreSQL process (SSRF).

Revoke `PUBLIC` execute. Administrators who need ad-hoc raw access should grant the function explicitly to a trusted role.

Increment version to v0.3.0 and add an upgrade script that revokes the permission for existing installations. Document the need to `GRANT` permission to the function and record details in `CHANGELOG.md`, including upgrading to 0.3.

Patch by Andrey Borodin, with documentation and upgrade scripting by David E. Wheeler.

Replaces #228.