### PR TITLE
Parse regex flags separate from emitting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ All notable changes to this project will be documented in this file. It uses the
     [v0.2.0](#v020--2026-04-13) to more accurately match the Postgres behavior
     when executing in ClickHouse. We no longer automatically push down `-s`,
     because it is enabled by default in both Postgres and ClickHouse. But the
-    Postgres flags `s` and `m` cancel each other out, so we always set `s`
-    unless `m` (or its alias, `n`) is enabled, and disable `-s` if `m` is
-    enabled.
+    Postgres flags `s` and `m` cancel each other out, so we only set `s` if
+    there is no `m` and if there is an `m` we set `(?m-s)`.
+*   Pushdown of the `p` regular expression fag as `-s` instead of `s` to more
+    accurately match the Postgres behavior.
 *   No longer push down regular expression functions if the regular expression
     argument is not a constant.
 
@@ -64,6 +65,8 @@ pg_clickhouse v0.3 will get its benefits on reload without needing to
     `re2extractallgroupshorizontal`, `re2extractallgroupsvertical`,
     `re2regexpquotemeta`, and `re2splitbyregexp`. Thanks to serprex for the PR
     ([#232]).
+*   Add pushdown for the Postgres regular expression flag `w` as `m` in
+    ClickHouse.
 
 ### 🐞 Bug Fixes
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1325,14 +1325,25 @@ aware of the differences between the two and how pg_clickhouse handles them.
 *   The only flags both support, and therefore can be used when evaluated by
     ClickHouse, are:
 
-    *   `i`: case-insensitive
-    *   `m`: `^` and `$` match begin/end line in addition to begin/end text
-    *   `n`: Postgres alias for `m`
-    *   `s`: let `.` match `\n`
-    *   `p`: partial newline-sensitive matching (treated the same as `s`)
-    *   `t`: tight syntax (the default, removed by pg_clickhouse)
+    | Flag | As    | Notes |
+    | ---- | ----- | -------------------------------------------------------------- |
+    | `i`  | `i`   | case-insensitive matching                                      |
+    | `m`  | `m-s` | `^` and `$` match begin/end line in addition to begin/end text |
+    | `n`  | `m-s` | Postgres alias for `m`                                         |
+    | `p`  | `-s`  | don't let `.` and `[^x]` match `\n`                            |
+    | `s`  | `s`   | let `.` and `[^x]` match `\n`                                  |
+    | `t`  |       | tight syntax, ignored                                          |
+    | `w`  | `m`   | inverse partial newline-sensitive matching                     |
 
     RE2 supports only these flags; don't use any other [Postgres flags].
+
+*   In Postgres, `m` and `p` prevent negated character classes (`[^xyz]`) from
+    matching a newline, while the ClickHouse equivalents do not. For example,
+    when evaluating either of these regular expressions against the string
+    `a\nb`, Postgres returns false and ClickHouse returns true:
+
+    *   `(?m)a[^x]b`
+    *   `(?p)a[^x]b`
 
 *   Any other flags passed to regular expression functions will prevent
     pushdown of the function.

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2567,50 +2567,82 @@ deparseJsonbExtractPath(FuncExpr * node, deparse_expr_cxt * context,
  * Utility function to append regular expression flags to `context->buf`. All
  * flags have already been vetted by `regex_flags_ok()`. The flag treatment is:
  *
- *  - 't' is ignored
- *  - 'p' is applied as 's'
- *  - 's' is passed through
- *  - 'm' is passed through
- *  - 'n' is applied as "m-s"
- *  - Any other flags are applied
  *
- * If, after processing all the flags, neither 's' nor 'm' was seen, it
- * applies 's'. This matches the ClickHouse behavior where 's' is set by
- * default.
+ *  - 'i' is applied as 'i'
+ *  - 'm' is applied as "m-s"
+ *  - 'n' is applied as "m-s"
+ *  - 'p' is applied as "-s"
+ *  - 's' is applied as 's'
+ *  - 't' is ignored
+ *  - 'w' is applied as 'm'
+
+ *  Whichever of the `[smpw]` flags appears last is the only one applied.
  *
 */
 static void
 appendRegexFlags(Const * arg, deparse_expr_cxt * context)
 {
-	char	   *flags = TextDatumGetCString(arg->constvalue);
-	bool		got_m = false;
-
-	while (*flags)
+	char	   *str = TextDatumGetCString(arg->constvalue);
+	enum
 	{
-		switch (*flags)
+		flag_0 = 0,
+		flag_i = 1,
+		flag_m = 2,
+		flag_p = 4,
+		flag_s = 8,
+		flag_w = 16,
+	};
+	uint16		flags = flag_0;
+
+	/* Iterate over the flags. */
+	while (*str)
+	{
+		switch (*str)
 		{
-			case 's':			/* Already applied above. */
-			case 'p':			/* Same as s, applied above. */
-				got_m = false;
+			case 'i':
+				flags |= flag_i;
+				break;
+			case 'm':
+			case 'n':			/* Postgres new name for m. */
+				flags |= flag_m;
+				flags &= ~flag_s;	/* Cancels out s. */
+				flags &= ~flag_p;	/* Cancels out p. */
+				flags &= ~flag_w;	/* Cancels out w. */
+				break;
+			case 'p':
+				flags |= flag_p;
+				flags &= ~flag_m;	/* Cancels out m. */
+				flags &= ~flag_s;	/* Cancels out s. */
+				flags &= ~flag_w;	/* Cancels out w. */
+				break;
+			case 's':
+				flags |= flag_s;
+				flags &= ~flag_m;	/* Cancels out m. */
+				flags &= ~flag_p;	/* Cancels out p. */
+				flags &= ~flag_w;	/* Cancels out w. */
 				break;
 			case 't':			/* Always tight syntax, skip. */
 				break;
-			case 'n':			/* Postgres new name for m. */
-			case 'm':
-				got_m = true;
+			case 'w':
+				flags |= flag_w;
+				flags &= ~flag_m;	/* Cancels out m. */
+				flags &= ~flag_p;	/* Cancels out p. */
+				flags &= ~flag_s;	/* Cancels out s. */
 				break;
-			default:
-				appendStringInfoChar(context->buf, *flags);
 		}
-		flags++;
+		str++;
 	}
 
-	/* Enable s unless m, in which case enable m and disable s. */
-	if (got_m)
+	if (flags & flag_i)
+		appendStringInfoChar(context->buf, 'i');
+	if (flags & flag_m)
 		appendStringInfoString(context->buf, "m-s");
-	else
-		/* Always apply, even though default, since explicitly passed. */
+	if (flags & flag_p)
+		appendStringInfoString(context->buf, "-s");
+	if (flags & flag_s)
 		appendStringInfoChar(context->buf, 's');
+	if (flags & flag_w)
+		appendStringInfoChar(context->buf, 'm');
 }
 
 /*

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -164,12 +164,13 @@ regex_flags_ok(char *flags, bool global_ok)
 	{
 		switch (*flags)
 		{
-			case 't':			/* Removed by appendRegexFlags() */
-			case 'p':			/* Removed by appendRegexFlags() */
-			case 's':
 			case 'i':
-			case 'n':			/* Replaced by appendRegexFlags() */
 			case 'm':
+			case 'n':
+			case 'p':
+			case 's':
+			case 't':
+			case 'w':
 				/* Pass through as-is. */
 				break;
 			case 'g':

--- a/test/expected/regex.out
+++ b/test/expected/regex.out
@@ -25,6 +25,9 @@ NOTICE:  (val2)
 NOTICE:  case-insensitive regexp_like PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
+NOTICE:  regexp_like with si PUSHED DOWN: t
+NOTICE:  (val1)
+NOTICE:  (val2)
 NOTICE:  regexp_like with unsupported flag NOT PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
@@ -61,11 +64,11 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,mor
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?is)', '-t-'), val) = ['aa','bb','cc']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
@@ -264,11 +267,11 @@ SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val,
 -- Case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: regexp_match(val, 'VAL[01]$'::text, 'i'::text)
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?is)', 'VAL[01]$')), 1, 1) = ['val1']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?i)', 'VAL[01]$')), 1, 1) = ['val1']))
 (3 rows)
 
 SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
