### PR TITLE
Fix gaps in clickhouse-c driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,24 +16,24 @@ All notable changes to this project will be documented in this file. It uses the
     `vendor/clickhouse-c`. This change eliminates conflicts between the C++
     and Postgres memory & exception handling and streams query results by the
     ClickHouse block for reduced memory consumption. It also greatly reduces
-    build time and the size of the library by over 75%. Thanks to Philip Dubé
-    for the the new library and the PR ([#254]).
+    build time and the size of the library by over 75%. Thanks to serprex for
+    the the new library and the PR ([#254]).
 *   Added multidimensional array support across SELECT and INSERT to both the
     binary and http drivers. Rectangular ClickHouse `Array(Array(...))` values
     now map to PostgreSQL multidimensional arrays, jagged arrays not supported,
     and PostgreSQL multidimensional arrays inserted into ClickHouse
-    `Array(Array(...))` columns preserve their nesting. Thanks to Philip Dubé
-    for the PR ([#233]).
+    `Array(Array(...))` columns preserve their nesting. Thanks to serprex for
+    the PR ([#233]).
 *   Added pushdown for [re2 extension] functions introduced in pg_re2 0.3:
     `re2extractallgroupshorizontal`, `re2extractallgroupsvertical`,
-    `re2regexpquotemeta`, and `re2splitbyregexp`. Thanks to Philip Dubé for
-    the PR ([#232]).
+    `re2regexpquotemeta`, and `re2splitbyregexp`. Thanks to serprex for the
+    PR ([#232]).
 
 ### 🐞 Bug Fixes
 
 *   Fixed incorrect casting of ClickHouse `UInt16` values to `int16` in the
     Binary driver. They now correctly convert to `int32` (Postgres `INT4`).
-    Part of the omnibus binary c driver conversion contributed by Philip Dubé
+    Part of the omnibus binary c driver conversion contributed by serprex
     ([#233]).
 
   [v0.3.1]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.0...v0.3.1
@@ -61,10 +61,10 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
 
 *   Added pushdown for [re2 extension] functions, if available, to their
     ClickHouse equivalents (e.g., `re2match` → `match`, `re2extractall` →
-    `extractAll`). Thanks to Philip Dubé for the PR ([#204]).
+    `extractAll`). Thanks to serprex for the PR ([#204]).
 *   Added pushdown for [fuzzystrmatch] functions `soundex()` and
     `levenshtein()` (2-arg, mapped to `editDistanceUTF8`). Thanks to
-    Philip Dubé for the PR ([#210]).
+    serprex for the PR ([#210]).
 *   Added mapping for `JSON` => `jsonb` to the binary driver (requires
     ClickHouse 24.10 or later).
 *   Added support for ClickHouse `JSON` mapped to Postgres `json`, supporting
@@ -74,19 +74,19 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
     pushes down when the format is a constant whose every keyword has an
     identical CH equivalent (`YYYY`, `MM`, `DD`, `DDD`, `HH24`, `HH12`, `HH`,
     `MI`, `SS`, `Q`, `Mon`, `Dy`, `AM`/`PM`, plus lowercase variants).
-    Thanks to Philip Dubé for the PR ([#244]).
+    Thanks to serprex for the PR ([#244]).
 *   Made builtin function pushdown opt-in: Postgres builtins now ship to
     ClickHouse only when explicitly mapped, so name or signature differences
-    cannot silently alter results. Thanks to Philip Dubé for the PR ([#245]).
+    cannot silently alter results. Thanks to serprex for the PR ([#245]).
 *   Added explicit mappings for `mod`, `pow`/`power`, `bit_count(bytea)`, and
     `reverse(text)` (→ `reverseUTF8`) to retain previously working pushdowns.
-    Thanks to Philip Dubé for the PR ([#245]).
+    Thanks to serprex for the PR ([#245]).
 
 ### 🐞 Bug Fixes
 
 *   Fixed `EXPLAIN (VERBOSE)` failing with "could not find window clause for
-    winref N" when window functions push down to ClickHouse. Thanks to Philip
-    Dubé for the PR ([#223]).
+    winref N" when window functions push down to ClickHouse. Thanks to serprex
+    for the PR ([#223]).
 *   Fixed the parsing of strings that start with `[` in the http driver so
     that it no longer assumes it's the start of an array. Thanks to Kaushik
     Iska for the PR ([#234]).
@@ -96,15 +96,14 @@ ALTER EXTENSION pg_clickhouse UPDATE TO '0.3';
 *   Fixed the `column_name` foreign-table column option being ignored by
     `INSERT`, which caused the binary engine to fail to match ClickHouse block
     columns and the HTTP engine to deparse PostgreSQL attribute names. Thanks
-    to Philip Dubé for the PR ([#231]).
+    to serprex for the PR ([#231]).
 *   Fixed `length(text)` and `strpos(text, text)` pushdown to map to
     `lengthUTF8` and `positionUTF8` rather than ClickHouse's byte-counting
     `length` and `position`, matching Postgres character semantics. Thanks to
-    Philip Dubé for the PR ([#245]).
+    serprex for the PR ([#245]).
 *   Stopped pushing down `asin`, `acos`, `atanh`, and `acosh`: Postgres raises
     an error on out-of-range input where ClickHouse returns `NaN`. Evaluating
-    locally preserves Postgres semantics. Thanks to Philip Dubé for the PR
-    ([#245]).
+    locally preserves Postgres semantics. Thanks to serprex for the PR ([#245]).
 
 ### 📚 Documentation
 
@@ -272,8 +271,8 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
     `PERCENT_RANK`, `MIN`/`MAX OVER`) to ClickHouse instead of computing
     them locally. Thanks Kaushik Iska for the PR ([#175]).
 *   Pushdown `bool_and`/`every` as `groupBitAnd`, `bool_or` as `groupBitOr`,
-    and `string_agg` as `groupConcat` to ClickHouse. Thanks Philip Dubé for
-    the PR ([#184]).
+    and `string_agg` as `groupConcat` to ClickHouse. Thanks serprex for the
+    PR ([#184]).
 *   Added mapping to push down the Postgres "SQL Value Functions", including
     `CURRENT_TIMESTAMP`, `CURRENT_USER`, and `CURRENT_DATABASE`.
 *   Changed the behavior of `CURRENT_DATABASE()` to push down the name of the
@@ -288,24 +287,24 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
 ### 🐛 Bug Fixes
 
 *   Improved memory management, fixing potential crashes in out of memory
-    situations. Thanks to Philip Dubé for the PRs ([#173], [#173]).
+    situations. Thanks to serprex for the PRs ([#173], [#173]).
 *   Fixed issue where the `-Merge` suffix was not consistently appended to
-    aggregates on `AggregateFunction` columns. Thanks to Philip Dubé for the
+    aggregates on `AggregateFunction` columns. Thanks to serprex for the
     PR ([#179]).
 *   Fixed `NTILE`, `CUME_DIST`, and `PERCENT_RANK` pushdown failing because
     the FDW emitted a `ROWS UNBOUNDED PRECEDING` frame clause that ClickHouse
-    rejects for ranking functions. Thanks Philip Dubé for the PR ([#184]).
+    rejects for ranking functions. Thanks serprex for the PR ([#184]).
 *   `regr_avgx`, `regr_avgy`, `regr_count`, `regr_intercept`, `regr_r2`,
     `regr_slope`, `regr_sxx`, `regr_sxy`, `regr_syy`, `json_agg_strict`, and
     `jsonb_agg_strict` now evaluate locally instead of being pushed to
-    ClickHouse where they would fail. Thanks Philip Dubé for the PR ([#184]).
+    ClickHouse where they would fail. Thanks serprex for the PR ([#184]).
 
 ### 📔 Notes
 
 *   Eliminated use of a constant that required libcurl 7.87.0, restoring
     support for earlier versions.
 *   Introduced clang-tidy and integrated it into `make lint` and for use in
-    CI. Thanks to Philip Dubé for the PR ([#177]).
+    CI. Thanks to serprex for the PR ([#177]).
 
   [v0.1.10]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.1.6...v0.1.10
   [sub-column syntax]: https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns
@@ -402,7 +401,7 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
     Rahul Mehta for the report (#140).
 *   Fixed http driver array parsing, which previously did not properly parse
     string values and would raise an error on values containing brackets
-    (`[]`). Thanks to Philip Dubé for the spot (#142).
+    (`[]`). Thanks to serprex for the spot (#142).
 *   Fixed a bug where the binary driver would raise an error on an empty
     array.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ adding DML features. Our road map:
 ## Authors
 
 *   [David E. Wheeler](https://justatheory.com/)
+*   [serprex](https://github.com/serprex)
 *   [Ildus Kurbangaliev](https://github.com/ildus)
 *   [Ibrar Ahmed](https://github.com/ibrarahmad)
 

--- a/src/binary/connection.c
+++ b/src/binary/connection.c
@@ -24,6 +24,7 @@
 
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include <openssl/x509v3.h>
 
 #include "binary_internal.h"
 #include "engine.h"
@@ -139,7 +140,13 @@ tls_connect(struct ch_binary_state *s, const char *host)
 				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
 				 errmsg("pg_clickhouse: failed to initialize opensssl"),
 				 errdetail("SSL_CTX_new failed")));
-	SSL_CTX_set_verify(s->ssl_ctx, SSL_VERIFY_NONE, NULL);
+	/* Authenticate server: verify chain against system CAs and hostname. */
+	SSL_CTX_set_verify(s->ssl_ctx, SSL_VERIFY_PEER, NULL);
+	if (SSL_CTX_set_default_verify_paths(s->ssl_ctx) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+				 errmsg("pg_clickhouse: failed to initialize openssl"),
+				 errdetail("could not load default CA certificates")));
 
 	s->ssl = SSL_new(s->ssl_ctx);
 	if (!s->ssl)
@@ -148,13 +155,28 @@ tls_connect(struct ch_binary_state *s, const char *host)
 				 errmsg("pg_clickhouse: failed to initialize opensssl"),
 				 errdetail("SSL_new failed")));
 	SSL_set_tlsext_host_name(s->ssl, host);
+	SSL_set_hostflags(s->ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+	if (SSL_set1_host(s->ssl, host) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+				 errmsg("pg_clickhouse: failed to initialize openssl"),
+				 errdetail("could not set certificate verification host")));
 	SSL_set_fd(s->ssl, s->fd);
 	if (SSL_connect(s->ssl) != 1)
 	{
+		/* verification failures leave error queue empty, use verify result */
+		long		vr = SSL_get_verify_result(s->ssl);
 		unsigned long e = ERR_peek_last_error();
-		char		ebuf[160];
+		char		ebuf[256];
 
-		ERR_error_string_n(e, ebuf, sizeof(ebuf));
+		if (vr != X509_V_OK)
+			snprintf(ebuf, sizeof(ebuf), "certificate verify failed: %s",
+					 X509_verify_cert_error_string(vr));
+		else if (e)
+			ERR_error_string_n(e, ebuf, sizeof(ebuf));
+		else
+			snprintf(ebuf, sizeof(ebuf), "SSL_connect failed");
+
 		ereport(ERROR,
 				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
 				 errmsg("pg_clickhouse: openssl failed to connect"),

--- a/src/binary/decode.c
+++ b/src/binary/decode.c
@@ -718,8 +718,9 @@ read_value(const chc_column * col, const chc_type * type, uint64_t row,
 				int64		power = pow10i[scale];
 
 				*valtype = TIMESTAMPTZOID;
+				/* multiply before divide so scale > 6 keeps sub-second us */
 				return TimestampTzGetDatum(time_t_to_timestamptz(raw / power)
-										   + (raw % power) * (USECS_PER_SEC / power));
+										   + (raw % power) * USECS_PER_SEC / power);
 			}
 		case CHC_UUID:
 			*valtype = UUIDOID;

--- a/src/binary/insert.c
+++ b/src/binary/insert.c
@@ -203,6 +203,13 @@ classify_column(ic_col * ic, const chc_type * t)
 					 errmsg("pg_clickhouse: unsupported LowCardinality variant: %s",
 							chc_type_name(base, NULL))));
 		}
+
+		/*
+		 * Nullable lives inside LowCardinality, not as an outer wrapper, so
+		 * record it here: resolve_col tracks the per-row null bits
+		 * build_lc_dict reads to map nulls onto dict slot 0.
+		 */
+		ic->is_nullable = inner_nullable;
 		ic->layout = IC_LC_STRING;
 		ic->elem_t = base;
 		return;
@@ -545,6 +552,7 @@ append_string_row(ic_col * c, const void *p, size_t n)
 static void
 decimal_text_to_bytes(const char *s, uint32_t scale, size_t width, uint8_t * out)
 {
+	const char *input = s;
 	bool		neg = false;
 
 	if (!s)
@@ -575,6 +583,13 @@ decimal_text_to_bytes(const char *s, uint32_t scale, size_t width, uint8_t * out
 		char		c = i < ilen ? s[i]
 			: i - ilen < flen ? frac[i - ilen]
 			: '0';
+
+		/* reject NaN / Infinity from numeric_out */
+		if (c < '0' || c > '9')
+			ereport(ERROR,
+					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+					 errmsg("pg_clickhouse: cannot encode \"%s\" as ClickHouse Decimal",
+							input)));
 		uint64_t	carry = (uint64_t) (c - '0');
 
 		for (size_t b = 0; b < nwords; b++)

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -411,7 +411,7 @@ SELECT clickhouse_raw_query($$
 		-- TEXTOID
 		c16 Nullable(String), c17 Nullable(FixedString(1)),
 		c18 Nullable(Enum('x'=1)), c19 Nullable(Enum16('x'=1)),
-		-- c20 LowCardinality(Nullable(String)),
+		c20 LowCardinality(Nullable(String)),
 		-- DATEOID
 		c21 Nullable(Date), c22 Nullable(Date32),
 		-- TIMESTAMPOID, TIMESTAMPTZOID
@@ -433,14 +433,14 @@ IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (null_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 INSERT INTO null_vals VALUES(
 	1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -- NULL,
+	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	   NULL, NULL, NULL, NULL, -- ARRAY[NULL]::int[],
 	   NULL, NULL, NULL
 );
 SELECT * FROM null_vals;
- c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 | c11 | c12 | c13 | c14 | c15 | c16 | c17 | c18 | c19 | c21 | c22 | c23 | c24 | c26 | c27 | c28 
-----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
-  1 |    |    |    |    |    |    |    |    |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     | 
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 | c11 | c12 | c13 | c14 | c15 | c16 | c17 | c18 | c19 | c20 | c21 | c22 | c23 | c24 | c26 | c27 | c28 
+----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
+  1 |    |    |    |    |    |    |    |    |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     | 
 (1 row)
 
 -- Test default values.
@@ -496,9 +496,15 @@ SELECT * FROM default_vals;
 ----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
 (0 rows)
 
--- Test unsupported Nullables.
-INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL);
-ERROR:  pg_clickhouse: cannot append NULL to NOT NULL LowCardinality(Nullable(String)) column
+-- LowCardinality(Nullable(String)) round-trips NULL and non-NULL.
+INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL), (2, 'x', 'x', 'lc');
+SELECT * FROM not_nullable ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | x  | x  | 
+  2 | x  | x  | lc
+(2 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -402,7 +402,7 @@ SELECT clickhouse_raw_query($$
 		-- TEXTOID
 		c16 Nullable(String), c17 Nullable(FixedString(1)),
 		c18 Nullable(Enum('x'=1)), c19 Nullable(Enum16('x'=1)),
-		-- c20 LowCardinality(Nullable(String)),
+		c20 LowCardinality(Nullable(String)),
 		-- DATEOID
 		c21 Nullable(Date), c22 Nullable(Date32),
 		-- TIMESTAMPOID, TIMESTAMPTZOID
@@ -424,14 +424,14 @@ IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (null_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 INSERT INTO null_vals VALUES(
 	1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -- NULL,
+	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	   NULL, NULL, NULL, NULL, -- ARRAY[NULL]::int[],
 	   NULL, NULL, NULL
 );
 SELECT * FROM null_vals;
- c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 | c11 | c12 | c13 | c14 | c15 | c16 | c17 | c18 | c19 | c21 | c22 | c23 | c24 | c26 | c27 | c28 
-----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
-  1 |    |    |    |    |    |    |    |    |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     | 
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 | c11 | c12 | c13 | c14 | c15 | c16 | c17 | c18 | c19 | c20 | c21 | c22 | c23 | c24 | c26 | c27 | c28 
+----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
+  1 |    |    |    |    |    |    |    |    |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     |     | 
 (1 row)
 
 -- Test default values.
@@ -487,9 +487,15 @@ SELECT * FROM default_vals;
 ----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
 (0 rows)
 
--- Test unsupported Nullables.
-INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL);
-ERROR:  pg_clickhouse: cannot append NULL to NOT NULL LowCardinality(Nullable(String)) column
+-- LowCardinality(Nullable(String)) round-trips NULL and non-NULL.
+INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL), (2, 'x', 'x', 'lc');
+SELECT * FROM not_nullable ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+  1 | x  | x  | 
+  2 | x  | x  | lc
+(2 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -185,7 +185,7 @@ SELECT clickhouse_raw_query($$
 		-- TEXTOID
 		c16 Nullable(String), c17 Nullable(FixedString(1)),
 		c18 Nullable(Enum('x'=1)), c19 Nullable(Enum16('x'=1)),
-		-- c20 LowCardinality(Nullable(String)),
+		c20 LowCardinality(Nullable(String)),
 		-- DATEOID
 		c21 Nullable(Date), c22 Nullable(Date32),
 		-- TIMESTAMPOID, TIMESTAMPTZOID
@@ -204,7 +204,7 @@ FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 
 INSERT INTO null_vals VALUES(
 	1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -- NULL,
+	   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 	   NULL, NULL, NULL, NULL, -- ARRAY[NULL]::int[],
 	   NULL, NULL, NULL
 );
@@ -258,8 +258,9 @@ INSERT INTO default_vals VALUES(
 
 SELECT * FROM default_vals;
 
--- Test unsupported Nullables.
-INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL);
+-- LowCardinality(Nullable(String)) round-trips NULL and non-NULL.
+INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL), (2, 'x', 'x', 'lc');
+SELECT * FROM not_nullable ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');


### PR DESCRIPTION
Verify TLS certificates
Fix LowCardinality(Nullable(String)) INSERT crash
Fix DateTime64 sub-second precision for scale > 6
Reject NaN/Infinity on Decimal INSERT

Update clickhouse-c with fixes around overflow detection