### PR TITLE
Push down compatible to_char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     ClickHouse 24.10 or later).
 *   Added support for ClickHouse `JSON` mapped to Postgres `json`, supporting
     all the same operators and functions as the `jsonb` mapping.
+*   Added pushdown for `to_char(timestamp[tz], fmt)` to ClickHouse
+    `formatDateTime()`, with strict format-string validation.  Only
+    pushes down when the format is a constant whose every keyword has an
+    identical CH equivalent (`YYYY`, `MM`, `DD`, `DDD`, `HH24`, `HH12`, `HH`,
+    `MI`, `SS`, `Q`, `Mon`, `Dy`, `AM`/`PM`, plus lowercase variants).
+    Thanks to Philip Dubé for the PR ([#244]).
 
 ### 🐞 Bug Fixes
 
@@ -99,6 +105,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     "ClickHouse/pg_clickhouse#235 Detect TSV NULL marker before unescaping"
   [#231]: https://github.com/ClickHouse/pg_clickhouse/pull/231
     "ClickHouse/pg_clickhouse#231 Fix column_name option not being respected by inserts"
+  [#244]: https://github.com/ClickHouse/pg_clickhouse/pull/244
+    "ClickHouse/pg_clickhouse#244 Push down compatible to_char"
   [#223]: https://github.com/ClickHouse/pg_clickhouse/pull/223
     "pg_clickhouse#223 Fix EXPLAIN (VERBOSE) for window functions"
   [#228]: https://github.com/ClickHouse/pg_clickhouse/pull/228

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1087,6 +1087,11 @@ maps the following functions:
 *   `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
+*   `to_char(timestamp[tz], fmt)`: [formatDateTime](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime)
+    when `fmt` is a string constant whose every keyword has a faithful
+    ClickHouse equivalent. See [to_char()](#to_char) under Compatibility
+    Notes for the supported keywords. Otherwise the function evaluates
+    locally in PostgreSQL.
 *   `statement_timestamp`, `transaction_timestamp`, & `clock_timestamp`:
     [nowInBlock64](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#nowInBlock64)
     (`nowInBlock64(9, $session_timezone)`)
@@ -1323,6 +1328,45 @@ Postgres regular expression from pushing down to ClickHouse, and using the
 [re2 extension], for which pg_clickhouse supports [direct pushdown](#re2)
 of ClickHouse-compatible [RE2] regular expressions.
 
+### to_char()
+
+PostgreSQL [`to_char()`] for `timestamp` and `timestamp with time zone`
+pushes down to ClickHouse [formatDateTime] only when the format argument
+is a non-NULL string constant whose every PostgreSQL keyword has a
+byte-for-byte identical ClickHouse equivalent. If the format is dynamic
+(not a `Const`), or contains any unsupported keyword or modifier, the
+call falls back to local evaluation in PostgreSQL — pushdown is never
+attempted with a partial translation, so output stays PG-compatible.
+
+Two-argument `to_char()` forms over `numeric`, `interval`, and other
+non-timestamp types never push down; ClickHouse [formatDateTime] only
+formats date-time values.
+
+#### Translated keywords
+
+| PostgreSQL | ClickHouse | Meaning |
+| ---------- | ---------- | ------- |
+| `YYYY`, `yyyy` | `%Y` | 4-digit year |
+| `YY`, `yy` | `%y` | 2-digit year |
+| `MM`, `mm` | `%m` | zero-padded month (01–12) |
+| `DD`, `dd` | `%d` | zero-padded day of month (01–31) |
+| `DDD`, `ddd` | `%j` | zero-padded day of year (001–366) |
+| `HH24`, `hh24` | `%H` | zero-padded 24-hour (00–23) |
+| `HH`, `hh`, `HH12`, `hh12` | `%I` | zero-padded 12-hour (01–12) |
+| `MI`, `mi` | `%i` | zero-padded minute (00–59) |
+| `SS`, `ss` | `%S` | zero-padded second (00–59) |
+| `Q`, `q` | `%Q` | quarter (1–4) |
+| `Mon` | `%b` | abbreviated month name, e.g., `Oct` |
+| `Dy` | `%a` | abbreviated weekday name, e.g., `Mon` |
+| `AM`, `PM` | `%p` | meridiem indicator, always uppercase |
+
+#### Quoted text and literals
+
+Text wrapped in `"..."` passes through verbatim, with any literal `%`
+doubled to `%%` to escape ClickHouse's specifier prefix. A `\"` outside
+quotes also passes through as a literal `"`. Inside `"..."`, backslash
+only escapes `"`; other backslash sequences are treated as literal text.
+
 ## Authors
 
 *   [David E. Wheeler](https://justatheory.com/)
@@ -1433,3 +1477,7 @@ Copyright (c) 2025-2026, ClickHouse.
     "PostgreSQL Docs: intarray"
   [fuzzystrmatch]: https://www.postgresql.org/docs/current/fuzzystrmatch.html
     "PostgreSQL Docs: fuzzystrmatch"
+  [`to_char()`]: https://www.postgresql.org/docs/current/functions-formatting.html
+    "PostgreSQL Docs: Data Type Formatting Functions"
+  [formatDateTime]: https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime
+    "ClickHouse Docs: formatDateTime"

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -62,6 +62,8 @@
 #define F_ARRAY_FILL_ANYELEMENT__INT4 F_ARRAY_FILL
 #define F_ARRAY_FILL_ANYELEMENT__INT4__INT4 F_ARRAY_FILL_WITH_LOWER_BOUNDS
 #define F_CARDINALITY F_ARRAY_CARDINALITY
+#define F_TO_CHAR_TIMESTAMP_TEXT 2049
+#define F_TO_CHAR_TIMESTAMPTZ_TEXT 1770
 #endif
 /* regexp_like was added in Postgres 15 */
 #if PG_VERSION_NUM < 150000
@@ -269,6 +271,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_MD5_BYTEA:
 			case F_MD5_TEXT:
 			case F_TO_TIMESTAMP_FLOAT8:
+			case F_TO_CHAR_TIMESTAMP_TEXT:
+			case F_TO_CHAR_TIMESTAMPTZ_TEXT:
 			case F_JSONB_EXTRACT_PATH:
 			case F_JSONB_EXTRACT_PATH_TEXT:
 			case F_JSON_EXTRACT_PATH:
@@ -418,6 +422,13 @@ chfdw_check_for_custom_function(Oid funcid)
 					 */
 					strcpy(entry->custom_name, "fromUnixTimestamp(toInt64");
 					entry->paren_count = 2;
+					break;
+				}
+			case F_TO_CHAR_TIMESTAMP_TEXT:
+			case F_TO_CHAR_TIMESTAMPTZ_TEXT:
+				{
+					entry->cf_type = CF_TO_CHAR;
+					strcpy(entry->custom_name, "formatDateTime");
 					break;
 				}
 			case F_JSONB_EXTRACT_PATH_TEXT:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2547,6 +2547,172 @@ appendRegex(List * args, deparse_expr_cxt * context)
 }
 
 /*
+ * Map a Postgres `to_char()` template into a ClickHouse `formatDateTime()`
+ * template.  Only translates keywords whose CH equivalent matches PG output
+ * byte-for-byte across supported CH versions.  Any keyword PG recognizes but
+ * which cannot translate exactly (case-following names, blank-padded names,
+ * ordinal postfix, fill-mode prefixes, fractional seconds, ISO week, etc.)
+ * causes refusal.  Outside `"..."` quoted text, an uppercase or lowercase
+ * letter PG would bind to one of its date keywords also refuses,
+ * so a stray `Y` cannot silently survive as a literal.
+ *
+ * See PG `DCH_keywords` in `src/backend/utils/adt/formatting.c` for the
+ * full PG token grammar.
+ */
+typedef struct
+{
+	const char *pg;
+	const char *ch;				/* NULL → recognized keyword we refuse */
+}			ToCharTok;
+
+static const ToCharTok to_char_toks[] = {
+	{"Y,YYY", NULL}, {"y,yyy", NULL},
+	{"SSSSS", NULL}, {"sssss", NULL},
+	{"MONTH", NULL}, {"Month", NULL}, {"month", NULL},
+	{"YYYY", "%Y"}, {"yyyy", "%Y"},
+	{"HH24", "%H"}, {"hh24", "%H"},
+	{"HH12", "%I"}, {"hh12", "%I"},
+	{"IYYY", NULL}, {"iyyy", NULL},
+	{"IDDD", NULL}, {"iddd", NULL},
+	{"SSSS", NULL}, {"ssss", NULL},
+	{"A.D.", NULL}, {"a.d.", NULL},
+	{"B.C.", NULL}, {"b.c.", NULL},
+	{"P.M.", NULL}, {"p.m.", NULL},
+	{"A.M.", NULL}, {"a.m.", NULL},
+	{"YYY", NULL}, {"yyy", NULL},
+	{"DDD", "%j"}, {"ddd", "%j"},
+	{"DAY", NULL}, {"day", NULL}, {"Day", NULL},
+	{"Mon", "%b"},
+	{"MON", NULL}, {"mon", NULL},
+	{"IYY", NULL}, {"iyy", NULL},
+	{"FF1", NULL}, {"FF2", NULL}, {"FF3", NULL},
+	{"FF4", NULL}, {"FF5", NULL}, {"FF6", NULL},
+	{"ff1", NULL}, {"ff2", NULL}, {"ff3", NULL},
+	{"ff4", NULL}, {"ff5", NULL}, {"ff6", NULL},
+	{"TZH", NULL}, {"tzh", NULL},
+	{"TZM", NULL}, {"tzm", NULL},
+	{"AD", NULL}, {"ad", NULL},
+	{"AM", "%p"}, {"PM", "%p"},
+	{"am", NULL}, {"pm", NULL},
+	{"BC", NULL}, {"bc", NULL},
+	{"CC", NULL}, {"cc", NULL},
+	{"DD", "%d"}, {"dd", "%d"},
+	{"Dy", "%a"},
+	{"DY", NULL}, {"dy", NULL},
+	{"FM", NULL}, {"fm", NULL},
+	{"FX", NULL}, {"fx", NULL},
+	{"HH", "%I"}, {"hh", "%I"},
+	{"ID", NULL}, {"id", NULL},
+	{"IW", NULL}, {"iw", NULL},
+	{"IY", NULL}, {"iy", NULL},
+	{"MI", "%i"}, {"mi", "%i"},
+	{"MM", "%m"}, {"mm", "%m"},
+	{"MS", NULL}, {"ms", NULL},
+	{"OF", NULL}, {"of", NULL},
+	{"RM", NULL}, {"rm", NULL},
+	{"SS", "%S"}, {"ss", "%S"},
+	{"TM", NULL}, {"tm", NULL},
+	{"TZ", NULL}, {"tz", NULL},
+	{"US", NULL}, {"us", NULL},
+	{"WW", NULL}, {"ww", NULL},
+	{"YY", "%y"}, {"yy", "%y"},
+	{"D", NULL}, {"d", NULL},
+	{"I", NULL}, {"i", NULL},
+	{"J", NULL}, {"j", NULL},
+	{"Q", "%Q"}, {"q", "%Q"},
+	{"W", NULL}, {"w", NULL},
+	{"Y", NULL}, {"y", NULL},
+	{NULL, NULL}
+};
+
+bool
+chfdw_translate_to_char_format(const char *pgfmt, StringInfo out)
+{
+	const char *p = pgfmt;
+	bool		just_keyword = false;
+
+	while (*p)
+	{
+		const		ToCharTok *t;
+		bool		matched = false;
+
+		/*
+		 * Ordinal postfix (TH/th) attaches to a preceding numeric keyword; CH
+		 * has no ordinal output, so refuse rather than diverge.
+		 */
+		if (just_keyword
+			&& (p[0] == 'T' || p[0] == 't')
+			&& (p[1] == 'H' || p[1] == 'h'))
+			return false;
+		just_keyword = false;
+
+		/* Quoted literal: pass inner chars through, doubling % for CH. */
+		if (*p == '"')
+		{
+			p++;
+			while (*p)
+			{
+				if (*p == '\\' && p[1])
+					p++;
+				else if (*p == '"')
+				{
+					p++;
+					break;
+				}
+				if (out)
+				{
+					if (*p == '%')
+						appendStringInfoString(out, "%%");
+					else
+						appendStringInfoChar(out, *p);
+				}
+				p++;
+			}
+			continue;
+		}
+
+		/* Outside quotes, backslash escapes only a literal " */
+		if (p[0] == '\\' && p[1] == '"')
+		{
+			if (out)
+				appendStringInfoChar(out, '"');
+			p += 2;
+			continue;
+		}
+
+		for (t = to_char_toks; t->pg; t++)
+		{
+			size_t		l = strlen(t->pg);
+
+			if (strncmp(p, t->pg, l) == 0)
+			{
+				if (!t->ch)
+					return false;
+				if (out)
+					appendStringInfoString(out, t->ch);
+				p += l;
+				just_keyword = true;
+				matched = true;
+				break;
+			}
+		}
+		if (matched)
+			continue;
+
+		if (out)
+		{
+			if (*p == '%')
+				appendStringInfoString(out, "%%");
+			else
+				appendStringInfoChar(out, *p);
+		}
+		p++;
+	}
+
+	return true;
+}
+
+/*
  * Deparse a function call.
  */
 static void
@@ -2861,6 +3027,33 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 				deparseExpr((Expr *) linitial(node->args), context);
 				appendStringInfoChar(buf, ')');
 				return;
+			case CF_TO_CHAR:
+				{
+					/*
+					 * formatDateTime(ts, '<translated fmt>'). Shippability
+					 * already validated the format string is a non-NULL Const
+					 * whose tokens all translate; redoing the translation
+					 * here is just to materialize the result for SQL-literal
+					 * quoting.
+					 */
+					Const	   *fmt_const = (Const *) list_nth(node->args, 1);
+					char	   *pgfmt = TextDatumGetCString(fmt_const->constvalue);
+					StringInfoData chfmt;
+
+					initStringInfo(&chfmt);
+					if (!chfdw_translate_to_char_format(pgfmt, &chfmt))
+						elog(ERROR, "to_char format unexpectedly rejected during deparse: %s", pgfmt);
+
+					appendStringInfoChar(buf, '(');
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+					deparseStringLiteral(buf, chfmt.data);
+					appendStringInfoChar(buf, ')');
+
+					pfree(chfmt.data);
+					pfree(pgfmt);
+					return;
+				}
 			default:
 				break;
 		}

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -334,6 +334,9 @@ typedef enum
 	CF_ARRAY_CONTAINS,			/* @> → hasAll(left, right) */
 	CF_ARRAY_CONTAINED_BY,		/* <@ → hasAll(right, left) */
 	CF_ARRAY_OVERLAP,			/* && → hasAny(left, right) */
+	CF_TO_CHAR,					/* to_char(timestamp[tz], fmt) →
+								 * formatDateTime, with strict format
+								 * translation */
 }			custom_object_type;
 
 typedef enum
@@ -379,6 +382,15 @@ extern Datum ch_time_out(PG_FUNCTION_ARGS);
 extern bool chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * fpinfo,
 							   CustomObjectDef * *outcdef);
 extern double time_diff(struct timeval *prior, struct timeval *latter);
+
+/*
+ * Translate a Postgres `to_char()` template into a ClickHouse
+ * `formatDateTime()` template.  Returns true on success, with the
+ * translation appended to `out` (caller-owned, may be NULL to validate
+ * only).  Returns false on any unsupported PG keyword or modifier;
+ * when used to gate pushdown, false means caller must evaluate locally.
+ */
+extern bool chfdw_translate_to_char_format(const char *pgfmt, StringInfo out);
 
 /* compat */
 #if PG_VERSION_NUM < 120000

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -255,6 +255,27 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 							return false;
 					}
 					break;
+				case CF_TO_CHAR:
+					{
+						/* format must be a constant with exact CH translation */
+						Expr	   *fmt = (Expr *) list_nth(((FuncExpr *) node)->args, 1);
+						Const	   *fmt_const;
+						char	   *pgfmt;
+						bool		ok;
+
+						if (!IsA(fmt, Const))
+							return false;
+						fmt_const = (Const *) fmt;
+						if (fmt_const->constisnull)
+							return false;
+
+						pgfmt = TextDatumGetCString(fmt_const->constvalue);
+						ok = chfdw_translate_to_char_format(pgfmt, NULL);
+						pfree(pgfmt);
+						if (!ok)
+							return false;
+					}
+					break;
 				case CF_MATCH:
 				case CF_SPLIT_BY_REGEX:
 				case CF_REPLACE_REGEX:

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1769,6 +1769,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1769,6 +1769,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1757,6 +1757,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1757,6 +1757,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1757,6 +1757,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1750,6 +1750,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1746,6 +1746,136 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 (4 rows)
 
 DROP EXTENSION fuzzystrmatch;
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YYYY-MM-DD HH24:MI:SS'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%Y-%m-%d %H:%i:%S') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+       to_char       
+---------------------
+ 2025-10-15 13:12:25
+ 2026-11-17 00:13:26
+ 2027-12-17 14:14:27
+ 2028-01-18 15:15:28
+ 2029-02-18 17:16:29
+ 2030-03-19 19:16:30
+(6 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, '%y/%m/%d %I:%i %p %Q %j %b %a') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+             to_char             
+---------------------------------
+ 25/10/15 01:12 PM 4 288 Oct Wed
+ 26/11/17 12:13 AM 4 321 Nov Tue
+ 27/12/17 02:14 PM 4 351 Dec Fri
+ 28/01/18 03:15 PM 1 018 Jan Tue
+ 29/02/18 05:16 PM 1 049 Feb Sun
+ 30/03/19 07:16 PM 1 078 Mar Tue
+(6 rows)
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: to_char(ts, '"Year=" YYYY "%"'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5 ORDER BY formatDateTime(ts, 'Year= %Y %%') ASC NULLS LAST
+(3 rows)
+
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+   to_char    
+--------------
+ Year= 2025 %
+ Year= 2026 %
+ Year= 2027 %
+ Year= 2028 %
+ Year= 2029 %
+ Year= 2030 %
+(6 rows)
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Month'::text) = 'October   '::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'Y'::text) = '5'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'DDTH'::text) = '15TH'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'FMMM'::text) = '10'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Foreign Scan on public.t5
+   Output: ts
+   Filter: (to_char(t5.ts, 'HH12 am'::text) = '08 pm'::text)
+   Remote SQL: SELECT ts FROM functions_test.t5
+(4 rows)
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: to_char(t5.ts, t4.val)
+   Relations: (t5) INNER JOIN (t4)
+   Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -488,6 +488,42 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
 
 DROP EXTENSION fuzzystrmatch;
 
+-- to_char: pushdown of formats whose every keyword has a faithful
+-- formatDateTime equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') FROM t5 ORDER BY 1;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+SELECT to_char(ts, 'YY/MM/DD HH12:MI AM Q DDD Mon Dy') FROM t5 ORDER BY 1;
+
+-- Quoted literal text and a literal % round-trip via formatDateTime escaping.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+SELECT to_char(ts, '"Year=" YYYY "%"') FROM t5 ORDER BY 1;
+
+-- to_char: refusal cases evaluate locally rather than pushing wrong output.
+-- Padded month name (Month) -- CH formatDateTime cannot blank-pad.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Month') = 'October   ';
+-- Single-digit year token (Y) -- CH has no equivalent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'Y') = '5';
+-- Ordinal suffix (TH) -- CH has no ordinal output.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'DDTH') = '15TH';
+-- FM modifier suppresses padding -- CH always pads.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'FMMM') = '10';
+-- Lowercase am/pm -- CH %p is always uppercase.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
+
+-- Dynamic format -- not a Const, so cannot be validated.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;


### PR DESCRIPTION
Translates PG to_char(timestamp[tz], fmt) to CH formatDateTime when fmt is a constant whose every keyword has CH equivalent: YYYY/YY, MM, DD, DDD, HH24, HH12/HH, MI, SS, Q, Mon, Dy, AM/PM, plus lowercase variants