@@ -287,7 +290,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) 
    Remote SQL: SELECT id, val FROM regex_test.strings
 (4 rows)
 
--- Compare consistency of s and m flag behavior matching \n.
+-- Compare consistency of `.` matching a newline.
 SELECT regexp_match(val, 'line.') FROM strings
  WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
  regexp_match 
@@ -332,6 +335,28 @@ SELECT regexp_match(val, 'line.', 'n'), id FROM strings
               |  8
 (8 rows)
 
+SELECT regexp_match(val, 'line.', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line.', 'w') FROM strings
+ WHERE regexp_match(val, 'line.', 'w') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
 -- Last flag overrides.
 SELECT regexp_match(val, 'line.', 'ms') FROM strings
  WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
@@ -355,7 +380,72 @@ SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
               |  8
 (8 rows)
 
--- Compare consistency of s and m flag behavior matching $.
+SELECT regexp_match(val, 'line.', 'mspw') FROM strings
+ WHERE regexp_match(val, 'line.', 'mspw') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+ -- Compare consistency of `[^x]` matching a newline.
+SELECT regexp_match(val, 'line[^x]') FROM strings
+ WHERE regexp_match(val, 'line[^x]') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line[^x]', 's') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 's') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+-- m, n match in CH but not PG
+SELECT regexp_match(val, 'line[^x]', 'm') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'm') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ 
+(1 row)
+
+SELECT regexp_match(val, 'line[^x]', 'n') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'n') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ 
+(1 row)
+
+SELECT regexp_match(val, 'line[^x]', 'p') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'p') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ 
+(1 row)
+
+-- w matches in both.
+SELECT regexp_match(val, 'line[^x]', 'w') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'w') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line[^x]', 'msw') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'msw') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+-- Compare consistency of `$` end of line.
 SELECT regexp_match(val, 'line$'), id FROM strings
  WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
  regexp_match | id 
