### PR TITLE
HTTP streaming: gate write_callback pause on having a row-aligned batch

### DIFF
--- a/src/http_streaming.c
+++ b/src/http_streaming.c
@@ -185,10 +185,13 @@ write_callback(void *contents, size_t size, size_t nmemb, void *userp)
 	size_t		needed;
 
 	/*
-	 * If we already have enough bytes, pause WITHOUT consuming this chunk.
-	 * CURL will re-deliver the same data when resumed.
+	 * If we already have at least one row-aligned batch ready (>= fetch_size
+	 * bytes AND a newline present), pause WITHOUT consuming this chunk. CURL
+	 * will re-deliver the same data when resumed. Pausing on byte-count alone
+	 * can starve the parser of the newline it needs when fetch_size is tiny.
 	 */
-	if (self->write_pos >= (size_t) self->fetch_size)
+	if (self->write_pos >= (size_t) self->fetch_size
+		&& memchr(self->buf, '\n', self->write_pos) != NULL)
 	{
 		self->paused = true;
 		return CURL_WRITEFUNC_PAUSE;

--- a/test/expected/stream_out.out
+++ b/test/expected/stream_out.out
@@ -1,5 +1,5 @@
 CREATE SERVER try_http FOREIGN DATA WRAPPER clickhouse_fdw
-    OPTIONS(dbname 'try_test', driver 'http', fetch_size '0');
+    OPTIONS(dbname 'try_test', driver 'http', fetch_size '1');
 CREATE USER MAPPING FOR CURRENT_USER SERVER try_http;
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS try_test');
  clickhouse_raw_query 

--- a/test/expected/stream_out.out
+++ b/test/expected/stream_out.out
@@ -3534,6 +3534,13 @@ SELECT * FROM try_http_ft;
  3499
 (3500 rows)
 
+ALTER SERVER try_http OPTIONS (SET fetch_size '3');
+SELECT count(*), min(c1), max(c1), sum(c1::bigint) FROM try_http_ft;
+ count | min | max  |   sum   
+-------+-----+------+---------
+  3500 |   0 | 3499 | 6123250
+(1 row)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER try_http;
 DROP SERVER try_http CASCADE;
 NOTICE:  drop cascades to foreign table try_http_ft

--- a/test/sql/stream_out.sql
+++ b/test/sql/stream_out.sql
@@ -14,6 +14,10 @@ CREATE FOREIGN TABLE try_http_ft (c1 int)
 
 SELECT * FROM try_http_ft;
 
+ALTER SERVER try_http OPTIONS (SET fetch_size '3');
+
+SELECT count(*), min(c1), max(c1), sum(c1::bigint) FROM try_http_ft;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER try_http;
 DROP SERVER try_http CASCADE;
 SELECT clickhouse_raw_query('DROP DATABASE try_test');


### PR DESCRIPTION
**Targets David's #220 (`streaming-fail`).**

## Root cause

`write_callback` pauses receipt whenever `write_pos >= fetch_size`, regardless of whether a complete row has landed. With small `fetch_size` (David's test uses `1`), this fires before the first `\n` arrives. The downstream chain then collapses:

- `find_batch_end` returns 0 (no row-aligned cut available).
- `pump` returns with `batch_end=0`.
- `ch_http_stream_available` returns 0.
- `ch_http_read_state_init(..., 0)` sets `state->data = NULL`.
- `http_fetch_row_from_state` returns `NULL` — which is also how it signals end-of-stream.

PG sees `NULL`, closes the cursor, and the rest of curl's pending response is discarded. Row counts varied across CI runs (3329, 3329, 3332, 3376 locally) because the loss point depends on where curl's chunk boundaries fell.

## Fix

Gate the pause on the buffer actually containing a `\n`. Same `CURL_WRITEFUNC_PAUSE` idiom; minimum-surface change (5 lines).

```c
if (self->write_pos >= (size_t) self->fetch_size
    && memchr(self->buf, '\n', self->write_pos) != NULL)
{
    self->paused = true;
    return CURL_WRITEFUNC_PAUSE;
}
```

## Test

Also extends `stream_out` with a second `SELECT *` at `fetch_size=3` so we cover a non-degenerate small-fetch case. Both pass: 3500/3500 rows.

## Alternative

Sibling PR `stream-fix-accept-then-pause` restructures `write_callback` to always accept the chunk and pause via `curl_easy_pause` afterward. Slightly larger diff, no curl-internal redelivery cycle, otherwise functionally identical. Pick one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
