### PR TITLE
Don't use `IN` for empty array (`ANY('{}')`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ All notable changes to this project will be documented in this file. It uses the
 *   Fixed a memory leak in the http driver when not using streaming ([#281]).
 *   Fixed a memory leak when a foreign scan repeatedly re-scans, typically a
     nested-loop join with a parameterized inner foreign scan ([#282]).
+*   Change the deparsing of `ANY()` with an empty array (`WHERE x = ANY('{}')`)
+    to a `has()` function rather than an `IN()` expression. This fixes errors
+    on versions prior to ClickHouse 25, where `IN()` with no list returns an
+    error ([#285])
 
 ### 🏗️ Build Setup
 
@@ -65,6 +69,8 @@ All notable changes to this project will be documented in this file. It uses the
   [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
   [#283]: https://github.com/ClickHouse/pg_clickhouse/pull/283
     "ClickHouse/pg_clickhouse#283 clang-format"
+ [#285]: https://github.com/ClickHouse/pg_clickhouse/pull/285
+    "ClickHouse/pg_clickhouse#285 Don't use `IN` for empty array (`ANY('{}')`)"
 
 ## [v0.3.1] — 2026-05-02
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -3853,6 +3853,39 @@ deparseAsIn(ScalarArrayOpExpr* node, deparse_expr_cxt* context, int optype) {
 }
 
 /*
+ * Returns true if `node` is a constant and, if it's output is an array, the
+ * array has more than one value. Replace with `IsA(expr, Const)` when
+ * ClickHouse 24 support dropped.
+ */
+static bool
+is_ok_in_expr(Expr* expr) {
+    Const* node;
+    Oid typoutput;
+    bool typIsVarlena;
+    AnyArrayType* array;
+
+    if (!IsA(expr, Const)) {
+        return false;
+    }
+
+    node = (Const*)expr;
+    getTypeOutputInfo(node->consttype, &typoutput, &typIsVarlena);
+    if (typoutput != F_ARRAY_OUT) {
+        return true;
+    }
+
+    /*
+     * An empty `IN()` was invalid prior to ClickHouse 25, so disqualify an
+     * empty array. We could change things to `WHERE false` in this situation,
+     * but hopefully this workaround is temporary until we drop ClickHouse 24
+     * support someday, so just leave it to the ClickHouse optimizer to deal
+     * with it.
+     */
+    array = DatumGetAnyArrayP((Datum)node->constvalue);
+    return AARR_NDIM(array) > 0;
+}
+
+/*
  * Deparse given ScalarArrayOpExpr expression. To avoid problems around
  * priority of operations, we always parenthesize the arguments.
  */
@@ -3883,8 +3916,8 @@ deparseScalarArrayOpExpr(ScalarArrayOpExpr* node, deparse_expr_cxt* context) {
     if (node->useOr) {
         arg2 = lsecond(node->args);
 
-        /* very narrow case for = ANY(ARRAY) */
-        if (optype == 1 && IsA(arg2, Const)) {
+        /* very narrow case for IN() and = ANY(ARRAY) */
+        if (optype == 1 && is_ok_in_expr(arg2)) {
             deparseAsIn(node, context, optype);
         } else {
             if (optype == 1) {
@@ -3907,8 +3940,8 @@ deparseScalarArrayOpExpr(ScalarArrayOpExpr* node, deparse_expr_cxt* context) {
     } else {
         arg2 = lsecond(node->args);
 
-        /* very narrow case for <> ALL(ARRAY) */
-        if (optype == 2 && IsA(arg2, Const)) {
+        /* very narrow case for NOT IN() and <> ANY(ARRAY) */
+        if (optype == 2 && is_ok_in_expr(arg2)) {
             deparseAsIn(node, context, optype);
         } else {
             appendStringInfoString(buf, "countEqual(");

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -519,6 +519,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -517,6 +517,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -517,6 +517,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -517,6 +517,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -517,6 +517,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -519,6 +519,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -519,6 +519,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 110 | 1990-01-01 | 1990-01-01 | 0  | 0  | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on binary_queries_test.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM binary_queries_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -629,6 +629,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -627,6 +627,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -627,6 +627,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -627,6 +627,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -627,6 +627,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -629,6 +629,20 @@ SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- Scalar
  110 |  0 | 00110 | 1990-01-01 | 1990-01-01 | 0  | 0          | foo
 (110 rows)
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Foreign Scan on public.ft1 t1
+   Output: c1, c2, c3, c4, c5, c6, c7, c8
+   Remote SQL: SELECT c1, c2, c3, c4, c5, c6, c7, c8 FROM http_test.t1 WHERE ((has([],c1)))
+(3 rows)
+
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----+----
+(0 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------

--- a/test/sql/binary_queries.sql
+++ b/test/sql/binary_queries.sql
@@ -166,6 +166,10 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1
 
 SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- ScalarArrayOpExpr
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
 
 SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -224,6 +224,10 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1
 
 SELECT * FROM ft1 t1 WHERE c1 = ANY(ARRAY[c2, 1, c1 + 0]) ORDER BY c1; -- ScalarArrayOpExpr
 
+-- Syntax error on ClickHouse 24 and earlier.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+SELECT * FROM ft1 t1 WHERE c1 = ANY('{}'); -- Empty ScalarArrayOpExpr
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1]; -- ArrayRef
 
 SELECT * FROM ft1 t1 WHERE c1 = (ARRAY[c1,c2,3])[1] ORDER BY c1; -- ArrayRef


### PR DESCRIPTION
Prior to ClickHouse 25, an `IN` expression with no values, e.g., `WHERE x = IN()`, fails with an error. An alternative is to use `has([], x)`, which does not fail on earlier versions

Revise the code that determines when to use `IN` to detect when an `ANY` expression has passed an empty array, and if so, disqualify it for use in an `IN()` expression. This lets it continue with the `has()` function, instead. Add tests to validate this behavior, and include a note to replace the new function, `is_ok_in_expr()`, with the original, simpler `IsA(expr, Const)` expression.

Resolves #275.