@@ -398,6 +488,29 @@ SELECT regexp_match(val, 'line$', 's'), id FROM strings
               |  8
 (8 rows)
 
+-- p matches in CH but not PG.
+SELECT regexp_match(val, 'line$', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- w matches in both.
+SELECT regexp_match(val, 'line$', 'w') FROM strings
+ WHERE regexp_match(val, 'line$', 'w') = E'{line}'::text[];
+ regexp_match 
+--------------
+ {line}
+(1 row)
+
 -- Last flag overrides.
 SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
  WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
@@ -420,7 +533,14 @@ SELECT regexp_match(val, 'line$', 'sm') FROM strings
  {line}
 (1 row)
 
--- Compare consistency of s and m flag behavior matching ^.
+SELECT regexp_match(val, 'line$', 'smw') FROM strings
+ WHERE regexp_match(val, 'line$', 'smw') = E'{line}'::text[];
+ regexp_match 
+--------------
+ {line}
+(1 row)
+
+-- Compare consistency of `^` start of line.
 SELECT regexp_match(val, '^target'), id FROM strings
  WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
  regexp_match | id 
@@ -463,6 +583,29 @@ SELECT regexp_match(val, '^target', 's'), id FROM strings
               |  8
 (8 rows)
 
+-- p matches in CH but not PG.
+SELECT regexp_match(val, '^target', 'p'), id FROM strings
+ WHERE regexp_match(val, '^target', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- w matches in both.
+SELECT regexp_match(val, '^target', 'w') FROM strings
+ WHERE regexp_match(val, '^target', 'w') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
 -- Last flag overrides.
 SELECT regexp_match(val, '^target', 'ms'), id FROM strings
  WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
@@ -480,6 +623,13 @@ SELECT regexp_match(val, '^target', 'ms'), id FROM strings
 
 SELECT regexp_match(val, '^target', 'sm') FROM strings
  WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 'msw') FROM strings
+ WHERE regexp_match(val, '^target', 'msw') = E'{target}'::text[];
  regexp_match 
 --------------
  {target}

--- a/test/expected/regex_1.out
+++ b/test/expected/regex_1.out
@@ -25,6 +25,9 @@ NOTICE:  (val2)
 NOTICE:  case-insensitive regexp_like PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
+NOTICE:  regexp_like with si PUSHED DOWN: t
+NOTICE:  (val1)
+NOTICE:  (val2)
 NOTICE:  regexp_like with unsupported flag NOT PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
@@ -61,11 +64,11 @@ SELECT val FROM strings WHERE regexp_split_to_array(val, '\s+') = '{sleep,no,mor
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: val
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?is)', '-t-'), val) = ['aa','bb','cc']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((splitByRegexp(concat('(?i)', '-t-'), val) = ['aa','bb','cc']))
 (3 rows)
 
 SELECT val FROM strings WHERE regexp_split_to_array(val, '-t-', 'i') = '{aa,bb,cc}'::text[];
