### PR TITLE
Add ShellCheck to pre-commit hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     env: { pg: 19 }
     steps:
       - name: Install Postgres
-        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev liblz4-dev libzstd-dev clang-tidy bear
+        run: NO_CLUSTER=1 pg-start ${{ env.pg }} libcurl4-openssl-dev uuid-dev liblz4-dev libzstd-dev clang-tidy bear shellcheck
       - name: Checkout the Repository
         uses: actions/checkout@v6
         with: { submodules: true }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
-      - id: check-illegal-windows-names
+      # - id: check-illegal-windows-names
       - id: check-json
       - id: check-merge-conflict
-      - id: check-symlinks
+      # - id: check-symlinks
       - id: check-vcs-permalinks
       - id: check-yaml
       - id: destroyed-symlinks
@@ -39,6 +39,11 @@ repos:
         entry: sh -c 'if [ -f compile_commands.json ]; then run-clang-tidy -p . "$@"; else echo "No compile_commands.json; skipping"; fi'
         files: '\.c$'
         exclude: "^vendor/"
+      - id: shellcheck
+        name: ShellCheck
+        language: system
+        entry: shellcheck
+        types: [shell]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:


### PR DESCRIPTION
Must be installed locally; the GitHub runners already have it.

Also disable `check-illegal-windows-names` and `check-symlinks`; we have no files that match, so they're always skipped.