### PR TITLE
Remove vestiges of pg_bsd_indent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,14 @@ repos:
       - id: clang-format
         name: format code
         types: [c]
+        exclude: "^vendor/"
   - repo: local
     hooks:
       - id: clang-tidy
         name: clang-tidy static analysis
         language: system
         entry: sh -c 'if [ -f compile_commands.json ]; then run-clang-tidy -p . "$@"; else echo "No compile_commands.json; skipping"; fi'
-        files: '\.c$'
+        types: [c]
         exclude: "^vendor/"
       - id: shellcheck
         name: ShellCheck

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,9 @@ bake-vars:
 	@echo "revision=$(REVISION)"
 	@echo "pg_versions=$(PG_VERSIONS)"
 
-# Format the .c and .h files according to the PostgreSQL indentation
-# standard. Requires `pg_bsd_indent` to be in the path.
-indent: dev/indent.sh
-	@$<
+.PHONY: format # Format .c and .h files to project standard in .clang-format.
+format: $(wildcard src/*.c src/*/*.c src/*/*.h)
+	@clang-format --style=file:.clang-format -i $^
 
 # Linting.
 .PHONY: lint # Lint the project
@@ -133,7 +132,7 @@ lint: .pre-commit-config.yaml
 
 .PHONY: clang-tidy # Run clang-tidy static analysis (requires compile_commands.json)
 clang-tidy: compile_commands.json
-	run-clang-tidy -p . $(wildcard src/*.c src/*/*.c)
+	run-clang-tidy -p . $(wildcard src/*.c src/*/*.c src/*/*.h)
 
 ## .git/hooks/pre-commit: Install the pre-commit hook
 .git/hooks/pre-commit:

--- a/dev/indent.sh
+++ b/dev/indent.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-for fn in  src/**/*.h* src/**/*.h.in src/*.c src/**/*.c; do
-    printf "%s\n" "$fn"
-    pg_bsd_indent -bad -bap -bbb -bc -bl -cli1 -cp33 -cdb -nce -d0 -di12 -nfc1 -i4 -l79 -lp -lpl -nip -npro -sac -tpg -ts4 "$fn"
-done
-rm -f ./*.BAK


### PR DESCRIPTION
Replace the `indent` target in `Makefile` with `format`. Also exclude vendor files in `pre-commit` and teach `clang-tidy` to evaluate header files; doing so used to emit invalid errors, but no more. No idea why; perhaps the new format.