@@ -264,11 +267,11 @@ SELECT regexp_match(val, '([a-zA-Z0-9]+)@') FROM strings WHERE regexp_match(val,
 -- Case-insensitive.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.strings
    Output: regexp_match(val, 'VAL[01]$'::text, 'i'::text)
-   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?is)', 'VAL[01]$')), 1, 1) = ['val1']))
+   Remote SQL: SELECT val FROM regex_test.strings WHERE ((arraySlice(extractAll(val, concat('(?i)', 'VAL[01]$')), 1, 1) = ['val1']))
 (3 rows)
 
 SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, 'VAL[01]$', 'i') = '{val1}'::text[];
@@ -287,7 +290,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) 
    Remote SQL: SELECT id, val FROM regex_test.strings
 (4 rows)
 
--- Compare consistency of s and m flag behavior matching \n.
+-- Compare consistency of `.` matching a newline.
 SELECT regexp_match(val, 'line.') FROM strings
  WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
  regexp_match 
@@ -330,6 +333,26 @@ SELECT regexp_match(val, 'line.', 'n'), id FROM strings
               |  8
 (8 rows)
 
+SELECT regexp_match(val, 'line.', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+SELECT regexp_match(val, 'line.', 'w') FROM strings
+ WHERE regexp_match(val, 'line.', 'w') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
 -- Last flag overrides.
 SELECT regexp_match(val, 'line.', 'ms') FROM strings
  WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
@@ -351,7 +374,61 @@ SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
               |  8
 (8 rows)
 
--- Compare consistency of s and m flag behavior matching $.
+SELECT regexp_match(val, 'line.', 'mspw') FROM strings
+ WHERE regexp_match(val, 'line.', 'mspw') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+ -- Compare consistency of `[^x]` matching a newline.
+SELECT regexp_match(val, 'line[^x]') FROM strings
+ WHERE regexp_match(val, 'line[^x]') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+ {"line      +
+ "}
+(1 row)
+
+SELECT regexp_match(val, 'line[^x]', 's') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 's') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- m, n match in CH but not PG
+SELECT regexp_match(val, 'line[^x]', 'm') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'm') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line[^x]', 'n') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'n') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+SELECT regexp_match(val, 'line[^x]', 'p') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'p') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- w matches in both.
+SELECT regexp_match(val, 'line[^x]', 'w') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'w') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- Last flag overrides.
+SELECT regexp_match(val, 'line[^x]', 'msw') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'msw') = E'{"line\n"}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- Compare consistency of `$` end of line.
 SELECT regexp_match(val, 'line$'), id FROM strings
  WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
  regexp_match | id 
@@ -392,6 +469,28 @@ SELECT regexp_match(val, 'line$', 's'), id FROM strings
               |  8
 (8 rows)
 
+-- p matches in CH but not PG.
+SELECT regexp_match(val, 'line$', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- w matches in both.
+SELECT regexp_match(val, 'line$', 'w') FROM strings
+ WHERE regexp_match(val, 'line$', 'w') = E'{line}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
 -- Last flag overrides.
 SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
  WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
@@ -413,7 +512,13 @@ SELECT regexp_match(val, 'line$', 'sm') FROM strings
 --------------
 (0 rows)
 
--- Compare consistency of s and m flag behavior matching ^.
+SELECT regexp_match(val, 'line$', 'smw') FROM strings
+ WHERE regexp_match(val, 'line$', 'smw') = E'{line}'::text[];
+ regexp_match 
+--------------
+(0 rows)
+
+-- Compare consistency of `^` start of line.
 SELECT regexp_match(val, '^target'), id FROM strings
  WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
  regexp_match | id 
@@ -456,6 +561,29 @@ SELECT regexp_match(val, '^target', 's'), id FROM strings
               |  8
 (8 rows)
 
+-- p matches in CH but not PG.
+SELECT regexp_match(val, '^target', 'p'), id FROM strings
+ WHERE regexp_match(val, '^target', 'p') = '{}'::text[] ORDER BY id;
+ regexp_match | id 
+--------------+----
+              |  1
+              |  2
+              |  3
+              |  4
+              |  5
+              |  6
+              |  7
+              |  8
+(8 rows)
+
+-- w matches in both.
+SELECT regexp_match(val, '^target', 'w') FROM strings
+ WHERE regexp_match(val, '^target', 'w') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
 -- Last flag overrides.
 SELECT regexp_match(val, '^target', 'ms'), id FROM strings
  WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
@@ -473,6 +601,13 @@ SELECT regexp_match(val, '^target', 'ms'), id FROM strings
 
 SELECT regexp_match(val, '^target', 'sm') FROM strings
  WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
+ regexp_match 
+--------------
+ {target}
+(1 row)
+
+SELECT regexp_match(val, '^target', 'msw') FROM strings
+ WHERE regexp_match(val, '^target', 'msw') = E'{target}'::text[];
  regexp_match 
 --------------
  {target}

--- a/test/sql/regex.sql
+++ b/test/sql/regex.sql
@@ -41,16 +41,21 @@ DECLARE
         $${
           "func": "case-insensitive regexp_like",
           "where": "regexp_like(val, '^VAL\\d', 'i')",
+          "push": "(match(val, concat('(?i)', '^VAL\\\\d')))"
+        }$$,
+        $${
+          "func": "regexp_like with si",
+          "where": "regexp_like(val, '^VAL\\d', 'si')",
           "push": "(match(val, concat('(?is)', '^VAL\\\\d')))"
         }$$,
         $${
           "func": "regexp_like with unsupported flag",
-          "where": "regexp_like(val, '^VAL\\d', 'iw')"
+          "where": "regexp_like(val, '^VAL\\d', 'ix')"
         }$$,
         $${
           "func": "regexp_like with t flag",
           "where": "regexp_like(val, '^VAL\\d', 'it')",
-          "push": "(match(val, concat('(?is)', '^VAL\\\\d')))"
+          "push": "(match(val, concat('(?i)', '^VAL\\\\d')))"
         }$$
     ];
 BEGIN
