### PR TITLE
Don't push down functions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     ClickHouse equivalents (e.g., `re2match` → `match`, `re2extractall` →
     `extractAll`). Thanks to Philip Dubé for the PR ([#204]).
 *   Added pushdown for [fuzzystrmatch] functions `soundex()` and
-    `levenshtein()` (2-arg, mapped to `editDistance`).  Thanks to
+    `levenshtein()` (2-arg, mapped to `editDistanceUTF8`). Thanks to
     Philip Dubé for the PR ([#210]).
 *   Added mapping for `JSON` => `jsonb` to the binary driver (requires
     ClickHouse 24.10 or later).
@@ -37,6 +37,12 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     identical CH equivalent (`YYYY`, `MM`, `DD`, `DDD`, `HH24`, `HH12`, `HH`,
     `MI`, `SS`, `Q`, `Mon`, `Dy`, `AM`/`PM`, plus lowercase variants).
     Thanks to Philip Dubé for the PR ([#244]).
+*   Made builtin function pushdown opt-in: Postgres builtins now ship to
+    ClickHouse only when explicitly mapped, so name or signature differences
+    cannot silently alter results. Thanks to Philip Dubé for the PR ([#245]).
+*   Added explicit mappings for `mod`, `pow`/`power`, `bit_count(bytea)`, and
+    `reverse(text)` (→ `reverseUTF8`) to retain previously working pushdowns.
+    Thanks to Philip Dubé for the PR ([#245]).
 
 ### 🐞 Bug Fixes
 
@@ -53,6 +59,14 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     `INSERT`, which caused the binary engine to fail to match ClickHouse block
     columns and the HTTP engine to deparse PostgreSQL attribute names. Thanks
     to Philip Dubé for the PR ([#231]).
+*   Fixed `length(text)` and `strpos(text, text)` pushdown to map to
+    `lengthUTF8` and `positionUTF8` rather than ClickHouse's byte-counting
+    `length` and `position`, matching Postgres character semantics. Thanks to
+    Philip Dubé for the PR ([#245]).
+*   Stopped pushing down `asin`, `acos`, `atanh`, and `acosh`: Postgres raises
+    an error on out-of-range input where ClickHouse returns `NaN`. Evaluating
+    locally preserves Postgres semantics. Thanks to Philip Dubé for the PR
+    ([#245]).
 
 ### 📚 Documentation
 
@@ -113,6 +127,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     "Wikipedia: Server-side request forgery"
   [#228]: https://github.com/ClickHouse/pg_clickhouse/pull/228
     "pg_clickhouse#228 Security: revoke PUBLIC execute on clickhouse_raw_query"
+  [#245]: https://github.com/ClickHouse/pg_clickhouse/pull/245
+    "ClickHouse/pg_clickhouse#245 Don't push down functions by default"
 
 ## [v0.2.0] — 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.3.0] — Unreleased
+## [v0.3.0] — 2026-05-11
 
 This release makes binary-compatible changes to the v0.2 releases. Once
 installed, any existing use of pg_clickhouse v0.2 will benefit from its
@@ -41,8 +41,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
 ### 🐞 Bug Fixes
 
 *   Fixed `EXPLAIN (VERBOSE)` failing with "could not find window clause for
-    winref N" when window functions are pushed down to ClickHouse. Thanks to
-    Philip Dubé for the PR ([#223]).
+    winref N" when window functions push down to ClickHouse. Thanks to Philip
+    Dubé for the PR ([#223]).
 *   Fixed the parsing of strings that start with `[` in the http driver so
     that it no longer assumes it's the start of an array. Thanks to Kaushik
     Iska for the PR ([#234]).
@@ -56,13 +56,13 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
 
 ### 📚 Documentation
 
-*   Added "Extensions Pushdown" section to the [reference
+*   Added "Extension Pushdown" section to the [reference
     docs](doc/pg_clickhouse.md), covering re2, intarray, and fuzzystrmatch
     support.
 *   Added recommendation to the [reference docs](doc/pg_clickhouse.md) to
     consider using the [re2 extension] and disabling Postgres regular
     expression pushdown.
-*   Documented the `column_name` foreign-table column option in the [reference
+*   Documented the `column_name` foreign table column option in the [reference
     docs](doc/pg_clickhouse.md).
 *   Added `jsonb_extract_path_text()` and `jsonb_extract_path()` to the list
     of push down functions in the [reference docs](doc/pg_clickhouse.md),
@@ -81,8 +81,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
 *   Added SQL to revoke `EXECUTE` permission on `clickhouse_raw_query()` from
     `PUBLIC`. Leaving it executable by `PUBLIC` would allow any database user
     to reach internal services (metadata endpoints, private APIs, etc.) from
-    the PostgreSQL server — a classic SSRF vector. This ensures that admins
-    can limit access only those who legitimately need to execute ad-hoc
+    the PostgreSQL server — a classic [SSRF] vector. This ensures that admins
+    can limit access only to those who legitimately need to execute ad-hoc
     ClickHouse queries (e.g., a dedicated ClickHouse admin role). Thanks to
     Andrey Borodin for the PR ([#228]).
 
@@ -109,6 +109,8 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     "ClickHouse/pg_clickhouse#244 Push down compatible to_char"
   [#223]: https://github.com/ClickHouse/pg_clickhouse/pull/223
     "pg_clickhouse#223 Fix EXPLAIN (VERBOSE) for window functions"
+  [SSRF]: https://en.wikipedia.org/wiki/Server-side_request_forgery
+    "Wikipedia: Server-side request forgery"
   [#228]: https://github.com/ClickHouse/pg_clickhouse/pull/228
     "pg_clickhouse#228 Security: revoke PUBLIC execute on clickhouse_raw_query"
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1033,12 +1033,19 @@ SELECT clickhouse_raw_query(
 
 ### Pushdown Functions
 
-All PostgreSQL builtin functions used in conditionals (`HAVING` and `WHERE`
-clauses) to query ClickHouse foreign tables automatically push down to
-ClickHouse with the same names and signatures. However, some have different
-names or signatures and must be mapped to their equivalents. `pg_clickhouse`
-maps the following functions:
+`pg_clickhouse` pushes down a subset of the PostgreSQL builtin functions used
+in conditionals (`HAVING` and `WHERE` clauses). That subset maps to ClickHouse
+equivalents as follows:
 
+*   `abs`: [abs](https://clickhouse.com/docs/sql-reference/functions/arithmetic-functions#abs)
+*   `factorial`: [factorial](https://clickhouse.com/docs/sql-reference/functions/math-functions#factorial)
+*   `mod` (int2/int4/int8/numeric): [modulo](https://clickhouse.com/docs/sql-reference/functions/arithmetic-functions#modulo)
+*   `pow` & `power` (float8/numeric): [pow](https://clickhouse.com/docs/sql-reference/functions/math-functions#pow)
+*   `round`: [round](https://clickhouse.com/docs/sql-reference/functions/rounding-functions#round)
+*   `sin`, `cos`, `tan`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`,
+    `degrees`, `radians`, `pi`: [ClickHouse math functions](https://clickhouse.com/docs/sql-reference/functions/math-functions)
+    of the same name. `asin`, `acos`, `atanh`, `acosh` are not pushed
+    down: PG raises on out-of-range input where CH returns `NaN`.
 *   `date_part`:
     *   `date_part('day')`: [toDayOfMonth](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toDayOfMonth)
     *   `date_part('doy')`: [toDayOfYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toDayOfYear)
@@ -1061,6 +1068,9 @@ maps the following functions:
     *   `date_trunc('month')`: [toStartOfMonth](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfMonth)
     *   `date_trunc('quarter')`: [toStartOfQuarter](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfQuarter)
     *   `date_trunc('year')`: [toStartOfYear](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#toStartOfYear)
+*   `extract(field FROM source)`: same mappings as `date_part`
+*   `date(timestamp)` & `date(timestamptz)`: [toDate](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toDate)
+    (deparsed as CH alias `date`)
 *   `array_position`: [indexOf](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf)
 *   `array_cat`: [arrayConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayConcat)
 *   `array_append`: [arrayPushBack](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushBack)
@@ -1077,7 +1087,18 @@ maps the following functions:
 *   `array_sample`: [arrayRandomSample](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRandomSample)
 *   `array_sort`: [arraySort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySort) / [arrayReverseSort](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayReverseSort)
 *   `btrim`: [trimBoth](https://clickhouse.com/docs/sql-reference/functions/string-functions#trimboth)
-*   `strpos`: [position](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#position)
+*   `ltrim`: [ltrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#ltrim)
+*   `rtrim`: [rtrim](https://clickhouse.com/docs/sql-reference/functions/string-functions#rtrim)
+*   `concat_ws`: [concatWithSeparator](https://clickhouse.com/docs/sql-reference/functions/string-functions#concatwithseparator)
+*   `lower(text)`: [lowerUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lowerutf8)
+*   `upper(text)`: [upperUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#upperutf8)
+*   `substring(text, ...)` & `substr(text, ...)`: [substringUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#substringutf8)
+*   `substring(bytea, ...)` & `substr(bytea, ...)`: [substring](https://clickhouse.com/docs/sql-reference/functions/string-functions#substring)
+*   `length(text)`: [lengthUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#lengthutf8)
+*   `length(bytea)` & `octet_length`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
+*   `reverse(text)`: [reverseUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverseutf8)
+*   `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverse)
+*   `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionutf8)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 *   `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
@@ -1086,6 +1107,7 @@ maps the following functions:
 *   `json_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitcount)
 *   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
 *   `to_char(timestamp[tz], fmt)`: [formatDateTime](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime)
     when `fmt` is a string constant whose every keyword has a faithful
@@ -1167,7 +1189,7 @@ One [intarray] function pushes down to ClickHouse:
 Two [fuzzystrmatch] functions push down to ClickHouse:
 
 *   `soundex`: [soundex](https://clickhouse.com/docs/sql-reference/functions/string-functions#soundex)
-*   `levenshtein` (2-arg): [editDistance](https://clickhouse.com/docs/sql-reference/functions/string-functions#editDistance)
+*   `levenshtein` (2-arg): [editDistanceUTF8](https://clickhouse.com/docs/sql-reference/functions/string-functions#editDistanceUTF8)
 
 ### Pushdown Casts
 
@@ -1191,12 +1213,16 @@ These PostgreSQL aggregate functions pushdown to ClickHouse.
 
 *   [array_agg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/grouparray)
 *   [avg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/avg)
+*   [bit_and](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitand)
+*   [bit_or](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitor)
+*   [bit_xor](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitxor)
 *   [bool_and / every](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitand)
 *   [bool_or](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitor)
 *   [count](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count)
 *   [min](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/min)
 *   [max](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/max)
 *   [string_agg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupconcat)
+*   [sum](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/sum)
 
 ### Custom Aggregates
 

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -873,7 +873,7 @@ extern "C"
 
 		/* Initialize coltypes to SELECT types, when provided. */
 		if (query->tupdesc)
-			for (size_t i = 0; i < list_length(query->attr_nums); i++)
+			for (size_t i = 0; i < (size_t)list_length(query->attr_nums); i++)
 				state->coltypes[i]
 				= TupleDescAttr(query->tupdesc, lfirst_int(list_nth_cell(query->attr_nums, i)) - 1)->atttypid;
 		else

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -64,6 +64,140 @@
 #define F_CARDINALITY F_ARRAY_CARDINALITY
 #define F_TO_CHAR_TIMESTAMP_TEXT 2049
 #define F_TO_CHAR_TIMESTAMPTZ_TEXT 1770
+/* bit_count(bytea) and bit_xor aggregates were added in Postgres 14 */
+#define F_BIT_COUNT_BYTEA 6163
+#define F_BIT_XOR_INT2 6164
+#define F_BIT_XOR_INT4 6165
+#define F_BIT_XOR_INT8 6166
+/* Window function fmgroids changed names between PG 13 and 14. */
+#define F_ROW_NUMBER F_WINDOW_ROW_NUMBER
+#define F_RANK_ F_WINDOW_RANK
+#define F_DENSE_RANK_ F_WINDOW_DENSE_RANK
+#define F_PERCENT_RANK_ F_WINDOW_PERCENT_RANK
+#define F_CUME_DIST_ F_WINDOW_CUME_DIST
+#define F_NTILE F_WINDOW_NTILE
+/* PG 14 made lag/lead default-value variants polymorphic */
+#define F_LAG_ANYCOMPATIBLE_INT4_ANYCOMPATIBLE 3108
+#define F_LEAD_ANYCOMPATIBLE_INT4_ANYCOMPATIBLE 3111
+/*
+ * PG 14 generates fmgroids from proname[_proargtypes] form. PG 13
+ * generated them from prosrc, so overloaded aggregates sharing
+ * prosrc='aggregate_dummy' produced no usable macros, and many builtins
+ * had prosrc-based names (eg F_DSIN, F_TEXT_REVERSE) that differ from
+ * the proname form used since PG 14. Define the proname-based macros by
+ * literal OID so the case labels resolve on PG 13.
+ */
+#define F_AVG_INT8 2100
+#define F_AVG_INT4 2101
+#define F_AVG_INT2 2102
+#define F_AVG_NUMERIC 2103
+#define F_AVG_FLOAT4 2104
+#define F_AVG_FLOAT8 2105
+#define F_AVG_INTERVAL 2106
+#define F_SUM_INT8 2107
+#define F_SUM_INT4 2108
+#define F_SUM_INT2 2109
+#define F_SUM_FLOAT4 2110
+#define F_SUM_FLOAT8 2111
+#define F_SUM_INTERVAL 2113
+#define F_SUM_NUMERIC 2114
+#define F_MAX_INT8 2115
+#define F_MAX_INT4 2116
+#define F_MAX_INT2 2117
+#define F_MAX_FLOAT4 2119
+#define F_MAX_FLOAT8 2120
+#define F_MAX_DATE 2122
+#define F_MAX_TIMESTAMP 2126
+#define F_MAX_TIMESTAMPTZ 2127
+#define F_MAX_INTERVAL 2128
+#define F_MAX_TEXT 2129
+#define F_MAX_NUMERIC 2130
+#define F_MIN_INT8 2131
+#define F_MIN_INT4 2132
+#define F_MIN_INT2 2133
+#define F_MIN_FLOAT4 2135
+#define F_MIN_FLOAT8 2136
+#define F_MIN_DATE 2138
+#define F_MIN_TIMESTAMP 2142
+#define F_MIN_TIMESTAMPTZ 2143
+#define F_MIN_INTERVAL 2144
+#define F_MIN_TEXT 2145
+#define F_MIN_NUMERIC 2146
+#define F_COUNT_ANY 2147
+#define F_MAX_BPCHAR 2244
+#define F_MIN_BPCHAR 2245
+#define F_BOOL_AND 2517
+#define F_BOOL_OR 2518
+#define F_EVERY 2519
+#define F_COUNT_ 2803
+#define F_STRING_AGG_TEXT_TEXT 3538
+#define F_ARRAY_AGG_ANYARRAY 4053
+#define F_SIN 1604
+#define F_COS 1605
+#define F_TAN 1606
+#define F_ATAN 1602
+#define F_ATAN2 1603
+#define F_SINH 2462
+#define F_COSH 2463
+#define F_TANH 2464
+#define F_ASINH 2465
+#define F_PI 1610
+#define F_REVERSE 3062
+#define F_MOD_INT2_INT2 940
+#define F_MOD_INT4_INT4 941
+#define F_MOD_INT8_INT8 947
+#define F_MOD_NUMERIC_NUMERIC 1728
+#define F_POW_FLOAT8_FLOAT8 1346
+#define F_POWER_FLOAT8_FLOAT8 1368
+#define F_POW_NUMERIC_NUMERIC 1738
+#define F_POWER_NUMERIC_NUMERIC 2169
+#define F_ABS_INT2 1398
+#define F_ABS_INT4 1397
+#define F_ABS_INT8 1396
+#define F_ABS_FLOAT4 1394
+#define F_ABS_FLOAT8 1395
+#define F_ABS_NUMERIC 1705
+#define F_ROUND_FLOAT8 1342
+#define F_ROUND_NUMERIC 1708
+#define F_ROUND_NUMERIC_INT4 1707
+#define F_FACTORIAL 1376
+#define F_LTRIM_TEXT 881
+#define F_RTRIM_TEXT 882
+#define F_CONCAT_WS 3059
+#define F_LENGTH_TEXT 1317
+#define F_LENGTH_BYTEA 2010
+#define F_LOWER_TEXT 870
+#define F_UPPER_TEXT 871
+#define F_SUBSTR_TEXT_INT4_INT4 877
+#define F_SUBSTR_TEXT_INT4 883
+#define F_SUBSTRING_TEXT_INT4_INT4 936
+#define F_SUBSTRING_TEXT_INT4 937
+#define F_SUBSTRING_BYTEA_INT4_INT4 2012
+#define F_SUBSTRING_BYTEA_INT4 2013
+#define F_SUBSTR_BYTEA_INT4_INT4 2085
+#define F_SUBSTR_BYTEA_INT4 2086
+#define F_LEAD_ANYELEMENT 3109
+#define F_LEAD_ANYELEMENT_INT4 3110
+#define F_LAG_ANYELEMENT 3106
+#define F_LAG_ANYELEMENT_INT4 3107
+#define F_OCTET_LENGTH_BYTEA 720
+#define F_OCTET_LENGTH_TEXT 1374
+#define F_OCTET_LENGTH_BPCHAR 1375
+#define F_BIT_AND_INT2 2236
+#define F_BIT_OR_INT2 2237
+#define F_BIT_AND_INT4 2238
+#define F_BIT_OR_INT4 2239
+#define F_BIT_AND_INT8 2240
+#define F_BIT_OR_INT8 2241
+/*
+ * PG 13 prosrc-based names mean these macros resolve to the opposite
+ * direction: date->timestamp[tz] casts (oids 2024, 1174). Redefine to the
+ * PG 14+ proname-based oids which are the timestamp[tz]->date casts.
+ */
+#undef F_DATE_TIMESTAMP
+#undef F_DATE_TIMESTAMPTZ
+#define F_DATE_TIMESTAMP 2029
+#define F_DATE_TIMESTAMPTZ 1178
 #endif
 /* regexp_like was added in Postgres 15 */
 #if PG_VERSION_NUM < 150000
@@ -75,12 +209,15 @@
 #define F_ARRAY_SHUFFLE 6215
 #define F_ARRAY_SAMPLE 6216
 #endif
-/* array_reverse, array_sort added in Postgres 18 */
+/* array_reverse, array_sort, reverse(bytea) added in Postgres 18 */
 #if PG_VERSION_NUM < 180000
 #define F_ARRAY_REVERSE 6381
 #define F_ARRAY_SORT_ANYARRAY 6388
 #define F_ARRAY_SORT_ANYARRAY_BOOL 6389
 #define F_ARRAY_SORT_ANYARRAY_BOOL_BOOL 6390
+/* before PG 18 reverse(text) was unique so macro was F_REVERSE; reverse(bytea) didn't exist */
+#define F_REVERSE_TEXT F_REVERSE
+#define F_REVERSE_BYTEA 6382
 #endif
 
 #define STR_STARTS_WITH(str, sub) strncmp(str, sub, strlen(sub)) == 0
@@ -257,6 +394,16 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_EXTRACT_TEXT_DATE:
 			case F_ARRAY_POSITION_ANYCOMPATIBLEARRAY_ANYCOMPATIBLE:
 			case F_STRPOS:
+			case F_LOWER_TEXT:
+			case F_UPPER_TEXT:
+			case F_SUBSTR_TEXT_INT4_INT4:
+			case F_SUBSTR_TEXT_INT4:
+			case F_SUBSTRING_TEXT_INT4_INT4:
+			case F_SUBSTRING_TEXT_INT4:
+			case F_SUBSTR_BYTEA_INT4_INT4:
+			case F_SUBSTR_BYTEA_INT4:
+			case F_SUBSTRING_BYTEA_INT4_INT4:
+			case F_SUBSTRING_BYTEA_INT4:
 			case F_BTRIM_TEXT_TEXT:
 			case F_BTRIM_TEXT:
 			case F_REGEXP_LIKE_TEXT_TEXT:
@@ -267,7 +414,91 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT:
 			case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
 			case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
+				/* aggregates with matching name and 1:1 semantics */
 			case F_ARRAY_AGG_ANYNONARRAY:
+			case F_ARRAY_AGG_ANYARRAY:
+			case F_AVG_INT8:
+			case F_AVG_INT4:
+			case F_AVG_INT2:
+			case F_AVG_NUMERIC:
+			case F_AVG_FLOAT4:
+			case F_AVG_FLOAT8:
+			case F_AVG_INTERVAL:
+			case F_SUM_INT8:
+			case F_SUM_INT4:
+			case F_SUM_INT2:
+			case F_SUM_FLOAT4:
+			case F_SUM_FLOAT8:
+			case F_SUM_INTERVAL:
+			case F_SUM_NUMERIC:
+			case F_COUNT_ANY:
+			case F_COUNT_:
+			case F_MIN_INT8:
+			case F_MIN_INT4:
+			case F_MIN_INT2:
+			case F_MIN_FLOAT4:
+			case F_MIN_FLOAT8:
+			case F_MIN_DATE:
+			case F_MIN_TIMESTAMP:
+			case F_MIN_TIMESTAMPTZ:
+			case F_MIN_INTERVAL:
+			case F_MIN_TEXT:
+			case F_MIN_NUMERIC:
+			case F_MIN_BPCHAR:
+			case F_MAX_INT8:
+			case F_MAX_INT4:
+			case F_MAX_INT2:
+			case F_MAX_FLOAT4:
+			case F_MAX_FLOAT8:
+			case F_MAX_DATE:
+			case F_MAX_TIMESTAMP:
+			case F_MAX_TIMESTAMPTZ:
+			case F_MAX_INTERVAL:
+			case F_MAX_TEXT:
+			case F_MAX_NUMERIC:
+			case F_MAX_BPCHAR:
+			case F_BOOL_AND:
+			case F_BOOL_OR:
+			case F_EVERY:
+			case F_STRING_AGG_TEXT_TEXT:
+				/* window functions sharing PG and CH names */
+			case F_ROW_NUMBER:
+			case F_RANK_:
+			case F_DENSE_RANK_:
+			case F_PERCENT_RANK_:
+			case F_CUME_DIST_:
+			case F_NTILE:
+
+				/*
+				 * trig: PG and CH agree on all finite inputs. Skipping
+				 * asin/acos/atanh/acosh because PG errors on out-of-range
+				 * input where CH returns NaN; sin/cos/tan share the same
+				 * error-vs-NaN divergence only at infinity.
+				 */
+			case F_SIN:
+			case F_COS:
+			case F_TAN:
+			case F_ATAN:
+			case F_ATAN2:
+			case F_SINH:
+			case F_COSH:
+			case F_TANH:
+			case F_ASINH:
+			case F_DEGREES:
+			case F_RADIANS:
+			case F_PI:
+				/* scalar 1:1 mappings */
+			case F_REVERSE_TEXT:
+			case F_REVERSE_BYTEA:
+			case F_BIT_COUNT_BYTEA:
+			case F_MOD_INT2_INT2:
+			case F_MOD_INT4_INT4:
+			case F_MOD_INT8_INT8:
+			case F_MOD_NUMERIC_NUMERIC:
+			case F_POW_FLOAT8_FLOAT8:
+			case F_POWER_FLOAT8_FLOAT8:
+			case F_POW_NUMERIC_NUMERIC:
+			case F_POWER_NUMERIC_NUMERIC:
 			case F_MD5_BYTEA:
 			case F_MD5_TEXT:
 			case F_TO_TIMESTAMP_FLOAT8:
@@ -283,6 +514,52 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_CLOCK_TIMESTAMP:
 			case F_CURRENT_SCHEMA:
 			case F_CURRENT_DATABASE:
+				/* numeric scalar functions, names match ClickHouse */
+			case F_ABS_INT2:
+			case F_ABS_INT4:
+			case F_ABS_INT8:
+			case F_ABS_FLOAT4:
+			case F_ABS_FLOAT8:
+			case F_ABS_NUMERIC:
+			case F_ROUND_FLOAT8:
+			case F_ROUND_NUMERIC:
+			case F_ROUND_NUMERIC_INT4:
+			case F_FACTORIAL:
+				/* string functions: CH ltrim/rtrim/concat_ws are aliases */
+			case F_LTRIM_TEXT:
+			case F_RTRIM_TEXT:
+			case F_CONCAT_WS:
+
+				/*
+				 * length(text) deparses to lengthUTF8 (code points);
+				 * length(bytea) keeps byte count
+				 */
+			case F_LENGTH_TEXT:
+			case F_LENGTH_BYTEA:
+				/* octet_length deparses to CH length (bytes) */
+			case F_OCTET_LENGTH_TEXT:
+			case F_OCTET_LENGTH_BPCHAR:
+			case F_OCTET_LENGTH_BYTEA:
+				/* bit_and/or/xor aggregates map to CH groupBitAnd/Or/Xor */
+			case F_BIT_AND_INT2:
+			case F_BIT_AND_INT4:
+			case F_BIT_AND_INT8:
+			case F_BIT_OR_INT2:
+			case F_BIT_OR_INT4:
+			case F_BIT_OR_INT8:
+			case F_BIT_XOR_INT2:
+			case F_BIT_XOR_INT4:
+			case F_BIT_XOR_INT8:
+				/* date(ts), date(tstz) deparse as CH date() (alias toDate) */
+			case F_DATE_TIMESTAMP:
+			case F_DATE_TIMESTAMPTZ:
+				/* window functions: lead/lag share PG and CH names */
+			case F_LEAD_ANYELEMENT:
+			case F_LEAD_ANYELEMENT_INT4:
+			case F_LEAD_ANYCOMPATIBLE_INT4_ANYCOMPATIBLE:
+			case F_LAG_ANYELEMENT:
+			case F_LAG_ANYELEMENT_INT4:
+			case F_LAG_ANYCOMPATIBLE_INT4_ANYCOMPATIBLE:
 				/* array functions: simple mappings */
 			case F_ARRAY_CAT:
 			case F_ARRAY_APPEND:
@@ -301,17 +578,6 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_TRIM_ARRAY:
 			case F_ARRAY_FILL_ANYELEMENT__INT4:
 			case F_ARRAY_SORT_ANYARRAY_BOOL:
-				/* array functions: unshippable */
-			case F_ARRAY_DIMS:
-			case F_ARRAY_NDIMS:
-			case F_ARRAY_LOWER:
-			case F_ARRAY_UPPER:
-			case F_ARRAY_REPLACE:
-			case F_ARRAY_POSITIONS:
-			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
-			case F_STRING_TO_ARRAY_TEXT_TEXT_TEXT:
-			case F_ARRAY_FILL_ANYELEMENT__INT4__INT4:
-			case F_ARRAY_SORT_ANYARRAY_BOOL_BOOL:
 				special_builtin = true;
 				break;
 			default:
@@ -371,9 +637,32 @@ chfdw_check_for_custom_function(Oid funcid)
 				}
 			case F_STRPOS:
 				{
-					strcpy(entry->custom_name, "position");
+					/* PG strpos counts code points, CH position counts bytes */
+					strcpy(entry->custom_name, "positionUTF8");
 					break;
 				}
+			case F_LOWER_TEXT:
+				/* PG lower(text) is locale-aware on code points */
+				strcpy(entry->custom_name, "lowerUTF8");
+				break;
+			case F_UPPER_TEXT:
+				/* PG upper(text) is locale-aware on code points */
+				strcpy(entry->custom_name, "upperUTF8");
+				break;
+			case F_SUBSTR_TEXT_INT4_INT4:
+			case F_SUBSTR_TEXT_INT4:
+			case F_SUBSTRING_TEXT_INT4_INT4:
+			case F_SUBSTRING_TEXT_INT4:
+				/* PG substring(text, ...) counts code points */
+				strcpy(entry->custom_name, "substringUTF8");
+				break;
+			case F_SUBSTR_BYTEA_INT4_INT4:
+			case F_SUBSTR_BYTEA_INT4:
+			case F_SUBSTRING_BYTEA_INT4_INT4:
+			case F_SUBSTRING_BYTEA_INT4:
+				/* bytea variant is byte-based; CH substring matches */
+				strcpy(entry->custom_name, "substring");
+				break;
 			case F_REGEXP_LIKE_TEXT_TEXT:
 			case F_REGEXP_LIKE_TEXT_TEXT_TEXT:
 				{
@@ -414,6 +703,54 @@ chfdw_check_for_custom_function(Oid funcid)
 					entry->paren_count = 3;
 					break;
 				}
+			case F_REVERSE_TEXT:
+				/* reverse code points, not bytes */
+				strcpy(entry->custom_name, "reverseUTF8");
+				break;
+			case F_LENGTH_TEXT:
+
+				/*
+				 * PG length(text) counts code points, CH length() counts
+				 * bytes
+				 */
+				strcpy(entry->custom_name, "lengthUTF8");
+				break;
+			case F_OCTET_LENGTH_TEXT:
+			case F_OCTET_LENGTH_BPCHAR:
+			case F_OCTET_LENGTH_BYTEA:
+				strcpy(entry->custom_name, "length");
+				break;
+			case F_BIT_AND_INT2:
+			case F_BIT_AND_INT4:
+			case F_BIT_AND_INT8:
+				strcpy(entry->custom_name, "groupBitAnd");
+				break;
+			case F_BIT_OR_INT2:
+			case F_BIT_OR_INT4:
+			case F_BIT_OR_INT8:
+				strcpy(entry->custom_name, "groupBitOr");
+				break;
+			case F_BIT_XOR_INT2:
+			case F_BIT_XOR_INT4:
+			case F_BIT_XOR_INT8:
+				strcpy(entry->custom_name, "groupBitXor");
+				break;
+			case F_BIT_COUNT_BYTEA:
+				strcpy(entry->custom_name, "bitCount");
+				break;
+			case F_MOD_INT2_INT2:
+			case F_MOD_INT4_INT4:
+			case F_MOD_INT8_INT8:
+			case F_MOD_NUMERIC_NUMERIC:
+				strcpy(entry->custom_name, "modulo");
+				break;
+			case F_POW_FLOAT8_FLOAT8:
+			case F_POWER_FLOAT8_FLOAT8:
+			case F_POW_NUMERIC_NUMERIC:
+			case F_POWER_NUMERIC_NUMERIC:
+				/* CH lacks "power", maps to pow */
+				strcpy(entry->custom_name, "pow");
+				break;
 			case F_TO_TIMESTAMP_FLOAT8:
 				{
 					/*
@@ -474,19 +811,6 @@ chfdw_check_for_custom_function(Oid funcid)
 					entry->custom_name[0] = '\1';
 					break;
 				}
-				/* array functions: unshippable */
-			case F_ARRAY_DIMS:
-			case F_ARRAY_NDIMS:
-			case F_ARRAY_LOWER:
-			case F_ARRAY_UPPER:
-			case F_ARRAY_REPLACE:
-			case F_ARRAY_POSITIONS:
-			case F_ARRAY_TO_STRING_ANYARRAY_TEXT_TEXT:
-			case F_STRING_TO_ARRAY_TEXT_TEXT_TEXT:
-			case F_ARRAY_FILL_ANYELEMENT__INT4__INT4:
-			case F_ARRAY_SORT_ANYARRAY_BOOL_BOOL:
-				entry->cf_type = CF_UNSHIPPABLE;
-				break;
 				/* array functions: simple mappings */
 			case F_ARRAY_CAT:
 				strcpy(entry->custom_name, "arrayConcat");
@@ -579,9 +903,14 @@ chfdw_check_for_custom_function(Oid funcid)
 			{
 				if (STR_EQUAL(proname, "levenshtein") &&
 					procform->pronargs == 2)
-					strcpy(entry->custom_name, "editDistance");
+					strcpy(entry->custom_name, "editDistanceUTF8");
 				else if (!(STR_EQUAL(proname, "soundex")))
-					entry->cf_type = CF_UNSHIPPABLE;
+				{
+					ReleaseSysCache(proctup);
+					pfree(extname);
+					hash_search(custom_objects_cache, (void *) &funcid, HASH_REMOVE, NULL);
+					return NULL;
+				}
 			}
 			else if (STR_EQUAL(extname, "pg_clickhouse"))
 			{

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2246,6 +2246,35 @@ deparseConst(Const * node, deparse_expr_cxt * context, int showtype)
 		deparseArray(node->constvalue, context);
 		goto cleanup;
 	}
+	else if (node->consttype == BYTEAOID)
+	{
+		/*
+		 * Emit printable ASCII as-is and \xHH for everything else. PG's
+		 * bytea_out hex format (\xHHHH...) doesn't round-trip through CH's
+		 * string lexer past a single byte: \x consumes exactly two hex digits
+		 * and any remaining hex chars become ASCII literals.
+		 */
+		bytea	   *bp = DatumGetByteaPP(node->constvalue);
+		const char *bytes = VARDATA_ANY(bp);
+		int			len = VARSIZE_ANY_EXHDR(bp);
+
+		appendStringInfoChar(buf, '\'');
+		for (int i = 0; i < len; i++)
+		{
+			unsigned char c = (unsigned char) bytes[i];
+
+			if (c == '\'')
+				appendStringInfoString(buf, "\\'");
+			else if (c == '\\')
+				appendStringInfoString(buf, "\\\\");
+			else if (c >= 0x20 && c <= 0x7E)
+				appendStringInfoChar(buf, (char) c);
+			else
+				appendStringInfo(buf, "\\x%02x", c);
+		}
+		appendStringInfoChar(buf, '\'');
+		goto cleanup;
+	}
 	else
 	{
 		extval = OidOutputFunctionCall(typoutput, node->constvalue);

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -291,7 +291,6 @@ typedef struct ConnCacheEntry
 typedef enum
 {
 	CF_USUAL = 0,
-	CF_UNSHIPPABLE,				/* do not ship */
 	CF_SIGN_SUM,				/* SUM aggregation */
 	CF_SIGN_AVG,				/* AVG aggregation */
 	CF_SIGN_COUNT,				/* COUNT aggregation */

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -218,7 +218,7 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 					/* Don't pushdown regular expressions if the GUC is false. */
 					return chfdw_pushdown_regex_ok();
 				default:
-					return (cdef->cf_type != CF_UNSHIPPABLE);
+					return true;
 			}
 		}
 	}
@@ -325,13 +325,32 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 				default:
 					break;
 			}
-			return (cdef->cf_type != CF_UNSHIPPABLE);
+			return true;
 		}
 	}
 
-	/* Built-in objects are presumed shippable. */
+	/*
+	 * Builtin operators and types ship by default. Builtin functions only
+	 * ship when explicitly registered via chfdw_check_for_custom_function, so
+	 * unrecognised builtins fail planner shippability checks rather than
+	 * deparse to a name that may behave differently on ClickHouse. Cast
+	 * coercions are an exception: deparse handles them as cast() or by
+	 * dropping the implicit wrapper, regardless of the underlying funcid.
+	 */
 	if (chfdw_is_builtin(objectId))
-		return true;
+	{
+		if (classId != ProcedureRelationId)
+			return true;
+		if (node && IsA(node, FuncExpr))
+		{
+			FuncExpr   *fe = (FuncExpr *) node;
+
+			if (fe->funcformat == COERCE_IMPLICIT_CAST ||
+				fe->funcformat == COERCE_EXPLICIT_CAST)
+				return true;
+		}
+		return false;
+	}
 
 	if (classId == ProcedureRelationId)
 	{
@@ -340,7 +359,7 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 		if (outcdef != NULL)
 			*outcdef = cdef;
 
-		return (cdef && cdef->cf_type != CF_UNSHIPPABLE);
+		return cdef != NULL;
 	}
 	else if (classId == TypeRelationId && chfdw_check_for_custom_type(objectId) != NULL)
 		return true;

--- a/test/expected/aggregates.out
+++ b/test/expected/aggregates.out
@@ -1275,11 +1275,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (3 rows)
 
 -- bool_and pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1287,11 +1289,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_or pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
@@ -1299,11 +1303,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- every pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Foreign Scan
+   Output: (every((cost > '0'::numeric)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((cost > 0)) FROM agg_test.hits
+(4 rows)
 
  every 
 -------
@@ -1311,11 +1317,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_and pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1323,23 +1331,70 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_or pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
  t
 (1 row)
 
+-- bit_and pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_and((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_and 
+---------
+     304
+(1 row)
+
+-- bit_or pushdown (binary)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_or((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_or 
+--------
+    304
+(1 row)
+
+-- bit_xor pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_xor((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_xor 
+---------
+     304
+(1 row)
+
 -- regr_slope local fallback
-         QUERY PLAN         
-----------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Aggregate
-   ->  Foreign Scan on hits
-(2 rows)
+   Output: regr_slope((cost)::double precision, (duration)::double precision)
+   ->  Foreign Scan on agg_bin.hits
+         Output: id, uuid, "timestamp", datestamp, path, duration, cost
+         Remote SQL: SELECT duration, cost FROM agg_test.hits
+(5 rows)
 
 NOTICE:  drop cascades to foreign table agg_bin.hits
 NOTICE:  drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_1.out
+++ b/test/expected/aggregates_1.out
@@ -1275,11 +1275,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (3 rows)
 
 -- bool_and pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1287,11 +1289,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_or pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
@@ -1299,11 +1303,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- every pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Foreign Scan
+   Output: (every((cost > '0'::numeric)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((cost > 0)) FROM agg_test.hits
+(4 rows)
 
  every 
 -------
@@ -1311,11 +1317,13 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_and pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1323,23 +1331,70 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
 (1 row)
 
 -- bool_or pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
  t
 (1 row)
 
+-- bit_and pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_and((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_and 
+---------
+     304
+(1 row)
+
+-- bit_or pushdown (binary)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_or((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_or 
+--------
+    304
+(1 row)
+
+-- bit_xor pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_xor((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_xor 
+---------
+     304
+(1 row)
+
 -- regr_slope local fallback
-         QUERY PLAN         
-----------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Aggregate
-   ->  Foreign Scan on hits
-(2 rows)
+   Output: regr_slope((cost)::double precision, (duration)::double precision)
+   ->  Foreign Scan on agg_bin.hits
+         Output: id, uuid, "timestamp", datestamp, path, duration, cost
+         Remote SQL: SELECT duration, cost FROM agg_test.hits
+(5 rows)
 
 NOTICE:  drop cascades to foreign table agg_bin.hits
 NOTICE:  drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_2.out
+++ b/test/expected/aggregates_2.out
@@ -1220,8 +1220,11 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
    Remote SQL: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT groupConcat('|')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. Maybe you meant: ['mapConcat','arrayConcat']
-DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
+                                   string_agg                                    
+---------------------------------------------------------------------------------
+ /users/283434|/users/802683|/search|/users/283434|/users/7392323|/users/7392323
+(1 row)
+
 -- string_agg pushdown (http)
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
@@ -1231,9 +1234,11 @@ DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((
    Remote SQL: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: Code: 46. DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT groupConcat('')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. Maybe you meant: ['mapConcat','arrayConcat']. (UNKNOWN_FUNCTION)
-DETAIL:  Remote Query: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
-CONTEXT:  HTTP status code: 404
+                                 string_agg                                 
+----------------------------------------------------------------------------
+ /users/283434/users/802683/search/users/283434/users/7392323/users/7392323
+(1 row)
+
 -- string_agg DISTINCT pushdown (binary)
                                                  QUERY PLAN                                                  
 -------------------------------------------------------------------------------------------------------------
@@ -1244,13 +1249,13 @@ CONTEXT:  HTTP status code: 404
 (4 rows)
 
 -- string_agg with ORDER BY falls back to local execution
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Aggregate
    Output: string_agg(path, ', '::text ORDER BY path)
    ->  Foreign Scan on agg_bin.hits
          Output: id, uuid, "timestamp", datestamp, path, duration, cost
-         Remote SQL: SELECT path FROM agg_test.hits WHERE ((datestamp = '2025-12-05')) ORDER BY path ASC NULLS LAST
+         Remote SQL: SELECT path FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (5 rows)
 
 -- string_agg per-group pushdown (binary)
@@ -1262,14 +1267,21 @@ CONTEXT:  HTTP status code: 404
    Remote SQL: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE (datestamp >= '2025-12-05') AND (datestamp <= '2025-12-07') GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST. Maybe you meant: ['mapConcat','arrayConcat']
-DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
+ datestamp  |                                      string_agg                                      
+------------+--------------------------------------------------------------------------------------
+ 2025-12-05 | /users/283434, /users/802683, /search, /users/283434, /users/7392323, /users/7392323
+ 2025-12-06 | /users/7392323, /widgets/voluptatem, /users
+ 2025-12-07 | /users, /users/802683, /search
+(3 rows)
+
 -- bool_and pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1277,11 +1289,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_or pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
@@ -1289,11 +1303,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- every pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Foreign Scan
+   Output: (every((cost > '0'::numeric)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((cost > 0)) FROM agg_test.hits
+(4 rows)
 
  every 
 -------
@@ -1301,11 +1317,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_and pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1313,23 +1331,56 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_or pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
  t
 (1 row)
 
+-- bit_and pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_and((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_and 
+---------
+     304
+(1 row)
+
+-- bit_or pushdown (binary)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_or((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_or 
+--------
+    304
+(1 row)
+
 -- regr_slope local fallback
-         QUERY PLAN         
-----------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Aggregate
-   ->  Foreign Scan on hits
-(2 rows)
+   Output: regr_slope((cost)::double precision, (duration)::double precision)
+   ->  Foreign Scan on agg_bin.hits
+         Output: id, uuid, "timestamp", datestamp, path, duration, cost
+         Remote SQL: SELECT duration, cost FROM agg_test.hits
+(5 rows)
 
 NOTICE:  drop cascades to foreign table agg_bin.hits
 NOTICE:  drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_4.out
+++ b/test/expected/aggregates_4.out
@@ -1220,7 +1220,7 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
    Remote SQL: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT groupConcat('|')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'
+ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['mapConcat','arrayConcat']: While processing SELECT groupConcat('|')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'
 DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 -- string_agg pushdown (http)
                                             QUERY PLAN                                            
@@ -1231,7 +1231,7 @@ DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((
    Remote SQL: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: Code: 46. DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT groupConcat('')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. (UNKNOWN_FUNCTION)
+ERROR:  pg_clickhouse: Code: 46. DB::Exception: Unknown function groupConcat. Maybe you meant: ['mapConcat','arrayConcat']: While processing SELECT groupConcat('')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. (UNKNOWN_FUNCTION)
 DETAIL:  Remote Query: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 CONTEXT:  HTTP status code: 404
 -- string_agg DISTINCT pushdown (binary)
@@ -1262,14 +1262,16 @@ CONTEXT:  HTTP status code: 404
    Remote SQL: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE (datestamp >= '2025-12-05') AND (datestamp <= '2025-12-07') GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
+ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['mapConcat','arrayConcat']: While processing SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE (datestamp >= '2025-12-05') AND (datestamp <= '2025-12-07') GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 -- bool_and pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1277,11 +1279,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_or pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
@@ -1289,11 +1293,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- every pushdown (binary)
-            QUERY PLAN            
-----------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Foreign Scan
+   Output: (every((cost > '0'::numeric)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((cost > 0)) FROM agg_test.hits
+(4 rows)
 
  every 
 -------
@@ -1301,11 +1307,13 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_and pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_and((duration > 0)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitAnd((duration > 0)) FROM agg_test.hits
+(4 rows)
 
  bool_and 
 ----------
@@ -1313,23 +1321,70 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
 (1 row)
 
 -- bool_or pushdown (http)
-            QUERY PLAN            
-----------------------------------
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
  Foreign Scan
+   Output: (bool_or((duration > 5000)))
    Relations: Aggregate on (hits)
-(2 rows)
+   Remote SQL: SELECT groupBitOr((duration > 5000)) FROM agg_test.hits
+(4 rows)
 
  bool_or 
 ---------
  t
 (1 row)
 
+-- bit_and pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_and((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_and 
+---------
+     304
+(1 row)
+
+-- bit_or pushdown (binary)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_or((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_or 
+--------
+    304
+(1 row)
+
+-- bit_xor pushdown (binary)
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (bit_xor((duration)::integer))
+   Relations: Aggregate on (hits)
+   Remote SQL: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
+(4 rows)
+
+ bit_xor 
+---------
+     304
+(1 row)
+
 -- regr_slope local fallback
-         QUERY PLAN         
-----------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Aggregate
-   ->  Foreign Scan on hits
-(2 rows)
+   Output: regr_slope((cost)::double precision, (duration)::double precision)
+   ->  Foreign Scan on agg_bin.hits
+         Output: id, uuid, "timestamp", datestamp, path, duration, cost
+         Remote SQL: SELECT duration, cost FROM agg_test.hits
+(5 rows)
 
 NOTICE:  drop cascades to foreign table agg_bin.hits
 NOTICE:  drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_5.out
+++ b/test/expected/aggregates_5.out
@@ -1220,7 +1220,7 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
    Remote SQL: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT groupConcat('|')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. Maybe you meant: ['mapConcat','arrayConcat']
+ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT groupConcat('|')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'
 DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 -- string_agg pushdown (http)
                                             QUERY PLAN                                            
@@ -1231,7 +1231,7 @@ DETAIL:  Remote Query: SELECT groupConcat('|')(path) FROM agg_test.hits WHERE ((
    Remote SQL: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 (4 rows)
 
-ERROR:  pg_clickhouse: Code: 46. DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT groupConcat('')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. Maybe you meant: ['mapConcat','arrayConcat']. (UNKNOWN_FUNCTION)
+ERROR:  pg_clickhouse: Code: 46. DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT groupConcat('')(path) FROM agg_test.hits WHERE datestamp = '2025-12-05'. (UNKNOWN_FUNCTION)
 DETAIL:  Remote Query: SELECT groupConcat('')(path) FROM agg_test.hits WHERE ((datestamp = '2025-12-05'))
 CONTEXT:  HTTP status code: 404
 -- string_agg DISTINCT pushdown (binary)
@@ -1262,7 +1262,7 @@ CONTEXT:  HTTP status code: 404
    Remote SQL: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 (4 rows)
 
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'groupConcat' does not exists. In scope SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE (datestamp >= '2025-12-05') AND (datestamp <= '2025-12-07') GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST. Maybe you meant: ['mapConcat','arrayConcat']
+ERROR:  pg_clickhouse: DB::Exception: Unknown function groupConcat. Maybe you meant: ['arrayConcat']: While processing SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE (datestamp >= '2025-12-05') AND (datestamp <= '2025-12-07') GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.hits WHERE ((datestamp >= '2025-12-05')) AND ((datestamp <= '2025-12-07')) GROUP BY datestamp ORDER BY datestamp ASC NULLS LAST
 -- bool_and pushdown (binary)
                              QUERY PLAN                              
@@ -1343,11 +1343,8 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
    Remote SQL: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 (4 rows)
 
- bit_and 
----------
-     304
-(1 row)
-
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument for aggregate function groupBitAnd
+DETAIL:  Remote Query: SELECT groupBitAnd(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 -- bit_or pushdown (binary)
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
@@ -1357,11 +1354,8 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
    Remote SQL: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 (4 rows)
 
- bit_or 
---------
-    304
-(1 row)
-
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument for aggregate function groupBitOr
+DETAIL:  Remote Query: SELECT groupBitOr(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 -- bit_xor pushdown (binary)
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
@@ -1371,11 +1365,8 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
    Remote SQL: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 (4 rows)
 
- bit_xor 
----------
-     304
-(1 row)
-
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument for aggregate function groupBitXor
+DETAIL:  Remote Query: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FROM agg_test.hits WHERE ((id = 3498231651))
 -- regr_slope local fallback
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------

--- a/test/expected/array_functions_1.out
+++ b/test/expected/array_functions_1.out
@@ -244,38 +244,10 @@ SELECT current_setting('server_version_num')::int >= 160000 AS pg16 \gset
 \if :pg16
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM t1 WHERE cardinality(array_shuffle(vals)) = cardinality(vals) ORDER BY id;
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on arr_test.t1
-   Output: id
-   Remote SQL: SELECT id FROM arr_test.t1 WHERE ((length(arrayShuffle(vals)) = length(vals))) ORDER BY id ASC NULLS LAST
-(3 rows)
-
 SELECT id FROM t1 WHERE cardinality(array_shuffle(vals)) = cardinality(vals) ORDER BY id;
- id 
-----
-  1
-  2
-  3
-(3 rows)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Foreign Scan on arr_test.t1
-   Output: id
-   Remote SQL: SELECT id FROM arr_test.t1 WHERE ((length(arrayRandomSample(vals, 1)) = 1)) ORDER BY id ASC NULLS LAST
-(3 rows)
-
 SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
- id 
-----
-  1
-  2
-  3
-(3 rows)
-
 \endif
 -- Operators: @> → hasAll
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/expected/array_functions_2.out
+++ b/test/expected/array_functions_2.out
@@ -269,13 +269,9 @@ SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
 (3 rows)
 
 SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
- id 
-----
-  1
-  2
-  3
-(3 rows)
-
+ERROR:  pg_clickhouse: Code: 46. DB::Exception: Unknown function arrayRandomSample: While processing SELECT id FROM arr_test.t1 WHERE length(arrayRandomSample(vals, 1)) = 1 ORDER BY id ASC NULLS LAST. (UNKNOWN_FUNCTION)
+DETAIL:  Remote Query: SELECT id FROM arr_test.t1 WHERE ((length(arrayRandomSample(vals, 1)) = 1)) ORDER BY id ASC NULLS LAST
+CONTEXT:  HTTP status code: 404
 \endif
 -- Operators: @> → hasAll
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -649,12 +649,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/binary_queries_7.out
+++ b/test/expected/binary_queries_7.out
@@ -647,12 +647,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM binary_queries_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1740,14 +1740,14 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1899,6 +1899,666 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverse(CAST(val AS bytea(0))) = 'olleh'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -624,7 +624,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('dAy'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC NULLS LAST
 (4 rows)
@@ -640,7 +640,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('day'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC NULLS LAST
 (4 rows)
@@ -735,7 +735,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') a
                                                                                                                      QUERY PLAN                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('SeCond'::text, (c AT TIME ZONE 'UTC'::text)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC NULLS LAST
 (4 rows)
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1224,11 +1224,11 @@ SELECT ts FROM t5 WHERE EXTRACT(epoch FROM ts) > 1866158180;
 
 -- Check extract from date.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toYear(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 2027))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toYear(cast(ts, 'Nullable(Date)')) = 2027))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
@@ -1238,11 +1238,11 @@ SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonth(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 11))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonth(cast(ts, 'Nullable(Date)')) = 11))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
@@ -1252,11 +1252,11 @@ SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfMonth(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 18))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfMonth(cast(ts, 'Nullable(Date)')) = 18))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
@@ -1740,14 +1740,14 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1899,6 +1899,654 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -624,7 +624,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('dAy'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC NULLS LAST
 (4 rows)
@@ -640,7 +640,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('day'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC NULLS LAST
 (4 rows)
@@ -735,7 +735,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') a
                                                                                                                      QUERY PLAN                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('SeCond'::text, (c AT TIME ZONE 'UTC'::text)))
+   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM functions_test.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC NULLS LAST
 (4 rows)
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1224,11 +1224,11 @@ SELECT ts FROM t5 WHERE EXTRACT(epoch FROM ts) > 1866158180;
 
 -- Check extract from date.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toYear(cast(ts, 'Nullable(Date)')) = 2027))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toYear(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 2027))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
@@ -1238,11 +1238,11 @@ SELECT ts FROM t5 WHERE EXTRACT(year FROM ts::date) = 2027;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonth(cast(ts, 'Nullable(Date)')) = 11))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toMonth(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 11))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
@@ -1252,11 +1252,11 @@ SELECT ts FROM t5 WHERE EXTRACT(month FROM ts::date) = 11;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfMonth(cast(ts, 'Nullable(Date)')) = 18))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfMonth(cast(cast(ts, 'Nullable(Date)'), 'Nullable(DateTime)')) = 18))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(day FROM ts::date) = 18;
@@ -1476,8 +1476,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -1487,8 +1491,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -1498,8 +1506,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
                                               QUERY PLAN                                              
@@ -1728,14 +1740,14 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1887,6 +1899,642 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 
@@ -1895,7 +2543,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -1904,3 +2552,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table times

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1476,7 +1476,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
                                                 QUERY PLAN                                                
@@ -1487,7 +1487,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
                                                 QUERY PLAN                                                
@@ -1498,7 +1498,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name `nowInBlock64` does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
@@ -1728,14 +1728,14 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1887,6 +1887,666 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverse(CAST(val AS bytea(0))) = 'olleh'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1476,7 +1476,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
                                                 QUERY PLAN                                                
@@ -1487,7 +1487,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
                                                 QUERY PLAN                                                
@@ -1498,7 +1498,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exist. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
@@ -1728,14 +1728,14 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1887,6 +1887,666 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ a 
+---
+ 5
+(1 row)
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverse(CAST(val AS bytea(0))) = 'olleh'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -782,12 +782,12 @@ SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c 
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (strpos(val, 'val'::text))
    Relations: Aggregate on (t4)
-   Remote SQL: SELECT position(val, 'val') FROM functions_test.t4 GROUP BY (position(val, 'val')) ORDER BY position(val, 'val') ASC NULLS LAST
+   Remote SQL: SELECT positionUTF8(val, 'val') FROM functions_test.t4 GROUP BY (positionUTF8(val, 'val')) ORDER BY positionUTF8(val, 'val') ASC NULLS LAST
 (4 rows)
 
 SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
@@ -1476,7 +1476,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
                                                 QUERY PLAN                                                
@@ -1487,7 +1487,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
                                                 QUERY PLAN                                                
@@ -1498,7 +1498,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'nowInBlock64' does not exists. In scope SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2. Maybe you meant: ['nowInBlock']
 DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
@@ -1704,8 +1704,11 @@ SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:0
 (3 rows)
 
 SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
-ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument 2 of function concatWithSeparator: While processing concatWithSeparator(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 -- Test fuzzystrmatch pushdown.
 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 -- soundex pushes down with same name.
@@ -1725,19 +1728,19 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
  val2
 (2 rows)
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
  Foreign Scan on public.t4
    Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function editDistance. Maybe you meant: ['geoDistance','h3Distance']: While processing editDistance(val, 'val1') <= 1
-DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((editDistance(val, 'val1') <= 1))
+ERROR:  pg_clickhouse: DB::Exception: Function with name 'editDistanceUTF8' does not exists. In scope SELECT val FROM functions_test.t4 WHERE editDistanceUTF8(val, 'val1') <= 1. Maybe you meant: ['editDistance','ngramDistanceUTF8']
+DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
 -- 5-arg levenshtein (custom costs) evaluates locally.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
@@ -1880,6 +1883,660 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
    Remote SQL: SELECT r1.ts, r2.val FROM  functions_test.t5 r1 ALL INNER JOIN functions_test.t4 r2 ON (TRUE) LIMIT 1
 (4 rows)
 
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverseUTF8(val) = 'βαΩ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(a, 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((pow(f64, 2) < 1)) ORDER BY i64 ASC NULLS LAST
+(3 rows)
+
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+ i64 
+-----
+   0
+(1 row)
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Decimal(10, 0) of argument of function pow: In scope SELECT a FROM functions_test.t3 WHERE pow(CAST(a, 'Nullable(Decimal)'), 2) = 25
+DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+(3 rows)
+
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+ERROR:  pg_clickhouse: DB::Exception: Illegal type Decimal(10, 0) of argument of function pow: In scope SELECT a FROM functions_test.t3 WHERE pow(CAST(a, 'Nullable(Decimal)'), 2) = 25
+DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs((a - 5)) = 2)) ORDER BY a ASC NULLS LAST
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+ a 
+---
+ 3
+ 7
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((abs(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((factorial(a) = 120))
+(3 rows)
+
+SELECT a FROM t3 WHERE factorial(a) = 120;
+ a 
+---
+ 5
+(1 row)
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((round(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+(3 rows)
+
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+ a 
+---
+ 5
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t3
+   Output: a
+   Remote SQL: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+(3 rows)
+
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+ a 
+---
+(0 rows)
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sin(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cos(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((atan2(f64, 1) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((sinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((cosh(f64) = 1))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((tanh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((asinh(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((degrees(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((i64 = 0)) AND ((radians(f64) = 0))
+(3 rows)
+
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+ i64 
+-----
+   0
+(1 row)
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t6
+   Output: i64
+   Remote SQL: SELECT i64 FROM functions_test.t6 WHERE ((f64 < 3.141592653589793))
+(3 rows)
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lowerUTF8(val) = 'val3'))
+(3 rows)
+
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+ val  
+------
+ VAL3
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((upperUTF8(val) = 'VAL1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+ val  
+------
+ val1
+(1 row)
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 1, 3) = 'val')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substringUTF8(val, 2) = 'αβ'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = 'va')) ORDER BY val ASC NULLS LAST
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+ val  
+------
+ val1
+ val2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 1, 2) = '\xce\xa9'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((substring(CAST(val AS bytea(0)), 2) = 'al1'))
+(3 rows)
+
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+ val  
+------
+ val1
+(1 row)
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((lengthUTF8(val) = 3))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val) = 3;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(val) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((length(CAST(val AS bytea(0))) = 6))
+(3 rows)
+
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+ val 
+-----
+ Ωαβ
+(1 row)
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on public.t4
+   Output: val
+   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverse(CAST(val AS bytea(0))) = 'olleh'))
+(3 rows)
+
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+  val  
+-------
+ hello
+(1 row)
+
+\endif
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t1
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Foreign Scan on public.t2
+   Output: a, b
+   Remote SQL: SELECT a, b FROM functions_test.t1 WHERE ((date(c) = '2019-01-01'))
+(3 rows)
+
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+ a | b 
+---+---
+ 1 | 1
+(1 row)
+
+RESET timezone;
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
  clickhouse_raw_query 

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -1719,12 +1719,8 @@ SELECT * FROM t4 WHERE soundex(val) = 'V400';
 (3 rows)
 
 SELECT * FROM t4 WHERE soundex(val) = 'V400';
- val  
-------
- val1
- val2
-(2 rows)
-
+ERROR:  pg_clickhouse: DB::Exception: Unknown function soundex. Maybe you meant: ['round','unhex']: While processing soundex(val) = 'V400'
+DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((soundex(val) = 'V400'))
 -- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -1918,11 +1914,8 @@ SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
 (3 rows)
 
 SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
-  val  
--------
- hello
-(1 row)
-
+ERROR:  pg_clickhouse: DB::Exception: Illegal type String of argument of function bitCount: While processing bitCount(CAST(val, 'bytea(0)')) = 21
+DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((bitCount(CAST(val AS bytea(0))) = 21)) ORDER BY val ASC NULLS LAST
 \endif
 -- mod(int, int) pushes down as modulo.
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -759,12 +759,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                           QUERY PLAN                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -759,12 +759,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                           QUERY PLAN                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -759,12 +759,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                           QUERY PLAN                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -759,12 +759,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                           QUERY PLAN                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -759,12 +759,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c8 = 'foo';  -- can't be
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,
 	sum(length(c2)) FROM ft2 GROUP BY a ORDER BY a;
-                                                                                                                                                                           QUERY PLAN                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                             QUERY PLAN                                                                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (CASE WHEN (c1 < 10) THEN 1 WHEN (c1 < 50) THEN 2 ELSE 3 END), (sum(length(c2)))
    Relations: Aggregate on (ft2)
-   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(length(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
+   Remote SQL: SELECT CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END, sum(lengthUTF8(c2)) FROM http_test.t2 GROUP BY (CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END) ORDER BY CASE WHEN (c1 < 10) THEN toInt32(1) WHEN (c1 < 50) THEN toInt32(2) ELSE toInt32(3) END ASC NULLS LAST
 (4 rows)
 
 SELECT (CASE WHEN c1 < 10 THEN 1 WHEN c1 < 50 THEN 2 ELSE 3 END) a,

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -13,14 +13,28 @@ aggregates.sql
  Postgres | File
 ----------|-----------------
  16-18    | aggregates.out
- 13-15    | aggregates_1.out
+ 14-15    | aggregates_1.out
+ 13       | aggregates_2.out
 
  ClickHouse | File
 ------------|-----------------
  24.8+      | aggregates.out
- 24.3       | aggregates_2.out
- 23.8       | aggregates_3.out
- 23.3       | aggregates_4.out
+ 24.3       | aggregates_3.out
+ 23.8       | aggregates_4.out
+ 23.3       | aggregates_5.out
+
+array_functions.sql
+-------------------
+
+ Postgres | File
+----------|----------------------
+ 16-18    | array_functions.out
+ 13-15    | array_functions_1.out
+
+ ClickHouse | File
+------------|----------------------
+ 24.3+      | array_functions.out
+ 23         | array_functions_2.out
 
 binary_inserts.sql
 ------------------
@@ -81,17 +95,18 @@ functions.sql
 
  Postgres | File
 ----------|---------------
- 14-18    | functions.out
- 13       | functions_1.out
+ 18       | functions.out
+ 14-17    | functions_1.out
+ 13       | functions_2.out
 
  ClickHouse | File
 ------------|-----------------
  25.8+      | functions.out
- 25.3       | functions_2.out
- 24.8       | functions_3.out
- 24.3       | functions_4.out
- 23.8       | functions_5.out
- 23.3       | functions_6.out
+ 25.3       | functions_3.out
+ 24.8       | functions_4.out
+ 24.3       | functions_5.out
+ 23.8       | functions_6.out
+ 23.3       | functions_7.out
 
 http.sql
 --------
@@ -239,7 +254,7 @@ window_functions.sql
 
  Postgres | File
 ----------|------------------------
- 18       | window_functions.out
+ 13-18    | window_functions.out
 
  ClickHouse | File
 ------------|----------------------------

--- a/test/expected/window_functions.out
+++ b/test/expected/window_functions.out
@@ -115,6 +115,60 @@
  lead_300  | 2026-03-05 08:00:00+00 | 1970-01-01 00:00:00+00
 (5 rows)
 
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id |        ts_event        | prev_amount 
+-----------+------------------------+-------------
+ lead_100  | 2026-03-01 10:00:00+00 |           0
+ lead_100  | 2026-03-15 14:00:00+00 |         100
+ lead_200  | 2026-03-10 09:00:00+00 |           0
+ lead_200  | 2026-03-20 11:00:00+00 |         150
+ lead_300  | 2026-03-05 08:00:00+00 |           0
+(5 rows)
+
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -259,6 +313,33 @@
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/expected/window_functions_1.out
+++ b/test/expected/window_functions_1.out
@@ -102,6 +102,53 @@ DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITIO
 ERROR:  pg_clickhouse: Code: 63. DB::Exception: Aggregate function with name 'lead' does not exist. In scope SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE event_name = 'lead_created'. (UNKNOWN_AGGREGATE_FUNCTION)
 DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
 CONTEXT:  HTTP status code: 404
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Aggregate function with name 'lag' does not exist. In scope SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE event_name = 'lead_created'
+DETAIL:  Remote Query: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -239,6 +286,33 @@ DETAIL:  Remote Query: SELECT entity_id, amount, cume_dist() OVER (ORDER BY amou
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/expected/window_functions_2.out
+++ b/test/expected/window_functions_2.out
@@ -102,6 +102,53 @@ DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITIO
 ERROR:  pg_clickhouse: Code: 63. DB::Exception: Aggregate function with name 'lead' does not exists. In scope SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE event_name = 'lead_created'. (UNKNOWN_AGGREGATE_FUNCTION)
 DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
 CONTEXT:  HTTP status code: 404
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Aggregate function with name 'lag' does not exists. In scope SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE event_name = 'lead_created'
+DETAIL:  Remote Query: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -232,6 +279,33 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/expected/window_functions_3.out
+++ b/test/expected/window_functions_3.out
@@ -102,6 +102,53 @@ DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITIO
 ERROR:  pg_clickhouse: Code: 63. DB::Exception: Unknown aggregate function lead. (UNKNOWN_AGGREGATE_FUNCTION)
 DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
 CONTEXT:  HTTP status code: 404
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Unknown aggregate function lag
+DETAIL:  Remote Query: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -225,6 +272,33 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/expected/window_functions_4.out
+++ b/test/expected/window_functions_4.out
@@ -115,6 +115,60 @@
  lead_300  | 2026-03-05 08:00:00+00 | 1970-01-01 00:00:00+00
 (5 rows)
 
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id |        ts_event        | prev_amount 
+-----------+------------------------+-------------
+ lead_100  | 2026-03-01 10:00:00+00 |           0
+ lead_100  | 2026-03-15 14:00:00+00 |         100
+ lead_200  | 2026-03-10 09:00:00+00 |           0
+ lead_200  | 2026-03-20 11:00:00+00 |         150
+ lead_300  | 2026-03-05 08:00:00+00 |           0
+(5 rows)
+
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -252,6 +306,33 @@ DETAIL:  Remote Query: SELECT entity_id, amount, cume_dist() OVER (ORDER BY amou
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/expected/window_functions_5.out
+++ b/test/expected/window_functions_5.out
@@ -102,6 +102,53 @@ DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITIO
 ERROR:  pg_clickhouse: Code: 63. DB::Exception: Unknown aggregate function lead. (UNKNOWN_AGGREGATE_FUNCTION)
 DETAIL:  Remote Query: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
 CONTEXT:  HTTP status code: 404
+-- LAG pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Unknown aggregate function lag
+DETAIL:  Remote Query: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+-- rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | rk 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
+-- dense_rank pushdown (binary)
+           QUERY PLAN            
+---------------------------------
+ Foreign Scan
+   Relations: Window on (events)
+(2 rows)
+
+ entity_id | amount | dr 
+-----------+--------+----
+ lead_100  |    100 |  1
+ lead_100  |    200 |  2
+ lead_100  |    210 |  3
+ lead_200  |    150 |  1
+ lead_200  |    300 |  2
+ lead_200  |    310 |  3
+ lead_300  |    250 |  1
+ lead_300  |    260 |  2
+(8 rows)
+
 -- ntile pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -232,6 +279,33 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
    Output: entity_id, ts_event, (lead(ts_event))
    Relations: Window on (events)
    Remote SQL: SELECT entity_id, ts_event, lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE LAG pushdown (binary)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, ts_event, (lag(amount))
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, ts_event, lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) FROM wf_test.events WHERE ((event_name = 'lead_created'))
+(4 rows)
+
+-- VERBOSE rank pushdown (binary)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
+(4 rows)
+
+-- VERBOSE dense_rank pushdown (binary)
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: entity_id, amount, (dense_rank())
+   Relations: Window on (events)
+   Remote SQL: SELECT entity_id, amount, dense_rank() OVER (PARTITION BY entity_id ORDER BY amount ASC) FROM wf_test.events ORDER BY entity_id ASC NULLS LAST, amount ASC NULLS LAST
 (4 rows)
 
 -- VERBOSE ntile pushdown (binary)

--- a/test/sql/aggregates.sql
+++ b/test/sql/aggregates.sql
@@ -394,38 +394,61 @@ SELECT datestamp, string_agg(path, ', ') FROM agg_bin.hits
 
 -- bool_and / bool_or / every pushdown
 \echo -- bool_and pushdown (binary)
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT bool_and(duration > 0) FROM agg_bin.hits;
 
 SELECT bool_and(duration > 0) FROM agg_bin.hits;
 
 \echo -- bool_or pushdown (binary)
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT bool_or(duration > 5000) FROM agg_bin.hits;
 
 SELECT bool_or(duration > 5000) FROM agg_bin.hits;
 
 \echo -- every pushdown (binary)
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT every(cost > 0) FROM agg_bin.hits;
 
 SELECT every(cost > 0) FROM agg_bin.hits;
 
 \echo -- bool_and pushdown (http)
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT bool_and(duration > 0) FROM agg_http.hits;
 
 SELECT bool_and(duration > 0) FROM agg_http.hits;
 
 \echo -- bool_or pushdown (http)
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT bool_or(duration > 5000) FROM agg_http.hits;
 
 SELECT bool_or(duration > 5000) FROM agg_http.hits;
+
+-- bit_and / bit_or pushdown (groupBitAnd / groupBitOr)
+\echo -- bit_and pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT bit_and(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+
+SELECT bit_and(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+
+\echo -- bit_or pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT bit_or(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+
+SELECT bit_or(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+
+-- bit_xor added in PG14, pushes down as groupBitXor.
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+\echo -- bit_xor pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT bit_xor(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+
+SELECT bit_xor(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
+\endif
 
 -- regr_* local fallback (not pushed)
 \echo -- regr_slope local fallback
-EXPLAIN (COSTS OFF)
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT regr_slope(cost::float8, duration::float8) FROM agg_bin.hits;
 
 -- Clean up.

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -192,6 +192,18 @@ END;
 $$;
 \set ECHO all
 
+-- array_shuffle / array_sample added in PG16; output is non-deterministic
+-- so put them in WHERE with cardinality predicates that always hold.
+SELECT current_setting('server_version_num')::int >= 160000 AS pg16 \gset
+\if :pg16
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE cardinality(array_shuffle(vals)) = cardinality(vals) ORDER BY id;
+SELECT id FROM t1 WHERE cardinality(array_shuffle(vals)) = cardinality(vals) ORDER BY id;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
+SELECT id FROM t1 WHERE cardinality(array_sample(vals, 1)) = 1 ORDER BY id;
+\endif
+
 -- Operators: @> → hasAll
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE vals @> ARRAY[10];

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -477,7 +477,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE soundex(val) = 'V400';
 SELECT * FROM t4 WHERE soundex(val) = 'V400';
 
--- 2-arg levenshtein pushes down as editDistance.
+-- 2-arg levenshtein pushes down as editDistanceUTF8.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
@@ -523,6 +523,181 @@ SELECT ts FROM t5 WHERE to_char(ts, 'HH12 am') = '08 pm';
 -- Dynamic format -- not a Const, so cannot be validated.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
+
+-- reverse pushes down as reverseUTF8 to preserve code-point order on
+-- multi-byte input
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
+$$);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
+
+-- bit_count(bytea) pushes down as bitCount (PG14+).
+SELECT current_setting('server_version_num')::int >= 140000 AS pg14 \gset
+\if :pg14
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+SELECT val FROM t4 WHERE bit_count(val::bytea) = 21 ORDER BY val;
+\endif
+
+-- mod(int, int) pushes down as modulo.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+SELECT a FROM t3 WHERE mod(a, 3) = 0 ORDER BY a;
+
+-- pow(float8, float8) and power(float8, float8) both push down as pow.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+SELECT i64 FROM t6 WHERE pow(f64, 2::float8) < 1 ORDER BY i64;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+SELECT i64 FROM t6 WHERE power(f64, 2::float8) < 1 ORDER BY i64;
+
+-- mod / pow / power on numeric push down too.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
+
+-- abs() pushes down for int / float / numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+SELECT i64 FROM t6 WHERE abs(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+SELECT a FROM t3 WHERE abs(a::numeric) = 5;
+
+-- factorial(int8) pushes down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE factorial(a) = 120;
+SELECT a FROM t3 WHERE factorial(a) = 120;
+
+-- round() pushes down for float8 and numeric.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+SELECT i64 FROM t6 WHERE round(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+SELECT a FROM t3 WHERE round(a::numeric) = 5;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
+
+-- Trig functions push down at f64 = 0 where PG and CH agree exactly.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+SELECT i64 FROM t6 WHERE i64 = 0 AND cos(f64) = 1;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND tan(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND atan2(f64, 1::float8) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND sinh(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+SELECT i64 FROM t6 WHERE i64 = 0 AND cosh(f64) = 1;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND tanh(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND asinh(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND degrees(f64) = 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+SELECT i64 FROM t6 WHERE i64 = 0 AND radians(f64) = 0;
+
+-- pi() is immutable so PG constant-folds before deparse; the function name
+-- itself is never sent to CH but the remote literal proves the call worked.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT i64 FROM t6 WHERE f64 < pi();
+
+-- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
+SELECT clickhouse_raw_query($$
+    INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
+$$);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+SELECT val FROM t4 WHERE lower(val) = 'val3';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+SELECT val FROM t4 WHERE upper(val) = 'VAL1';
+
+-- substring/substr (text) push down as substringUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+SELECT val FROM t4 WHERE substring(val, 1, 3) = 'val' ORDER BY val;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+SELECT val FROM t4 WHERE substr(val, 2) = 'αβ';
+
+-- substring/substr (bytea) push down as substring (byte-based).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = 'va'::bytea ORDER BY val;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+SELECT val FROM t4 WHERE substring(val::bytea, 1, 2) = '\xcea9'::bytea;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+SELECT val FROM t4 WHERE substr(val::bytea, 2) = 'al1'::bytea;
+
+-- length(text) pushes down as lengthUTF8 (counts code points).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val) = 3;
+SELECT val FROM t4 WHERE length(val) = 3;
+
+-- length(bytea) pushes down as length (counts bytes).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+SELECT val FROM t4 WHERE length(val::bytea) = 6;
+
+-- octet_length(text) / octet_length(bytea) push down as length.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+SELECT val FROM t4 WHERE octet_length(val) = 6;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+SELECT val FROM t4 WHERE octet_length(val::bytea) = 6;
+
+-- reverse(bytea) added in PG18, pushes down as CH reverse (byte-wise).
+SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
+\if :pg18
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
+\endif
+
+-- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+SELECT a, b FROM t1 WHERE date(c) = '2019-01-01'::date;
+-- Pin TZ for the timestamptz variant so PG and CH interpret c identically.
+SET timezone = 'UTC';
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+SELECT a, b FROM t2 WHERE date(c) = '2019-01-01'::date;
+RESET timezone;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');

--- a/test/sql/window_functions.sql
+++ b/test/sql/window_functions.sql
@@ -130,6 +130,48 @@ FROM wf_http.events
 WHERE event_name = 'lead_created';
 
 -- ============================================================
+-- LAG() OVER
+-- ============================================================
+\echo -- LAG pushdown (binary)
+EXPLAIN (COSTS OFF)
+SELECT entity_id, ts_event,
+       lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) AS prev_amount
+FROM wf_bin.events
+WHERE event_name = 'lead_created';
+
+SELECT entity_id, ts_event,
+       lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) AS prev_amount
+FROM wf_bin.events
+WHERE event_name = 'lead_created';
+
+-- ============================================================
+-- RANK() and DENSE_RANK()
+-- ============================================================
+\echo -- rank pushdown (binary)
+EXPLAIN (COSTS OFF)
+SELECT entity_id, amount,
+       rank() OVER (PARTITION BY entity_id ORDER BY amount) AS rk
+FROM wf_bin.events
+ORDER BY entity_id, amount;
+
+SELECT entity_id, amount,
+       rank() OVER (PARTITION BY entity_id ORDER BY amount) AS rk
+FROM wf_bin.events
+ORDER BY entity_id, amount;
+
+\echo -- dense_rank pushdown (binary)
+EXPLAIN (COSTS OFF)
+SELECT entity_id, amount,
+       dense_rank() OVER (PARTITION BY entity_id ORDER BY amount) AS dr
+FROM wf_bin.events
+ORDER BY entity_id, amount;
+
+SELECT entity_id, amount,
+       dense_rank() OVER (PARTITION BY entity_id ORDER BY amount) AS dr
+FROM wf_bin.events
+ORDER BY entity_id, amount;
+
+-- ============================================================
 -- Ranking window functions (ntile, cume_dist, percent_rank)
 -- ============================================================
 \echo -- ntile pushdown (binary)
@@ -270,6 +312,33 @@ SELECT entity_id, ts_event,
        lead(ts_event) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) AS next_event
 FROM wf_bin.events
 WHERE event_name = 'lead_created';
+
+-- ============================================================
+-- LAG() OVER
+-- ============================================================
+\echo -- VERBOSE LAG pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT entity_id, ts_event,
+       lag(amount) OVER (PARTITION BY entity_id ORDER BY ts_event ASC) AS prev_amount
+FROM wf_bin.events
+WHERE event_name = 'lead_created';
+
+-- ============================================================
+-- RANK() and DENSE_RANK()
+-- ============================================================
+\echo -- VERBOSE rank pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT entity_id, amount,
+       rank() OVER (PARTITION BY entity_id ORDER BY amount) AS rk
+FROM wf_bin.events
+ORDER BY entity_id, amount;
+
+\echo -- VERBOSE dense_rank pushdown (binary)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT entity_id, amount,
+       dense_rank() OVER (PARTITION BY entity_id ORDER BY amount) AS dr
+FROM wf_bin.events
+ORDER BY entity_id, amount;
 
 \echo -- VERBOSE ntile pushdown (binary)
 EXPLAIN (VERBOSE, COSTS OFF)


### PR DESCRIPTION
Explicitly add functions which were falling through correctly by default

Include mapping mod/pow/power/bit_count/reverse/bit_and/bit_or/bit_xor

`length(text)` in PG is actually `lengthUTF8` in CH

asin/acos/atanh/acosh not pushed down for now since they need range checks: on PG out-of-range is error, whereas on CH out-of-range returns NaN