### PR TITLE
Improve Regex flag mapping & support regexp_match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,25 @@ All notable changes to this project will be documented in this file. It uses the
 *   [#268] added a `compression` server option for the binary driver to enable
     ClickHouse native protocol compression of query results and `INSERT` data.
     Accepts `none`, `lz4`, or `zstd`, and defaults to `lz4`.
+*   Added mapping for `regexp_match()` to pushdown to `extractGroups()`, or
+    `arraySlice(extractAll(text, pattern), 1, 1)` if the regex contains no
+    capturing groups.
 
 ### 🚀 Distribution
 
 *   [#269] added support for PostgreSQL 19beta1.
+
+### 🐞 Bug Fixes
+
+*   Fixed incorrect translation of regular expression flags introduced in
+    [v0.2.0](#v020--2026-04-13) to more accurately match the Postgres behavior
+    when executing in ClickHouse. We no longer automatically push down `-s`,
+    because it is enabled by default in both Postgres and ClickHouse. But the
+    Postgres flags `s` and `m` cancel each other out, so we always set `s`
+    unless `m` (or its alias, `n`) is enabled, and disable `-s` if `m` is
+    enabled.
+*   No longer push down regular expression functions if the regular expression
+    argument is not a constant.
 
   [#268]: https://github.com/ClickHouse/pg_clickhouse/pull/268
     "ClickHouse/pg_clickhouse#268 add compression option for binary protocol"

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1102,6 +1102,10 @@ equivalents as follows:
 *   `reverse(bytea)`: [reverse](https://clickhouse.com/docs/sql-reference/functions/string-functions#reverse)
 *   `strpos`: [positionUTF8](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#positionutf8)
 *   `regexp_like`: [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
+*   `regexp_match`: [extractGroups](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractGroups)
+    if the regular expression contains parenthesized subexpressions; otherwise
+    [extractAll](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#extractAll)
+    sliced with [arraySlice](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySlice).
 *   `regexp_replace`: [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpOne) or [replaceRegexpOne](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#replaceRegexpAll) when the `g` flag is present
 *   `regexp_split_to_array`: [splitByRegexp](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByRegexp)
 *   `md5`: [MD5](https://clickhouse.com/docs/sql-reference/functions/hash-functions#MD5)
@@ -1315,28 +1319,23 @@ aware of the differences between the two and how pg_clickhouse handles them.
     Becomes
 
     ```sql
-    match(val, concat('(?i-s)', '^VAL\\d'))
+    match(val, concat('(?i)', '^VAL\\d'))
     ```
-
-    Note the inclusion of `-s`; this aligns the behavior with Postgres regular
-    expressions by disabling `s`, which ClickHouse enables by default.
-    pg_clickhouse will not include `-s` if the flags in the Postgres function
-    call include `s`. Unfortunately, this behavior breaks the compatibility of
-    some regular expression in Postgres 24 and earlier.
 
 *   The only flags both support, and therefore can be used when evaluated by
     ClickHouse, are:
 
     *   `i`: case-insensitive
-    *   `m`: multi-line mode:
+    *   `m`: `^` and `$` match begin/end line in addition to begin/end text
+    *   `n`: Postgres alias for `m`
     *   `s`: let `.` match `\n`
     *   `p`: partial newline-sensitive matching (treated the same as `s`)
     *   `t`: tight syntax (the default, removed by pg_clickhouse)
 
-    RE2 supports only these flags; don't use any other [Postgres flags]
+    RE2 supports only these flags; don't use any other [Postgres flags].
 
-*   Any other flags passed to regular expression functions will cause the
-    function not to be pushed down.
+*   Any other flags passed to regular expression functions will prevent
+    pushdown of the function.
 
 *   The exception is `regexp_replace()`, which also supports the `g` flag.
     When `g` is set, pg_clickhouse uses `replaceRegexpAll()` instead of
@@ -1346,6 +1345,10 @@ aware of the differences between the two and how pg_clickhouse handles them.
     refer to the entire match, while in ClickHouse supports `\0` for the
     entire match. Be sure to use `\0` when the function pushes down to
     ClickHouse.
+
+*   Postgres `regexp_match` returns `NULL` when there are no matches, while
+    the expressions it pushes down to return an empty array. Use `COALESCE()`
+    to compare return values compatibly.
 
 To avoid all ambiguity, consider setting
 [pg_clickhouse.pushdown_regex](#pg_clickhousepushdown_regex) to prevent

--- a/src/binary/convert.c
+++ b/src/binary/convert.c
@@ -389,6 +389,9 @@ ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype)
 							   item_type, -1, 0);
 		}
 
+#if PG_VERSION_NUM >= 190000
+		TupleDescFinalize(state->indesc);
+#endif
 		state->indesc = BlessTupleDesc(state->indesc);
 
 		if (!(state->cdef || outtype == RECORDOID || outtype == TEXTOID))

--- a/src/binary/decode.c
+++ b/src/binary/decode.c
@@ -659,7 +659,7 @@ read_value(const chc_column * col, const chc_type * type, uint64_t row,
 				if (v > (uint64_t) PG_INT64_MAX)
 					ereport(ERROR,
 							(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-							 errmsg("value " UINT64_FORMAT " is out of range of bigint",
+							 errmsg("value %" PRIu64 " is out of range of bigint",
 									v)));
 				*valtype = INT8OID;
 				return Int64GetDatum((int64) v);

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -45,6 +45,8 @@
 #define F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT 2768
 #define F_REGEXP_REPLACE_TEXT_TEXT_TEXT 2284
 #define F_REGEXP_REPLACE_TEXT_TEXT_TEXT_TEXT 2285
+#define F_REGEXP_MATCH_TEXT_TEXT 3396
+#define F_REGEXP_MATCH_TEXT_TEXT_TEXT 3397
 
 /*
  * Prior to Postgres 14 EXTRACT mapped directly to DATE_PART.
@@ -412,6 +414,8 @@ chfdw_check_for_custom_function(Oid funcid)
 			case F_BTRIM_TEXT:
 			case F_REGEXP_LIKE_TEXT_TEXT:
 			case F_REGEXP_LIKE_TEXT_TEXT_TEXT:
+			case F_REGEXP_MATCH_TEXT_TEXT:
+			case F_REGEXP_MATCH_TEXT_TEXT_TEXT:
 			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT:
 			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT_TEXT:
 			case F_REGEXP_REPLACE_TEXT_TEXT_TEXT:
@@ -672,6 +676,13 @@ chfdw_check_for_custom_function(Oid funcid)
 				{
 					entry->cf_type = CF_MATCH;
 					strcpy(entry->custom_name, "match");
+					break;
+				}
+			case F_REGEXP_MATCH_TEXT_TEXT:
+			case F_REGEXP_MATCH_TEXT_TEXT_TEXT:
+				{
+					entry->cf_type = CF_REGEX_PG_MATCH;
+					entry->custom_name[0] = '\1';
 					break;
 				}
 			case F_REGEXP_SPLIT_TO_ARRAY_TEXT_TEXT:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -23,12 +23,14 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
+#include "fmgr.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/nodes.h"
 #include "nodes/primnodes.h"
 #include "optimizer/tlist.h"
 #include "parser/parsetree.h"
+#include "regex/regex.h"
 #include "utils/array.h"
 #include "utils/arrayaccess.h"
 #include "utils/builtins.h"
@@ -2563,30 +2565,39 @@ deparseJsonbExtractPath(FuncExpr * node, deparse_expr_cxt * context,
 
 /*
  * Utility function to append regular expression flags to `context->buf`. All
- * flags have already been vetted by `regex_flags_ok()`; this function ignores
- * `t` and always passes `-s` unless `p` or `s` is present.
+ * flags have already been vetted by `regex_flags_ok()`. The flag treatment is:
+ *
+ *  - 't' is ignored
+ *  - 'p' is applied as 's'
+ *  - 's' is passed through
+ *  - 'm' is passed through
+ *  - 'n' is applied as "m-s"
+ *  - Any other flags are applied
+ *
+ * If, after processing all the flags, neither 's' nor 'm' was seen, it
+ * applies 's'. This matches the ClickHouse behavior where 's' is set by
+ * default.
+ *
 */
 static void
 appendRegexFlags(Const * arg, deparse_expr_cxt * context)
 {
-	if (!arg)
-	{
-		appendStringInfoString(context->buf, "-s");
-		return;
-	}
-
 	char	   *flags = TextDatumGetCString(arg->constvalue);
-	bool		got_s = false;
+	bool		got_m = false;
 
 	while (*flags)
 	{
 		switch (*flags)
 		{
-			case 's':
-			case 'p':
-				got_s = true;	/* ClickHouse enables s by default */
+			case 's':			/* Already applied above. */
+			case 'p':			/* Same as s, applied above. */
+				got_m = false;
 				break;
-			case 't':
+			case 't':			/* Always tight syntax, skip. */
+				break;
+			case 'n':			/* Postgres new name for m. */
+			case 'm':
+				got_m = true;
 				break;
 			default:
 				appendStringInfoChar(context->buf, *flags);
@@ -2594,12 +2605,12 @@ appendRegexFlags(Const * arg, deparse_expr_cxt * context)
 		flags++;
 	}
 
-	/*
-	 * Append -s because ClickHouse enables s by default.
-	 * https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match
-	 */
-	if (!got_s)
-		appendStringInfoString(context->buf, "-s");
+	/* Enable s unless m, in which case enable m and disable s. */
+	if (got_m)
+		appendStringInfoString(context->buf, "m-s");
+	else
+		/* Always apply, even though default, since explicitly passed. */
+		appendStringInfoChar(context->buf, 's');
 }
 
 /*
@@ -2607,20 +2618,23 @@ appendRegexFlags(Const * arg, deparse_expr_cxt * context)
  * regular expression argument. It expects the second item in `args` to be the
  * regular expression, and the third, optional item to be the flags. If there
  * are no flags it simply appends the regexp expression. If there are flags,
- * it emits the regular expression as `concat('(?$flags), $regexp)`. This is
- * safe to do because the Postgres parser validates the flags, which must be a
- * string constant.
+ * it emits the regular expression as `concat('(?$flags), $regexp)`,
+ * delegating the actually flag output to `appendRegexFlags()`.
 */
 static void
 appendRegex(List * args, deparse_expr_cxt * context)
 {
+
+	if (list_length(args) <= 2)
+	{
+		/* No flags argument, just append the regexp expression. */
+		deparseExpr((Expr *) list_nth(args, 1), context);
+		return;
+	}
+
 	/* Concatenate the flags with the regexp expression. */
 	appendStringInfoString(context->buf, "concat('(?");
-	if (list_length(args) <= 2)
-		appendRegexFlags(NULL, context);
-	else
-		appendRegexFlags((Const *) list_nth(args, 2), context);
-
+	appendRegexFlags((Const *) list_nth(args, 2), context);
 	appendStringInfoString(context->buf, ")', ");
 	deparseExpr((Expr *) list_nth(args, 1), context);
 	appendStringInfoChar(context->buf, ')');
@@ -3070,6 +3084,24 @@ deparseFuncExpr(FuncExpr * node, deparse_expr_cxt * context)
 					appendStringInfoString(buf, ", ");
 					deparseExpr((Expr *) list_nth(node->args, 2), context);
 					appendStringInfoChar(buf, ')');
+					return;
+				}
+			case CF_REGEX_PG_MATCH:
+				{
+					/* Parse the regex so we can determine if it has captures. */
+					Const	   *arg = (Const *) list_nth(((FuncExpr *) node)->args, 1);
+					pg_regex_t *regex = RE_compile_and_cache(DatumGetTextP(arg->constvalue),
+															 REG_ADVANCED, node->inputcollid);
+
+					/*
+					 * If no captures, use arraySlice(extractAll(), otherwise
+					 * use extractGroups().
+					 */
+					appendStringInfoString(buf, regex->re_nsub ? "extractGroups(" : "arraySlice(extractAll(");
+					deparseExpr((Expr *) linitial(node->args), context);
+					appendStringInfoString(buf, ", ");
+					appendRegex(node->args, context);
+					appendStringInfoString(buf, regex->re_nsub ? ")" : "), 1, 1)");
 					return;
 				}
 			case CF_ARRAY_LENGTH:

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -312,6 +312,7 @@ typedef enum
 	CF_REPLACE_REGEX,			/* regexp_replace → replaceRegexpOne or
 								 * replaceRegexpAll */
 	CF_REGEX_MATCH,				/* ~ POSIX regex operator */
+	CF_REGEX_PG_MATCH,			/* regexp_match → extract or extractAll */
 	CF_REGEX_NO_MATCH,			/* !~ POSIX regex operator */
 	CF_REGEX_ICASE_MATCH,		/* ~* case-insensitive regex operator */
 	CF_REGEX_ICASE_NO_MATCH,	/* !~* case-insensitive regex operator */

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -168,6 +168,7 @@ regex_flags_ok(char *flags, bool global_ok)
 			case 'p':			/* Removed by appendRegexFlags() */
 			case 's':
 			case 'i':
+			case 'n':			/* Replaced by appendRegexFlags() */
 			case 'm':
 				/* Pass through as-is. */
 				break;
@@ -279,7 +280,10 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 				case CF_MATCH:
 				case CF_SPLIT_BY_REGEX:
 				case CF_REPLACE_REGEX:
+				case CF_REGEX_PG_MATCH:
 					{
+						Expr	   *arg;
+
 						/*
 						 * Don't pushdown regular expressions if the GUC is
 						 * false.
@@ -293,7 +297,7 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 
 						if ((list_length(fn->args) >= flags_idx + 1))
 						{
-							Expr	   *arg = (Expr *) list_nth(((FuncExpr *) node)->args, flags_idx);
+							arg = (Expr *) list_nth(((FuncExpr *) node)->args, flags_idx);
 
 							if (!IsA(arg, Const))
 								/* No support for a dynamic value here. */
@@ -306,6 +310,11 @@ chfdw_is_shippable(Node * node, Oid objectId, Oid classId, CHFdwRelationInfo * f
 								/* Using flags unsupported by ClickHouse. */
 								return false;
 						}
+
+						arg = (Expr *) list_nth(((FuncExpr *) node)->args, 1);
+						if (!IsA(arg, Const))
+							/* No support for a dynamic value here. */
+							return false;
 
 						/*
 						 * XXX Additional checks: Examine the regex and:

--- a/test/expected/regex.out
+++ b/test/expected/regex.out
@@ -33,11 +33,11 @@ NOTICE:  (val1)
 NOTICE:  (val2)
 -- Check regexp_split_to_array.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?-s)', ','), val) = ['a','b','c']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(',', val) = ['a','b','c']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
@@ -47,11 +47,11 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?-s)', '\\s+'), val) = ['sleep','no','more']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
@@ -61,11 +61,11 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,mor
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?i-s)', '-t-'), val) = ['aa','bb','cc']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?is)', '-t-'), val) = ['aa','bb','cc']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
@@ -74,100 +74,415 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,c
  aa-T-bb-t-cc
 (1 row)
 
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, val) = '{}'::text[];
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_split_to_array(strings.val, strings.val) = '{}'::text[])
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
 -- Check regexp_replace().
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- No replace returns unmodified string.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val2'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val2'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
- val  
-------
- val2
+ id | val  
+----+------
+  2 | val2
 (1 row)
 
 -- Case-insensitive, refer to capture.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Replace all case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Refer to full match.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
+(1 row)
+
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, val, '') = '';
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_replace(strings.val, strings.val, ''::text) = ''::text)
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+-- Check regexp_match().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, '[01]$'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, '[01]$'), 1, 1) = ['1']))
+(3 rows)
+
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+ regexp_match 
+--------------
+ {1}
+(1 row)
+
+-- No match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, regexp_match(val, '[34]$'::text)
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, '[34]$'), 1, 1) = []))
+(3 rows)
+
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+ id | regexp_match 
+----+--------------
+  1 | 
+  2 | 
+  3 | 
+  4 | 
+  5 | 
+  6 | 
+  7 | 
+  8 | 
+(8 rows)
+
+-- Multiple matches.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, 'ba'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, 'ba'), 1, 1) = ['ba']))
+(3 rows)
+
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+ regexp_match 
+--------------
+ {ba}
+(1 row)
+
+-- Capturing groups.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, '([a-zA-Z0-9]+)@'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((extractGroups(val, '([a-zA-Z0-9]+)@') = ['test']))
+(3 rows)
+
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+ regexp_match 
+--------------
+ {test}
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, 'VAL[01]$'::text, 'i'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?is)', 'VAL[01]$')), 1, 1) = ['val1']))
+(3 rows)
+
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+ regexp_match 
+--------------
+ {val1}
+(1 row)
+
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) = '{1}'::text[];
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_match(strings.val, strings.val) = '{1}'::text[])
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+-- Compare consistency of s and m flag behavior matching \n.
+SELECT regexp_match(val, 'line.') FROM strings
+ WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line.', 's') FROM strings
+ WHERE regexp_match(val, 'line.', 's') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line.', 'm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'm') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line.', 'n'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'n') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line.', 'ms') FROM strings
+ WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'sm') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Compare consistency of s and m flag behavior matching $.
+SELECT regexp_match(val, 'line$'), id FROM strings
+ WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line$', 'm') FROM strings
+ WHERE regexp_match(val, 'line$', 'm') = E'{line}'::text[];
+ regexp_match 
+--------------
+ {line}
+(1 row)
+
+SELECT regexp_match(val, 'line$', 'n') FROM strings
+ WHERE regexp_match(val, 'line$', 'n') = E'{line}'::text[];
+ regexp_match 
+--------------
+ {line}
+(1 row)
+
+SELECT regexp_match(val, 'line$', 's'), id FROM strings
+ WHERE regexp_match(val, 'line$', 's') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line$', 'sm') FROM strings
+ WHERE regexp_match(val, 'line$', 'sm') = E'{line}'::text[];
+ regexp_match 
+--------------
+ {line}
+(1 row)
+
+-- Compare consistency of s and m flag behavior matching ^.
+SELECT regexp_match(val, '^target'), id FROM strings
+ WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, '^target', 'm') FROM strings
+ WHERE regexp_match(val, '^target', 'm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 'n') FROM strings
+ WHERE regexp_match(val, '^target', 'n') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 's'), id FROM strings
+ WHERE regexp_match(val, '^target', 's') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, '^target', 'ms'), id FROM strings
+ WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, '^target', 'sm') FROM strings
+ WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
 (1 row)
 
 -- Ensure no pushdown when we disable it.
@@ -185,9 +500,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
+   Output: id, val
    Filter: (regexp_replace(strings.val, '^x'::text, 'y'::text) = 'val2'::text)
-   Remote SQL: SELECT val FROM regex_test.strings
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, '.') = '{1}'::text[];
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_match(strings.val, '.'::text) = '{1}'::text[])
+   Remote SQL: SELECT id, val FROM regex_test.strings
 (4 rows)
 
 \unset ECHO

--- a/test/expected/regex_1.out
+++ b/test/expected/regex_1.out
@@ -33,24 +33,25 @@ NOTICE:  (val1)
 NOTICE:  (val2)
 -- Check regexp_split_to_array.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?-s)', ','), val) = ['a','b','c']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(',', val) = ['a','b','c']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
- val 
------
-(0 rows)
+  val  
+-------
+ a,b,c
+(1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?-s)', '\\s+'), val) = ['sleep','no','more']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp('\\s+', val) = ['sleep','no','more']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
@@ -60,11 +61,11 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,mor
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?i-s)', '-t-'), val) = ['aa','bb','cc']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?is)', '-t-'), val) = ['aa','bb','cc']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
@@ -73,100 +74,408 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,c
  aa-T-bb-t-cc
 (1 row)
 
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, val) = '{}'::text[];
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: val
+   Filter: (regexp_split_to_array(strings.val, strings.val) = '{}'::text[])
+   Remote SQL: SELECT val FROM regex_test.strings
+(4 rows)
+
 -- Check regexp_replace().
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '[0,1]$', '_xyz') = 'val_xyz'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[0,1]$', '_xyz') = 'val_xyz';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- No replace returns unmodified string.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val2'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, '^x', 'y') = 'val2'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
- val  
-------
- val2
+ id | val  
+----+------
+  2 | val2
 (1 row)
 
 -- Case-insensitive, refer to capture.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', 'VAL([0,1])$'), 'x-\\1') = 'x-1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, 'VAL([0,1])$', 'x-\1', 'i') = 'x-1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '[VL]'), 'x') = 'xal1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'i') = 'xal1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Replace all case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpAll(val, concat('(?ii)', '[VL]'), 'x') = 'xax1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
 (1 row)
 
 -- Refer to full match.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
+   Output: id, val
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((replaceRegexpOne(val, concat('(?i)', '^val'), 'x-\\0') = 'x-val1'))
 (3 rows)
 
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
- val  
-------
- val1
+ id | val  
+----+------
+  1 | val1
+(1 row)
+
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, val, '') = '';
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_replace(strings.val, strings.val, ''::text) = ''::text)
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+-- Check regexp_match().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, '[01]$'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, '[01]$'), 1, 1) = ['1']))
+(3 rows)
+
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+ regexp_match 
+--------------
+ {1}
+(1 row)
+
+-- No match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, regexp_match(val, '[34]$'::text)
+   Remote SQL: SELECT id, val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, '[34]$'), 1, 1) = []))
+(3 rows)
+
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+ id | regexp_match 
+----+--------------
+  1 | 
+  2 | 
+  3 | 
+  4 | 
+  5 | 
+  6 | 
+  7 | 
+  8 | 
+(8 rows)
+
+-- Multiple matches.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, 'ba'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, 'ba'), 1, 1) = ['ba']))
+(3 rows)
+
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+ regexp_match 
+--------------
+ {ba}
+(1 row)
+
+-- Capturing groups.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, '([a-zA-Z0-9]+)@'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((extractGroups(val, '([a-zA-Z0-9]+)@') = ['test']))
+(3 rows)
+
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+ regexp_match 
+--------------
+ {test}
+(1 row)
+
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: regexp_match(val, 'VAL[01]$'::text, 'i'::text)
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?is)', 'VAL[01]$')), 1, 1) = ['val1']))
+(3 rows)
+
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+ regexp_match 
+--------------
+ {val1}
+(1 row)
+
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) = '{1}'::text[];
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_match(strings.val, strings.val) = '{1}'::text[])
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+-- Compare consistency of s and m flag behavior matching \n.
+SELECT regexp_match(val, 'line.') FROM strings
+ WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line.', 's') FROM strings
+ WHERE regexp_match(val, 'line.', 's') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line.', 'm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'm') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line.', 'n'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'n') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line.', 'ms') FROM strings
+ WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'sm') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Compare consistency of s and m flag behavior matching $.
+SELECT regexp_match(val, 'line$'), id FROM strings
+ WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line$', 'm') FROM strings
+ WHERE regexp_match(val, 'line$', 'm') = E'{line}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line$', 'n') FROM strings
+ WHERE regexp_match(val, 'line$', 'n') = E'{line}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line$', 's'), id FROM strings
+ WHERE regexp_match(val, 'line$', 's') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line$', 'sm') FROM strings
+ WHERE regexp_match(val, 'line$', 'sm') = E'{line}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- Compare consistency of s and m flag behavior matching ^.
+SELECT regexp_match(val, '^target'), id FROM strings
+ WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, '^target', 'm') FROM strings
+ WHERE regexp_match(val, '^target', 'm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 'n') FROM strings
+ WHERE regexp_match(val, '^target', 'n') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 's'), id FROM strings
+ WHERE regexp_match(val, '^target', 's') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, '^target', 'ms'), id FROM strings
+ WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, '^target', 'sm') FROM strings
+ WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
 (1 row)
 
 -- Ensure no pushdown when we disable it.
@@ -184,9 +493,18 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Foreign Scan on public.strings
-   Output: val
+   Output: id, val
    Filter: (regexp_replace(strings.val, '^x'::text, 'y'::text) = 'val2'::text)
-   Remote SQL: SELECT val FROM regex_test.strings
+   Remote SQL: SELECT id, val FROM regex_test.strings
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, '.') = '{1}'::text[];
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Foreign Scan on public.strings
+   Output: id, val
+   Filter: (regexp_match(strings.val, '.'::text) = '{1}'::text[])
+   Remote SQL: SELECT id, val FROM regex_test.strings
 (4 rows)
 
 \unset ECHO

--- a/test/sql/regex.sql
+++ b/test/sql/regex.sql
@@ -7,21 +7,22 @@ SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS regex_test');
 SELECT clickhouse_raw_query('CREATE DATABASE regex_test');
 
 SELECT clickhouse_raw_query($$
-	CREATE TABLE regex_test.strings(val String) engine=TinyLog()
+	CREATE TABLE regex_test.strings(id Int32, val String) engine=TinyLog()
 $$);
 
 SELECT clickhouse_raw_query($$
 	INSERT INTO regex_test.strings
-	VALUES ('val1'),
-		   ('val2'),
-		   ('a,b,c'),
-		   ('foo,bar,baz'),
-		   ('sleep   no   more'),
-		   ('aa-T-bb-t-cc')
+	VALUES (1, 'val1'),
+		   (2, 'val2'),
+		   (3, 'a,b,c'),
+		   (4, 'foo,bar,baz'),
+		   (5, 'sleep   no   more'),
+		   (6, 'aa-T-bb-t-cc'),
+           (7, 'test@example.com, user@hi.example'),
+           (8, 'line\ntarget')
 $$);
 
-CREATE FOREIGN TABLE strings (val text) SERVER regex_loopback;
-
+CREATE FOREIGN TABLE strings (id int, val text) SERVER regex_loopback;
 
 \unset ECHO
 -- Use DO to test functions available in Postgres 15+
@@ -35,21 +36,21 @@ DECLARE
         $${
           "func": "regexp_like",
           "where": "regexp_like(val, '^val\\d')",
-          "push": "(match(val, concat('(?-s)', '^val\\\\d')))"
+          "push": "(match(val, '^val\\\\d'))"
         }$$,
         $${
           "func": "case-insensitive regexp_like",
           "where": "regexp_like(val, '^VAL\\d', 'i')",
-          "push": "(match(val, concat('(?i-s)', '^VAL\\\\d')))"
+          "push": "(match(val, concat('(?is)', '^VAL\\\\d')))"
         }$$,
         $${
           "func": "regexp_like with unsupported flag",
-          "where": "regexp_like(val, '^VAL\\d', 'in')"
+          "where": "regexp_like(val, '^VAL\\d', 'iw')"
         }$$,
         $${
           "func": "regexp_like with t flag",
           "where": "regexp_like(val, '^VAL\\d', 'it')",
-          "push": "(match(val, concat('(?i-s)', '^VAL\\\\d')))"
+          "push": "(match(val, concat('(?is)', '^VAL\\\\d')))"
         }$$
     ];
 BEGIN
@@ -96,6 +97,8 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array
 SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,more}'::text[];
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
 SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, val) = '{}'::text[];
 
 -- Check regexp_replace().
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -121,11 +124,82 @@ SELECT * FROM strings WHERE regexp_replace(val, '[VL]', 'x', 'gig') = 'xax1';
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
 SELECT * FROM strings WHERE regexp_replace(val, '^val', 'x-\0', 'i') = 'x-val1';
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, val, '') = '';
+
+-- Check regexp_match().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+SELECT regexp_match(val, '[01]$') FROM strings WHERE regexp_match(val, '[01]$') = '{1}'::text[];
+-- No match.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+SELECT id, regexp_match(val, '[34]$') FROM strings WHERE regexp_match(val, '[34]$') = '{}'::text[];
+-- Multiple matches.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+SELECT regexp_match(val, 'ba') FROM strings WHERE regexp_match(val, 'ba') = '{ba}'::text[];
+-- Capturing groups.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val, '([a-zA-Z0-9]+)@') = '{test}'::text[];
+-- Case-insensitive.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
+-- No pushdown when the regex is not a constant.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) = '{1}'::text[];
+
+-- Compare consistency of s and m flag behavior matching \n.
+SELECT regexp_match(val, 'line.') FROM strings
+ WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line.', 's') FROM strings
+ WHERE regexp_match(val, 'line.', 's') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line.', 'm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'm') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line.', 'n'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'n') = '{}'::text[] ORDER BY id;
+-- Last flag overrides.
+SELECT regexp_match(val, 'line.', 'ms') FROM strings
+ WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'sm') = '{}'::text[] ORDER BY id;
+
+-- Compare consistency of s and m flag behavior matching $.
+SELECT regexp_match(val, 'line$'), id FROM strings
+ WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line$', 'm') FROM strings
+ WHERE regexp_match(val, 'line$', 'm') = E'{line}'::text[];
+SELECT regexp_match(val, 'line$', 'n') FROM strings
+ WHERE regexp_match(val, 'line$', 'n') = E'{line}'::text[];
+SELECT regexp_match(val, 'line$', 's'), id FROM strings
+ WHERE regexp_match(val, 'line$', 's') = '{}'::text[] ORDER BY id;
+-- Last flag overrides.
+SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line$', 'sm') FROM strings
+ WHERE regexp_match(val, 'line$', 'sm') = E'{line}'::text[];
+
+-- Compare consistency of s and m flag behavior matching ^.
+SELECT regexp_match(val, '^target'), id FROM strings
+ WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, '^target', 'm') FROM strings
+ WHERE regexp_match(val, '^target', 'm') = E'{target}'::text[];
+SELECT regexp_match(val, '^target', 'n') FROM strings
+ WHERE regexp_match(val, '^target', 'n') = E'{target}'::text[];
+SELECT regexp_match(val, '^target', 's'), id FROM strings
+ WHERE regexp_match(val, '^target', 's') = '{}'::text[] ORDER BY id;
+-- Last flag overrides.
+SELECT regexp_match(val, '^target', 'ms'), id FROM strings
+ WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, '^target', 'sm') FROM strings
+ WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
 
 -- Ensure no pushdown when we disable it.
 SET pg_clickhouse.pushdown_regex = 'false';
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, ',') = '{a,b,c}'::text[];
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_replace(val, '^x', 'y') = 'val2';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, '.') = '{1}'::text[];
 
 \unset ECHO
 -- Use DO to test functions available in Postgres 15+


### PR DESCRIPTION
Through some experimentation, and closer documentation reading, we determined that Postgres, like ClickHouse, enables the `s` regular expression flag by default. Thus 4f1acd6 wrongly introduced passing `-s` when no `s` was supplied. Investigation further revealed that the `Postgres` `m` and `s` flags cancel each other out in order of declaration. In other words `ms` resolves to `s` and `sm` resolves to `m`. Fun, right?

Update `appendRegexFlags()` to remove appending `-s` and to always append `s` unless `m` has been seen, in which case append `m-s`. This ensures that they properly cancel each other out. Also treat `n` as `m`, since they are the same in Postgres. Continue to pass `p` as `s`, even though it's almost certainly inaccurate. Will return to this issue in a future commit. Update the documentation to reflect these behavioral changes.

Update `appendRegex()` to skip appending flags if there are none, and to continue to delegate to `appendRegexFlags()` to append the flags.

Add support for pushing down `regexp_match()`. Parse the regular expression and push down to `extractGroups()` if it has matching groups and to `arraySlice(extractAll(text, pattern), 1, 1)` if it does not. Add a check that requires the regular expression only be provided as a constant expression, and refuse to push down if it's not, so that we know we have a regular expression to parse. Add a note to the documentation that ClickHouse returns an empty array on no match while Postgres returns `NULL`.

Use `regexp_match()` in new tests to validate the passing of regular expression flags, since it's supported back to at least Postgres 13, so is easier to use than the other regex functions.

While at it, change `UINT64_FORMAT` to `PRIu64`. For some reason it was incorrectly set to `u` on Postgres 17 on macOS, but correctly set to `PRIu64` in later versions. Just sue `PRIu64` to avoid that issue.

Also fix a shared memory crash on Postgres 19beta1, observed on macOS, by calling `TupleDescFinalize()` before `BlessTupleDesc()`, as required by Postgres commit [c456e3911] (Postgres itself added the calls it the parent commit, [503620311]).

  [c456e3911]: https://github.com/postgres/postgres/commit/c456e3911
  [503620311]: https://github.com/postgres/postgres/commit/503620311