### PR TITLE
Update clickhouse-cpp for proper Bool support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file. It uses the
     `re2extractallgroupshorizontal`, `re2extractallgroupsvertical`,
     `re2regexpquotemeta`, and `re2splitbyregexp`. Thanks to Philip Dubé for
     the PR ([#232]).
+*   Updated binary driver to properly support handling `Bool`s as boolean
+    values rather than `int16` values, avoiding the need for casting.
 
   [v0.3.1]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.0...v0.3.1
   [#232]: https://github.com/ClickHouse/pg_clickhouse/pull/232

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CH_CPP_BUILD_DIR = vendor/_build/$(OS)-$(ARCH)-$(CH_BUILD)-$(shell git submodule
 
 # List the clickhouse-cpp libraries we require.
 CH_CPP_LIB = $(CH_CPP_BUILD_DIR)/clickhouse/libclickhouse-cpp-lib$(DLSUFFIX)
-CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON
+CH_CPP_FLAGS = -D CMAKE_BUILD_TYPE=Release -D WITH_OPENSSL=ON -DCH_MAP_BOOL_TO_UINT8=OFF
 
 # Are we statically compiling clickhouse-cpp into the extension or no?
 ifeq ($(CH_BUILD), static)

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -300,6 +300,8 @@ extern "C"
 			case Type::Code::Int16:
 			case Type::Code::UInt8:
 				return INT2OID;
+			case Type::Code::Bool:
+				return BOOLOID;
 			case Type::Code::Int32:
 			case Type::Code::UInt16:
 				return INT4OID;
@@ -558,6 +560,21 @@ extern "C"
 						break;
 					default:
 						THROW_UNEXPECTED_COLUMN("INT2", col);
+				}
+				break;
+			}
+			case BOOLOID:
+			{
+				switch (col->Type()->GetCode())
+				{
+					case Type::Code::UInt8:
+						col->AsStrict<ColumnUInt8>()->Append((uint8_t)val);
+						break;
+					case Type::Code::Bool:
+						col->AsStrict<ColumnBool>()->Append((bool)val);
+						break;
+					default:
+						THROW_UNEXPECTED_COLUMN("BOOL", col);
 				}
 				break;
 			}
@@ -965,6 +982,13 @@ extern "C"
 				int16 val = col->AsStrict<ColumnUInt8>()->At(row);
 				ret = (Datum)val;
 				*valtype = INT2OID;
+			}
+			break;
+			case Type::Code::Bool:
+			{
+				bool val = col->AsStrict<ColumnBool>()->At(row);
+				ret = (Datum)val;
+				*valtype = BOOLOID;
 			}
 			break;
 			case Type::Code::UInt16:

--- a/src/convert.c
+++ b/src/convert.c
@@ -319,12 +319,6 @@ convert_bool(ch_convert_state * state, Datum val)
 	return BoolGetDatum(dat);
 }
 
-inline static Datum
-convert_bool_to_int16(ch_convert_output_state * state, Datum val)
-{
-	return Int16GetDatum(DatumGetBool(val) ? 1 : 0);
-}
-
 Datum
 ch_binary_convert_datum(void *state, Datum val)
 {
@@ -520,14 +514,6 @@ init_output_convert_state(ch_convert_output_state * state)
 		|| (state->intype == JSONOID && state->outtype == JSONBOID)
 		)
 		return;
-
-	/* Postgres has no cast from bool to INT16, so provide our own. */
-	if (state->outtype == INT2OID && state->intype == BOOLOID)
-	{
-		state->func = convert_bool_to_int16;
-		state->ctype = COERCION_PATH_FUNC;
-		return;
-	}
 
 	state->func = convert_out_generic;
 


### PR DESCRIPTION
The new version adds a `Bool` column type and the `-DCH_MAP_BOOL_TO_UINT8=OFF` compile directive to prevent converting bools to `uint8` values. This eliminates the need for the binary driver to cast to and from `uint8` (`INT2`) to handle boolean values: we can just directly use the boolean type support.