@@ -76,6 +81,9 @@ BEGIN
         RAISE NOTICE '(val1)';
         RAISE NOTICE '(val2)';
         RAISE NOTICE 'case-insensitive regexp_like PUSHED DOWN: t';
+        RAISE NOTICE '(val1)';
+        RAISE NOTICE '(val2)';
+        RAISE NOTICE 'regexp_like with si PUSHED DOWN: t';
         RAISE NOTICE '(val1)';
         RAISE NOTICE '(val2)';
         RAISE NOTICE 'regexp_like with unsupported flag NOT PUSHED DOWN: t';
@@ -150,7 +158,7 @@ SELECT regexp_match(val, 'VAL[01]$', 'i') FROM strings WHERE regexp_match(val, '
 -- No pushdown when the regex is not a constant.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, val) = '{1}'::text[];
 
--- Compare consistency of s and m flag behavior matching \n.
+-- Compare consistency of `.` matching a newline.
 SELECT regexp_match(val, 'line.') FROM strings
  WHERE regexp_match(val, 'line.') = E'{"line\n"}'::text[];
 SELECT regexp_match(val, 'line.', 's') FROM strings
@@ -159,13 +167,38 @@ SELECT regexp_match(val, 'line.', 'm'), id FROM strings
  WHERE regexp_match(val, 'line.', 'm') = '{}'::text[] ORDER BY id;
 SELECT regexp_match(val, 'line.', 'n'), id FROM strings
  WHERE regexp_match(val, 'line.', 'n') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line.', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line.', 'p') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line.', 'w') FROM strings
+ WHERE regexp_match(val, 'line.', 'w') = E'{"line\n"}'::text[];
 -- Last flag overrides.
 SELECT regexp_match(val, 'line.', 'ms') FROM strings
  WHERE regexp_match(val, 'line.', 'ms') = E'{"line\n"}'::text[];
 SELECT regexp_match(val, 'line.', 'sm'), id FROM strings
  WHERE regexp_match(val, 'line.', 'sm') = '{}'::text[] ORDER BY id;
+SELECT regexp_match(val, 'line.', 'mspw') FROM strings
+ WHERE regexp_match(val, 'line.', 'mspw') = E'{"line\n"}'::text[];
 
--- Compare consistency of s and m flag behavior matching $.
+ -- Compare consistency of `[^x]` matching a newline.
+SELECT regexp_match(val, 'line[^x]') FROM strings
+ WHERE regexp_match(val, 'line[^x]') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line[^x]', 's') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 's') = E'{"line\n"}'::text[];
+-- m, n match in CH but not PG
+SELECT regexp_match(val, 'line[^x]', 'm') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'm') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line[^x]', 'n') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'n') = E'{"line\n"}'::text[];
+SELECT regexp_match(val, 'line[^x]', 'p') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'p') = E'{"line\n"}'::text[];
+-- w matches in both.
+SELECT regexp_match(val, 'line[^x]', 'w') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'w') = E'{"line\n"}'::text[];
+-- Last flag overrides.
+SELECT regexp_match(val, 'line[^x]', 'msw') FROM strings
+ WHERE regexp_match(val, 'line[^x]', 'msw') = E'{"line\n"}'::text[];
+
+-- Compare consistency of `$` end of line.
 SELECT regexp_match(val, 'line$'), id FROM strings
  WHERE regexp_match(val, 'line$') = '{}'::text[] ORDER BY id;
 SELECT regexp_match(val, 'line$', 'm') FROM strings
