### PR TITLE
Add `dev/choci`, improve `dev/runch`

### DIFF
--- a/.github/ubuntu/clickhouse.sh
+++ b/.github/ubuntu/clickhouse.sh
@@ -40,7 +40,6 @@ done
 
 if [ "${CH_VERSION%%.*}" -lt 25 ]; then
     # Enable the JSON type in release prior to 2025.
-    printf "~~~~ Starting ClickHouse %s ~~~~\n" "$CH_VERSION"
     setting=allow_experimental_object_type
     if [ "${CH_VERSION:0:4}" == "24.8" ]; then
         # The setting was renamed.

--- a/dev/README.md
+++ b/dev/README.md
@@ -5,16 +5,18 @@ development of pg_clickhouse.
 
 *   `bear.json`: [Bear Configuration](#bear-configuration)
 *   `bear.yml`: [Bear Configuration](#bear-configuration)
+*   `choci`: [Run ClickHouse Server](#run-local-clickhouse-server)
+*   `configs`: Configuration files for `choci` and `runch`
 *   `docker-compose.yml`: [ClickHouse Version Testing Containers](#clickhouse-version-testing-containers)
 *   `Makefile`: Automates [ClickHouse Version Testing Containers](#clickhouse-version-testing-containers)
 *   `README.md`: This file
 *   `runch`: [Run ClickHouse Server](#run-clickhouse-server)
 *   [`tpch`]: [TPC-H Benchmark Scripts](./tpch/README.md)
 
-## Run ClickHouse Server
+## Run Local ClickHouse Server
 
-Use `runch` to run a specific version of the ClickHouse server. For a complete
-list of commands, run:
+Use `runch` to locally run a specific version of the ClickHouse server. For a
+complete list of commands, run:
 
 ```sh
 runch help
@@ -33,6 +35,28 @@ make installcheck
 
 Specify any version supported by [clickhousectl]. Currently defaults to
 `26.6`.
+
+## Run Docker ClickHouse Server
+
+Use `choci` to run a specific version of ClickHouse in an OCI (Docker)
+container. For a complete list of commands, run:
+
+```sh
+choci help
+```
+
+`choci` relies on [docker] to start or stop a ClickHouse server with the
+default ports mapped to localhost. Useful for testing against a specific
+version of ClickHouse. For example, to test pg_clickhouse against ClickHouse
+23.8:
+
+```sh
+./dev/choci start 23.8
+make installcheck
+./dev/choci stop
+```
+
+Specify any tag supported by the [Docker image]. Defaults to `latest`.
 
 ## ClickHouse Version Testing Containers
 
@@ -87,5 +111,7 @@ There are currently two files:
 The `compile_commands.json` target determines which to use.
 
   [clickhousectl]: https://clickhouse.com/docs/interfaces/cli "ClickHouse Docs: clickhousectl"
+  [Docker image]: https://hub.docker.com/r/clickhouse/clickhouse-server
+    "clickhouse/clickhouse-server on DockerHub"
   [pgxn-tools]: https://github.com/pgxn/docker-pgxn-tools/
   [Bear]: https://github.com/rizsotto/Bear "Bear generates a compilation database for Clang tooling"

--- a/dev/choci
+++ b/dev/choci
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Start and stop various versions of ClickHouse containers. Requires that an
+# OCI runner like Docker or Orb be running and the `docker` CLI.
+
+set -e
+
+usage() {
+    cat <<EOF
+Usage: choci <command> [<args>]
+
+The choci commands are:
+    start [<version>]   Start ClickHouse version; defaults to latest
+    stop                Stop the current ClickHouse server
+    status              Show status of server
+    download <version>  Download a version
+    remove <version>    Remove a version
+    versions            Show currently-downloaded versions
+    help                Show this usage statement and command summary
+EOF
+}
+
+# https://stackoverflow.com/a/246128
+dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+image="clickhouse/clickhouse-server"
+name="$(basename "${BASH_SOURCE[0]}")"
+
+cfg_file() {
+    # Determine which file from ./configs to use.
+    local version="$1"
+    # Default config.
+    fn=default
+    if [ "$version" != "latest" ] && [ "${version%%.*}" -lt 25 ]; then
+        fn=allow_object
+        # Enable the JSON type in release prior to 2025.
+        if [ "${version:0:4}" == "24.8" ]; then
+            # The setting was renamed.
+            fn=allow_json
+        fi
+    fi
+
+    echo "$fn"
+}
+stop() {
+    cid="$(docker ps -aq --filter "name=$name")"
+    if [ -n "$cid" ]; then
+        printf 'Stopping ClickHouse instance %s...\n' "$cid"
+        docker rm -f "$cid"
+    fi
+}
+
+case "$1" in
+    stop)
+        stop
+        ;;
+    start)
+        version="${2:-latest}"
+        stop
+        cfg_base="$(cfg_file "$version")"
+        printf 'Starting ClickHouse %s\n' "$version"
+        docker run -p 8123:8123 -p9000:9000 \
+            -e CLICKHOUSE_SKIP_USER_SETUP=1 \
+            --name "$name" \
+            --ulimit nofile=262144:262144 \
+             -v "$dir/configs/$cfg_base.yaml:/etc/clickhouse-server/users.d/$cfg_base.yaml" \
+             -d "$image:$version"
+        ;;
+    download)
+        version="${2:-latest}"
+        docker pull "$image:$version"
+        ;;
+    status)
+        docker ps -f "name=$name" --format "table {{.Names}}\t{{.Image}}\t{{.State}}"
+        ;;
+    remove)
+        version="$2"
+        if [ -z "$version" ]; then
+            printf 'No version specified\n'
+            usage
+            exit 1;
+        fi
+        docker image rm -f "$image:$version"
+        ;;
+    versions)
+        docker image ls --filter "reference=$image:*" --format '{{.Tag}}'
+        ;;
+    help)
+        usage
+        ;;
+    *)
+        test -n "$1" && printf 'Unknown command:  %s\n\n' "$1"
+        usage
+        exit 1;
+        ;;
+esac

--- a/dev/configs/allow_json.yaml
+++ b/dev/configs/allow_json.yaml
@@ -1,0 +1,4 @@
+timezone: UTC
+profiles:
+  default:
+    allow_experimental_json_type: 1

--- a/dev/configs/allow_object.yaml
+++ b/dev/configs/allow_object.yaml
@@ -1,0 +1,4 @@
+timezone: UTC
+profiles:
+  default:
+    allow_experimental_object_type: 1

--- a/dev/configs/default.yaml
+++ b/dev/configs/default.yaml
@@ -1,0 +1,1 @@
+timezone: UTC

--- a/dev/runch
+++ b/dev/runch
@@ -3,7 +3,6 @@
 # Start and stop various versions of ClickHouse. Requires:
 #
 # *   `clickhousectl` (a.k.a., `chctl`) v0.3.0 or later
-# *   `mkdir -p ~/.clickhouse/configs && echo 'timezone: UTC' > ~/.clickhouse/configs/default.yaml`
 
 set -e
 
@@ -15,12 +14,34 @@ The runch commands are:
     start [<version>]   Start ClickHouse version; defaults to 26.6
     stop                Stop the current ClickHouse server
     status              Show status of all running severs
+    remove <version>    Remove a version
+    versions            Show currently-installed versions
     help                Show this usage statement and command summary
-
 EOF
 }
 
-name="$(basename "$0")"
+# https://stackoverflow.com/a/246128
+dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+name="$(basename "${BASH_SOURCE[0]}")"
+
+cfg_file() {
+    # Determine which file from ./configs to use.
+    local version="$1"
+    # Default config.
+    fn=default
+    if [ "${version%%.*}" -lt 25 ]; then
+        fn=allow_object
+        # Enable the JSON type in release prior to 2025.
+        if [ "${version:0:4}" == "24.8" ]; then
+            # The setting was renamed.
+            fn=allow_json
+        fi
+    fi
+
+    mkdir -p "$HOME/.clickhouse/configs"
+    cp "$dir/configs/$fn.yaml" "$HOME/.clickhouse/configs/runch-$fn.yaml"
+    echo "runch-$fn"
+}
 
 case "$1" in
     stop)
@@ -29,14 +50,23 @@ case "$1" in
     start)
         version="${2:-26.6}"
 
-        # cfg_file="$(dirname "$0")/clickhouse.yaml"
-        cfg_file=default
-
         chctl local server stop-all # stop "$name"
-        chctl local server start --name "$name" --version "$version" --config-file "$cfg_file"
+        chctl local server start --name "$name-$version" --version "$version" --config-file "$(cfg_file "$version")"
         ;;
     status)
         chctl local server list
+        ;;
+    versions)
+        chctl local list
+        ;;
+    remove)
+        version="$2"
+        if [ -z "$version" ]; then
+            printf 'No version specified\n'
+            usage
+            exit 1;
+        fi
+        chctl local remove "$version"
         ;;
     help)
         usage


### PR DESCRIPTION
Add `dev/config` with configurations to support enabling features in specific versions of ClickHouse and teach `dev/runch` to install the appropriate one given the version. This mimics the behavior of `.github/ubuntu/clickhouse.sh`, which configures a ClickHouse server on Debian. These configs allow tests to pass for ClickHouse versions 24.8 and earlier on Linux. A few still fail on macOS, alas, as its outputs vary. Will investigate that issue later.

But in the meantime, add `dev/choci`, which is super similar to `dev/runch`, but runs a specific ClickHouse version in an OCI container. It, too, adds the relevant configuration file to the container so that ClickHouse will start with the appropriate configuration. This allows one to run tests against a specific ClickHouse version on any platform with an OCI runner and `docker` CLI.

While at it, add the `versions` and `remove` commands to `dev/runch`, as well as `dev/choci`, and name the `runch` service to include the version so as to prevent different versions from using the same dat directory.