### PR TITLE
Support binary boolean without casting

### DIFF
--- a/src/binary/binary_internal.h
+++ b/src/binary/binary_internal.h
@@ -149,6 +149,8 @@ extern void ch_binary_append_int(ch_binary_insert_handle * h, size_t col,
 								 int64_t val, bool isnull);
 extern void ch_binary_append_uint(ch_binary_insert_handle * h, size_t col,
 								  uint64_t val, bool isnull);
+extern void ch_binary_append_bool(ch_binary_insert_handle * h, size_t col,
+								  bool val, bool isnull);
 extern void ch_binary_append_double(ch_binary_insert_handle * h, size_t col,
 									double val, bool isnull);
 extern void ch_binary_append_float(ch_binary_insert_handle * h, size_t col,

--- a/src/binary/convert.c
+++ b/src/binary/convert.c
@@ -317,12 +317,6 @@ convert_bool(ch_convert_state * state, Datum val)
 	return BoolGetDatum(dat);
 }
 
-inline static Datum
-convert_bool_to_int16(ch_convert_output_state * state, Datum val)
-{
-	return Int16GetDatum(DatumGetBool(val) ? 1 : 0);
-}
-
 Datum
 ch_binary_convert_datum(void *state, Datum val)
 {
@@ -512,14 +506,6 @@ init_output_convert_state(ch_convert_output_state * state)
 	/* column_append() copies all bytes, no cast needed. */
 	if (state->intype == BYTEAOID && state->outtype == TEXTOID)
 		return;
-
-	/* Postgres has no cast from bool to INT16, so provide our own. */
-	if (state->outtype == INT2OID && state->intype == BOOLOID)
-	{
-		state->func = convert_bool_to_int16;
-		state->ctype = COERCION_PATH_FUNC;
-		return;
-	}
 
 	state->func = convert_out_generic;
 

--- a/src/binary/decode.c
+++ b/src/binary/decode.c
@@ -42,6 +42,12 @@ rd_u8(const uint8_t * p, uint64_t row)
 	return p[row];
 }
 
+static inline bool
+rd_bool(const bool *p, uint64_t row)
+{
+	return (bool) p[row];
+}
+
 static inline int16_t
 rd_i16(const uint8_t * p, uint64_t row)
 {
@@ -141,8 +147,9 @@ ch_kind_to_pg_oid(const chc_type * type)
 		case CHC_INT8:
 		case CHC_INT16:
 		case CHC_UINT8:
-		case CHC_BOOL:
 			return INT2OID;
+		case CHC_BOOL:
+			return BOOLOID;
 		case CHC_INT32:
 		case CHC_UINT16:
 			return INT4OID;
@@ -619,9 +626,11 @@ read_value(const chc_column * col, const chc_type * type, uint64_t row,
 			*is_null = true;
 			return (Datum) 0;
 		case CHC_UINT8:
-		case CHC_BOOL:
 			*valtype = INT2OID;
 			return (Datum) rd_u8((const uint8_t *) chc_column_fixed_data(col, NULL), row);
+		case CHC_BOOL:
+			*valtype = BOOLOID;
+			return (Datum) rd_bool((const bool *) chc_column_fixed_data(col, NULL), row);
 		case CHC_INT8:
 			*valtype = INT2OID;
 			return (Datum) rd_i8((const uint8_t *) chc_column_fixed_data(col, NULL), row);

--- a/src/binary/encode.c
+++ b/src/binary/encode.c
@@ -39,8 +39,9 @@ ch_kind_to_pg_oid_for_insert(const chc_type * type, const char *colname)
 		case CHC_INT8:
 		case CHC_INT16:
 		case CHC_UINT8:
-		case CHC_BOOL:
 			return INT2OID;
+		case CHC_BOOL:
+			return BOOLOID;
 		case CHC_INT32:
 		case CHC_UINT16:
 			return INT4OID;
@@ -187,6 +188,11 @@ append_one(ch_binary_insert_handle * h, size_t colidx,
 				ch_binary_append_int(h, colidx, v, isnull);
 				return;
 			}
+		case BOOLOID:
+			if (kind != CHC_BOOL && kind != CHC_UINT8)
+				goto type_mismatch;
+			ch_binary_append_bool(h, colidx, (bool) val, isnull);
+			return;
 		case FLOAT4OID:
 			if (kind != CHC_FLOAT32)
 				goto type_mismatch;

--- a/src/binary/insert.c
+++ b/src/binary/insert.c
@@ -671,6 +671,12 @@ ch_binary_append_uint(ch_binary_insert_handle * h, size_t col, uint64_t val, boo
 }
 
 void
+ch_binary_append_bool(ch_binary_insert_handle * h, size_t col, bool val, bool isnull)
+{
+	ch_binary_append_int(h, col, val, isnull);
+}
+
+void
 ch_binary_append_double(ch_binary_insert_handle * h, size_t col, double val, bool isnull)
 {
 	MemoryContext old = MemoryContextSwitchTo(h->cxt);


### PR DESCRIPTION
Add functions to convert between the boolean value on the wire (uint8) to Postgres `BOOL` Datums without casting.