@@ -174,13 +207,21 @@ SELECT regexp_match(val, 'line$', 'n') FROM strings
  WHERE regexp_match(val, 'line$', 'n') = E'{line}'::text[];
 SELECT regexp_match(val, 'line$', 's'), id FROM strings
  WHERE regexp_match(val, 'line$', 's') = '{}'::text[] ORDER BY id;
+-- p matches in CH but not PG.
+SELECT regexp_match(val, 'line$', 'p'), id FROM strings
+ WHERE regexp_match(val, 'line$', 'p') = '{}'::text[] ORDER BY id;
+-- w matches in both.
+SELECT regexp_match(val, 'line$', 'w') FROM strings
+ WHERE regexp_match(val, 'line$', 'w') = E'{line}'::text[];
 -- Last flag overrides.
 SELECT regexp_match(val, 'line$', 'ms'), id FROM strings
  WHERE regexp_match(val, 'line$', 'ms') = '{}'::text[] ORDER BY id;
 SELECT regexp_match(val, 'line$', 'sm') FROM strings
  WHERE regexp_match(val, 'line$', 'sm') = E'{line}'::text[];
+SELECT regexp_match(val, 'line$', 'smw') FROM strings
+ WHERE regexp_match(val, 'line$', 'smw') = E'{line}'::text[];
 
--- Compare consistency of s and m flag behavior matching ^.
+-- Compare consistency of `^` start of line.
 SELECT regexp_match(val, '^target'), id FROM strings
  WHERE regexp_match(val, '^target') = '{}'::text[] ORDER BY id;
 SELECT regexp_match(val, '^target', 'm') FROM strings
@@ -189,11 +230,19 @@ SELECT regexp_match(val, '^target', 'n') FROM strings
  WHERE regexp_match(val, '^target', 'n') = E'{target}'::text[];
 SELECT regexp_match(val, '^target', 's'), id FROM strings
  WHERE regexp_match(val, '^target', 's') = '{}'::text[] ORDER BY id;
+-- p matches in CH but not PG.
+SELECT regexp_match(val, '^target', 'p'), id FROM strings
+ WHERE regexp_match(val, '^target', 'p') = '{}'::text[] ORDER BY id;
+-- w matches in both.
+SELECT regexp_match(val, '^target', 'w') FROM strings
+ WHERE regexp_match(val, '^target', 'w') = E'{target}'::text[];
 -- Last flag overrides.
 SELECT regexp_match(val, '^target', 'ms'), id FROM strings
  WHERE regexp_match(val, '^target', 'ms') = '{}'::text[] ORDER BY id;
 SELECT regexp_match(val, '^target', 'sm') FROM strings
  WHERE regexp_match(val, '^target', 'sm') = E'{target}'::text[];
+SELECT regexp_match(val, '^target', 'msw') FROM strings
+ WHERE regexp_match(val, '^target', 'msw') = E'{target}'::text[];
 
 -- Ensure no pushdown when we disable it.
 SET pg_clickhouse.pushdown_regex = 'false';


### PR DESCRIPTION
Change `appendRegexFlags()` so that it first evaluates each flag in a list of regular expression flags and stores the findings in a bit flag variable. This allows clare overriding of mutually-exclusive flags: the last one wins.

Change the mapping for `p` to `-s` and add support for `w` pushed down as `m`. These mappings most closely match the Postgres equivalents except for the treatment of negated character classes (`[^xyz]`) matching newlines, which `m` and `p` affect in Postgres but not ClickHouse.

Cease to always add `s` to the flags; it's on by default in ClickHouse, so no need to set it. Do set it if it's explicitly passed, however.

Add a table to the documentation describing these mappings and a note on the variable treatment of negated character classes.

Add tests for the new behaviors, including the treatment of negated character classes as well as the `p` and `w` flags.