### PR TITLE
Add pushdown for statistical aggregate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [0.3.3] — Unreleased
+
+### ⚡ Improvements
+
+*   Added pushdown for more aggregate functions ([#290]):
+    *   [corr]
+    *   [covarpop]
+    *   [covarsamp]
+    *   [stddev_pop]
+    *   [stddev_samp/stddev]
+    *   [var_op]
+    *   [var_samp/variance]
+
+  [v0.3.3]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.2...v0.3.3
+  [#290]: https://github.com/ClickHouse/pg_clickhouse/pull/281
+    "ClickHouse/pg_clickhouse#281 Add pushdown for statistical aggregate functions"
+  [corr]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/corr
+  [covarpop]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarpop
+  [covarsamp]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarsamp
+  [stddev_pop]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/stddevpop
+  [stddev_samp/stddev]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/stddevsamp
+  [var_op]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varPop
+  [var_samp/variance]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varSamp
+
 ## [v0.3.2] — 2026-06-16
 
 This release makes binary-only changes. Once installed, any existing use of

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1235,10 +1235,17 @@ These PostgreSQL aggregate functions pushdown to ClickHouse.
 *   [bool_and / every](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitand)
 *   [bool_or](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupbitor)
 *   [count](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/count)
+*   [corr](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/corr)
+*   [covarpop](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarpop)
+*   [covarsamp](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarsamp)
 *   [min](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/min)
 *   [max](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/max)
+*   [stddev_pop](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/stddevpop)
+*   [stddev_samp / stddev](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/stddevsamp)
 *   [string_agg](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/groupconcat)
 *   [sum](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/sum)
+*   [var_op](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varPop)
+*   [var_samp /variance](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varSamp)
 
 ### Custom Aggregates
 
@@ -1287,17 +1294,17 @@ These PostgreSQL [window functions] push down to ClickHouse with `OVER
 (PARTITION BY ... ORDER BY ...)` clauses, including frame specifications where
 applicable.
 
-*   [row_number](https://clickhouse.com/docs/sql-reference/window-functions#row_number)
-*   [rank](https://clickhouse.com/docs/sql-reference/window-functions#rank)
-*   [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions#dense_rank)
-*   [ntile](https://clickhouse.com/docs/sql-reference/window-functions#ntile)
-*   [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions#cume_dist)
-*   [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions#percent_rank)
-*   [lead](https://clickhouse.com/docs/sql-reference/window-functions#lead)
-*   [lag](https://clickhouse.com/docs/sql-reference/window-functions#lag)
-*   [first_value](https://clickhouse.com/docs/sql-reference/window-functions#first_value)
-*   [last_value](https://clickhouse.com/docs/sql-reference/window-functions#last_value)
-*   [nth_value](https://clickhouse.com/docs/sql-reference/window-functions#nth_value)
+*   [row_number](https://clickhouse.com/docs/sql-reference/window-functions/row_number)
+*   [rank](https://clickhouse.com/docs/sql-reference/window-functions/rank)
+*   [dense_rank](https://clickhouse.com/docs/sql-reference/window-functions/dense_rank)
+*   [ntile](https://clickhouse.com/docs/sql-reference/window-functions/ntile)
+*   [cume_dist](https://clickhouse.com/docs/sql-reference/window-functions/cume_dist)
+*   [percent_rank](https://clickhouse.com/docs/sql-reference/window-functions/percent_rank)
+*   [lead](https://clickhouse.com/docs/sql-reference/window-functions/lead)
+*   [lag](https://clickhouse.com/docs/sql-reference/window-functions/lag)
+*   [first_value](https://clickhouse.com/docs/sql-reference/window-functions/first_value)
+*   [last_value](https://clickhouse.com/docs/sql-reference/window-functions/last_value)
+*   [nth_value](https://clickhouse.com/docs/sql-reference/window-functions/nth_value)
 *   `min` / `max` (with `OVER` clause)
 
 Ranking functions (`row_number`, `rank`, `dense_rank`, `ntile`, `cume_dist`,

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -135,6 +135,45 @@
 #define F_COUNT_ 2803
 #define F_STRING_AGG_TEXT_TEXT 3538
 #define F_ARRAY_AGG_ANYARRAY 4053
+#define F_CORR 2829
+#define F_COVAR_POP 2827
+#define F_COVAR_SAMP 2828
+#define F_STDDEV_INT2 2156
+#define F_STDDEV_INT4 2155
+#define F_STDDEV_INT8 2154
+#define F_STDDEV_FLOAT4 2157
+#define F_STDDEV_FLOAT8 2158
+#define F_STDDEV_NUMERIC 2159
+#define F_STDDEV_SAMP_INT2 2714
+#define F_STDDEV_SAMP_INT4 2713
+#define F_STDDEV_SAMP_INT8 2712
+#define F_STDDEV_SAMP_FLOAT4 2715
+#define F_STDDEV_SAMP_FLOAT8 2716
+#define F_STDDEV_SAMP_NUMERIC 2717
+#define F_STDDEV_POP_INT2 2726
+#define F_STDDEV_POP_INT4 2725
+#define F_STDDEV_POP_INT8 2724
+#define F_STDDEV_POP_FLOAT4 2727
+#define F_STDDEV_POP_FLOAT8 2728
+#define F_STDDEV_POP_NUMERIC 2729
+#define F_VAR_POP_INT2 2720
+#define F_VAR_POP_INT4 2719
+#define F_VAR_POP_INT8 2718
+#define F_VAR_POP_FLOAT4 2721
+#define F_VAR_POP_FLOAT8 2722
+#define F_VAR_POP_NUMERIC 2723
+#define F_VAR_SAMP_INT2 2643
+#define F_VAR_SAMP_INT4 2642
+#define F_VAR_SAMP_INT8 2641
+#define F_VAR_SAMP_FLOAT4 2644
+#define F_VAR_SAMP_FLOAT8 2645
+#define F_VAR_SAMP_NUMERIC 2646
+#define F_VARIANCE_INT2 2150
+#define F_VARIANCE_INT4 2149
+#define F_VARIANCE_INT8 2148
+#define F_VARIANCE_FLOAT4 2151
+#define F_VARIANCE_FLOAT8 2152
+#define F_VARIANCE_NUMERIC 2153
 #define F_SIN 1604
 #define F_COS 1605
 #define F_TAN 1606
@@ -619,6 +658,24 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
         def->ch_name = "\1";
         return true;
 
+    case F_STDDEV_INT2:
+    case F_STDDEV_INT4:
+    case F_STDDEV_INT8:
+    case F_STDDEV_FLOAT4:
+    case F_STDDEV_FLOAT8:
+    case F_STDDEV_NUMERIC:
+        def->ch_name = "stddev_samp";
+        return true;
+
+    case F_VARIANCE_INT2:
+    case F_VARIANCE_INT4:
+    case F_VARIANCE_INT8:
+    case F_VARIANCE_FLOAT4:
+    case F_VARIANCE_FLOAT8:
+    case F_VARIANCE_NUMERIC:
+        def->ch_name = "var_samp";
+        return true;
+
         /* 1:1 pass-through: PG and CH agree on name and semantics */
     case F_ARRAY_AGG_ANYARRAY:
     case F_AVG_INT8:
@@ -665,7 +722,35 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
     case F_BOOL_OR:
     case F_EVERY:
     case F_STRING_AGG_TEXT_TEXT:
-        /* window functions sharing PG and CH names */
+    case F_CORR:
+    case F_COVAR_POP:
+    case F_COVAR_SAMP:
+    case F_STDDEV_SAMP_INT2:
+    case F_STDDEV_SAMP_INT4:
+    case F_STDDEV_SAMP_INT8:
+    case F_STDDEV_SAMP_FLOAT4:
+    case F_STDDEV_SAMP_FLOAT8:
+    case F_STDDEV_SAMP_NUMERIC:
+    case F_STDDEV_POP_INT2:
+    case F_STDDEV_POP_INT4:
+    case F_STDDEV_POP_INT8:
+    case F_STDDEV_POP_FLOAT4:
+    case F_STDDEV_POP_FLOAT8:
+    case F_STDDEV_POP_NUMERIC:
+    case F_VAR_POP_INT2:
+    case F_VAR_POP_INT4:
+    case F_VAR_POP_INT8:
+    case F_VAR_POP_FLOAT4:
+    case F_VAR_POP_FLOAT8:
+    case F_VAR_POP_NUMERIC:
+    case F_VAR_SAMP_INT2:
+    case F_VAR_SAMP_INT4:
+    case F_VAR_SAMP_INT8:
+    case F_VAR_SAMP_FLOAT4:
+    case F_VAR_SAMP_FLOAT8:
+    case F_VAR_SAMP_NUMERIC:
+
+    /* window functions sharing PG and CH names */
     case F_ROW_NUMBER:
     case F_RANK_:
     case F_DENSE_RANK_:

--- a/test/expected/aggregates.out
+++ b/test/expected/aggregates.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1396,5 +1422,387 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 151.218385125619 | 151.218385125619 | 130.958963038045
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 151.2183851256189 | 151.2183851256189 | 130.95896303804486
+(1 row)
+
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_1.out
+++ b/test/expected/aggregates_1.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1396,5 +1422,387 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 151.218385125619 | 151.218385125619 | 130.958963038045
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 151.2183851256189 | 151.2183851256189 | 130.95896303804486
+(1 row)
+
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_2.out
+++ b/test/expected/aggregates_2.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1382,5 +1408,387 @@ FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 151.218385125619 | 151.218385125619 | 130.958963038045
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 151.2183851256189 | 151.2183851256189 | 130.95896303804486
+(1 row)
+
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_3.out
+++ b/test/expected/aggregates_3.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1386,5 +1412,387 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 151.218385125619 | 151.218385125619 | 130.958963038045
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 151.2183851256189 | 151.2183851256189 | 130.95896303804486
+(1 row)
+
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop  | var_samp | variance 
+----------+----------+----------
+ 17150.25 |    22867 |    22867
+(1 row)
+
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_4.out
+++ b/test/expected/aggregates_4.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1386,5 +1412,377 @@ DETAIL:  Remote Query: SELECT datestamp, groupConcat(', ')(path) FROM agg_test.h
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)')
+DETAIL:  Remote Query: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: Code: 42. DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)'). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)
+DETAIL:  Remote Query: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+CONTEXT:  HTTP status code: 500
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)')
+DETAIL:  Remote Query: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: Code: 42. DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)'). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)
+DETAIL:  Remote Query: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+CONTEXT:  HTTP status code: 500
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/expected/aggregates_5.out
+++ b/test/expected/aggregates_5.out
@@ -19,6 +19,24 @@
  
 (1 row)
 
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+               Foreign table "agg_bin.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_bin_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
+
                             Foreign table "agg_bin.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
 -----------+--------------------------+-----------+----------+---------+-------------
@@ -31,6 +49,14 @@
  cost      | numeric(10,2)            |           | not null |         | 
 Server: agg_bin_svr
 FDW options: (database 'agg_test', table_name 'hits', engine 'MergeTree')
+
+               Foreign table "agg_http.agg_numbers"
+ Column |   Type   | Collation | Nullable | Default | FDW options 
+--------+----------+-----------+----------+---------+-------------
+ a      | smallint |           | not null |         | 
+ b      | real     |           | not null |         | 
+Server: agg_http_svr
+FDW options: (database 'agg_test', table_name 'agg_numbers', engine 'MergeTree')
 
                             Foreign table "agg_http.hits"
   Column   |           Type           | Collation | Nullable | Default | FDW options 
@@ -1377,5 +1403,377 @@ DETAIL:  Remote Query: SELECT groupBitXor(cast(duration, 'Nullable(Int32)')) FRO
          Remote SQL: SELECT duration, cost FROM agg_test.hits
 (5 rows)
 
-NOTICE:  drop cascades to foreign table agg_bin.hits
-NOTICE:  drop cascades to foreign table agg_http.hits
+-- corr(int, float) corr(float, int)
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (corr((a)::double precision, (b)::double precision)), (corr((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT corr(a, b), corr(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+        corr        |        corr        
+--------------------+--------------------
+ 0.1396345165178734 | 0.1396345165178734
+(1 row)
+
+-- corr(int, float) corr(float, int)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (covar_pop((b)::double precision, (a)::double precision)), (covar_samp((b)::double precision, (a)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_test.agg_numbers
+(4 rows)
+
+     covar_pop     |    covar_samp     
+-------------------+-------------------
+ 653.6289553875104 | 871.5052738500139
+(1 row)
+
+-- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(a)), (stddev_samp(a)), (stddev_pop(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(a), stddev_samp(a), stddev_pop(a) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::integer)), (stddev_samp((a)::integer)), (stddev_pop((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int32)')), stddev_samp(cast(a, 'Nullable(Int32)')), stddev_pop(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev      |   stddev_samp    |    stddev_pop    
+------------------+------------------+------------------
+ 41.2270137975899 | 41.2270137975899 | 35.7036412708844
+(1 row)
+
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((a)::bigint)), (stddev_samp((a)::bigint)), (stddev_pop((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(a, 'Nullable(Int64)')), stddev_samp(cast(a, 'Nullable(Int64)')), stddev_pop(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      stddev       |    stddev_samp    |     stddev_pop     
+-------------------+-------------------+--------------------
+ 41.22701379758988 | 41.22701379758988 | 35.703641270884404
+(1 row)
+
+-- stddev(float), stddev_samp(float), stddev_pop(float)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38937377929688 | 151.38937377929688 | 131.10704040527344
+(1 row)
+
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev(b)), (stddev_samp(b)), (stddev_pop(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(b), stddev_samp(b), stddev_pop(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  stddev   | stddev_samp | stddev_pop 
+-----------+-------------+------------
+ 151.38937 |   151.38937 |  131.10704
+(1 row)
+
+-- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::double precision)), (stddev_samp((b)::double precision)), (stddev_pop((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Float64)')), stddev_samp(cast(b, 'Nullable(Float64)')), stddev_pop(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+       stddev       |    stddev_samp     |     stddev_pop     
+--------------------+--------------------+--------------------
+ 151.38936080399804 | 151.38936080399804 | 131.10703231895047
+(1 row)
+
+-- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)')
+DETAIL:  Remote Query: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (stddev((b)::numeric)), (stddev_samp((b)::numeric)), (stddev_pop((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: Code: 42. DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)'). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)
+DETAIL:  Remote Query: SELECT stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_samp(cast(b, 'Nullable(Decimal)')), stddev_pop(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+CONTEXT:  HTTP status code: 500
+-- var_pop(int2), var_samp(int2), variance(int2)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(a)), (var_samp(a)), (variance(a))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(a), var_samp(a), var_samp(a) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int4), var_samp(int4), variance(int4)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::integer)), (var_samp((a)::integer)), (variance((a)::integer))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')), var_samp(cast(a, 'Nullable(Int32)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(int8), var_samp(int8), variance(int8)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |     var_samp     |     variance     
+---------+------------------+------------------
+ 1274.75 | 1699.66666666667 | 1699.66666666667
+(1 row)
+
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((a)::bigint)), (var_samp((a)::bigint)), (variance((a)::bigint))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')), var_samp(cast(a, 'Nullable(Int64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ var_pop |      var_samp      |      variance      
+---------+--------------------+--------------------
+ 1274.75 | 1699.6666666666667 | 1699.6666666666667
+(1 row)
+
+-- var_pop(float), var_samp(float), variance(float)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+     var_pop     |   var_samp    |   variance    
+-----------------+---------------+---------------
+ 17189.056640625 | 22918.7421875 | 22918.7421875
+(1 row)
+
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop(b)), (var_samp(b)), (variance(b))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(b), var_samp(b), var_samp(b) FROM agg_test.agg_numbers
+(4 rows)
+
+  var_pop  | var_samp  | variance  
+-----------+-----------+-----------
+ 17189.057 | 22918.742 | 22918.742
+(1 row)
+
+-- var_pop(float8), var_samp(float8), variance(float8)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::double precision)), (var_samp((b)::double precision)), (variance((b)::double precision))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')), var_samp(cast(b, 'Nullable(Float64)')) FROM agg_test.agg_numbers
+(4 rows)
+
+      var_pop       |      var_samp      |      variance      
+--------------------+--------------------+--------------------
+ 17189.053923482326 | 22918.738564643103 | 22918.738564643103
+(1 row)
+
+-- var_pop(numeric), var_samp(numeric), variance(numeric)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)')
+DETAIL:  Remote Query: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (var_pop((b)::numeric)), (var_samp((b)::numeric)), (variance((b)::numeric))
+   Relations: Aggregate on (agg_numbers)
+   Remote SQL: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+(4 rows)
+
+ERROR:  pg_clickhouse: Code: 42. DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing CAST(b, 'Nullable(Decimal)'). (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)
+DETAIL:  Remote Query: SELECT var_pop(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')), var_samp(cast(b, 'Nullable(Decimal)')) FROM agg_test.agg_numbers
+CONTEXT:  HTTP status code: 500
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_bin.agg_numbers
+drop cascades to foreign table agg_bin.hits
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table agg_http.agg_numbers
+drop cascades to foreign table agg_http.hits

--- a/test/sql/aggregates.sql
+++ b/test/sql/aggregates.sql
@@ -103,12 +103,28 @@ SELECT clickhouse_raw_query($$
     (1538392900,'7e3f2fe1-5312-4257-ba3e-54662ba14b56','2025-12-19 07:24:50.960198','2025-12-19','/users/802683',216,5.9)
 $$);
 
+-- Set up a table with some numeric values.
+SELECT clickhouse_raw_query($$
+    CREATE TABLE agg_test.agg_numbers (
+        a Int16,
+        b Float32
+    ) ENGINE = MergeTree ORDER BY (a);
+$$);
+ 
+SELECT clickhouse_raw_query($$
+    INSERT INTO agg_test.agg_numbers
+    VALUES (56, 7.8)
+         , (100, 99.097)
+         , (0, 0.09561)
+         , (42, 324.78)
+$$);
+
 CREATE SCHEMA agg_bin;
 CREATE SCHEMA agg_http;
 IMPORT FOREIGN SCHEMA "agg_test" FROM SERVER agg_bin_svr INTO agg_bin;
-\d agg_bin.hits
+\d agg_bin.*
 IMPORT FOREIGN SCHEMA "agg_test" FROM SERVER agg_http_svr INTO agg_http;
-\d agg_http.hits
+\d agg_http.*
 
 \set id_limit 1000000000
 
@@ -450,6 +466,94 @@ SELECT bit_xor(duration::int4) FROM agg_bin.hits WHERE id = 3498231651;
 \echo -- regr_slope local fallback
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT regr_slope(cost::float8, duration::float8) FROM agg_bin.hits;
+
+-- corr()
+\echo -- corr(int, float) corr(float, int)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT corr(a, b), corr(b, a) FROM agg_bin.agg_numbers;
+SELECT corr(a, b), corr(b, a) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT corr(a, b), corr(b, a) FROM agg_http.agg_numbers;
+SELECT corr(a, b), corr(b, a) FROM agg_http.agg_numbers;
+
+-- covar_pop, covar_samp()
+\echo -- corr(int, float) corr(float, int)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_bin.agg_numbers;
+SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_bin.agg_numbers;
+SELECT covar_pop(b, a), covar_samp(b, a) FROM agg_bin.agg_numbers;
+
+-- stddev(), stddev_samp(), stddev_pop()
+\echo -- stddev(int2), stddev_samp(int2), stddev_pop(int2)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a), stddev_samp(a), stddev_pop(a) FROM agg_bin.agg_numbers;
+SELECT stddev(a), stddev_samp(a), stddev_pop(a) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a), stddev_samp(a), stddev_pop(a) FROM agg_http.agg_numbers;
+SELECT stddev(a), stddev_samp(a), stddev_pop(a) FROM agg_http.agg_numbers;;
+
+\echo -- stddev(int4), stddev_samp(int4), stddev_pop(int4)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a::int4), stddev_samp(a::int4), stddev_pop(a::int4) FROM agg_bin.agg_numbers;
+SELECT stddev(a::int4), stddev_samp(a::int4), stddev_pop(a::int4) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a::int4), stddev_samp(a::int4), stddev_pop(a::int4) FROM agg_http.agg_numbers;
+SELECT stddev(a::int4), stddev_samp(a::int4), stddev_pop(a::int4) FROM agg_http.agg_numbers;;
+
+\echo -- stddev(int8), stddev_samp(int8), stddev_pop(int8)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a::int8), stddev_samp(a::int8), stddev_pop(a::int8) FROM agg_bin.agg_numbers;
+SELECT stddev(a::int8), stddev_samp(a::int8), stddev_pop(a::int8) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(a::int8), stddev_samp(a::int8), stddev_pop(a::int8) FROM agg_http.agg_numbers;
+SELECT stddev(a::int8), stddev_samp(a::int8), stddev_pop(a::int8) FROM agg_http.agg_numbers;;
+
+\echo -- stddev(float), stddev_samp(float), stddev_pop(float)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b), stddev_samp(b), stddev_pop(b) FROM agg_bin.agg_numbers;
+SELECT stddev(b), stddev_samp(b), stddev_pop(b) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b), stddev_samp(b), stddev_pop(b) FROM agg_http.agg_numbers;
+SELECT stddev(b), stddev_samp(b), stddev_pop(b) FROM agg_http.agg_numbers;;
+
+\echo -- stddev(float8), stddev_samp(float8), stddev_pop(float8)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b::float8), stddev_samp(b::float8), stddev_pop(b::float8) FROM agg_bin.agg_numbers;
+SELECT stddev(b::float8), stddev_samp(b::float8), stddev_pop(b::float8) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b::float8), stddev_samp(b::float8), stddev_pop(b::float8) FROM agg_http.agg_numbers;
+SELECT stddev(b::float8), stddev_samp(b::float8), stddev_pop(b::float8) FROM agg_http.agg_numbers;;
+
+\echo -- stddev(numeric), stddev_samp(numeric), stddev_pop(numeric)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b::numeric), stddev_samp(b::numeric), stddev_pop(b::numeric) FROM agg_bin.agg_numbers;
+SELECT stddev(b::numeric), stddev_samp(b::numeric), stddev_pop(b::numeric) FROM agg_bin.agg_numbers;;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT stddev(b::numeric), stddev_samp(b::numeric), stddev_pop(b::numeric) FROM agg_http.agg_numbers;
+SELECT stddev(b::numeric), stddev_samp(b::numeric), stddev_pop(b::numeric) FROM agg_http.agg_numbers;;
+
+-- var_pop, var_samp(), variance()
+\echo -- var_pop(int2), var_samp(int2), variance(int2)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a), var_samp(a), variance(a) FROM agg_bin.agg_numbers;
+SELECT var_pop(a), var_samp(a), variance(a) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a), var_samp(a), variance(a) FROM agg_http.agg_numbers;
+SELECT var_pop(a), var_samp(a), variance(a) FROM agg_http.agg_numbers;
+
+\echo -- var_pop(int4), var_samp(int4), variance(int4)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a::int4), var_samp(a::int4), variance(a::int4) FROM agg_bin.agg_numbers;
+SELECT var_pop(a::int4), var_samp(a::int4), variance(a::int4) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a::int4), var_samp(a::int4), variance(a::int4) FROM agg_http.agg_numbers;
+SELECT var_pop(a::int4), var_samp(a::int4), variance(a::int4) FROM agg_http.agg_numbers;
+
+\echo -- var_pop(int8), var_samp(int8), variance(int8)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a::int8), var_samp(a::int8), variance(a::int8) FROM agg_bin.agg_numbers;
+SELECT var_pop(a::int8), var_samp(a::int8), variance(a::int8) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(a::int8), var_samp(a::int8), variance(a::int8) FROM agg_http.agg_numbers;
+SELECT var_pop(a::int8), var_samp(a::int8), variance(a::int8) FROM agg_http.agg_numbers;
+
+\echo -- var_pop(float), var_samp(float), variance(float)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b), var_samp(b), variance(b) FROM agg_bin.agg_numbers;
+SELECT var_pop(b), var_samp(b), variance(b) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b), var_samp(b), variance(b) FROM agg_http.agg_numbers;
+SELECT var_pop(b), var_samp(b), variance(b) FROM agg_http.agg_numbers;
+
+\echo -- var_pop(float8), var_samp(float8), variance(float8)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b::float8), var_samp(b::float8), variance(b::float8) FROM agg_bin.agg_numbers;
+SELECT var_pop(b::float8), var_samp(b::float8), variance(b::float8) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b::float8), var_samp(b::float8), variance(b::float8) FROM agg_http.agg_numbers;
+SELECT var_pop(b::float8), var_samp(b::float8), variance(b::float8) FROM agg_http.agg_numbers;
+
+\echo -- var_pop(numeric), var_samp(numeric), variance(numeric)
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b::numeric), var_samp(b::numeric), variance(b::numeric) FROM agg_bin.agg_numbers;
+SELECT var_pop(b::numeric), var_samp(b::numeric), variance(b::numeric) FROM agg_bin.agg_numbers;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT var_pop(b::numeric), var_samp(b::numeric), variance(b::numeric) FROM agg_http.agg_numbers;
+SELECT var_pop(b::numeric), var_samp(b::numeric), variance(b::numeric) FROM agg_http.agg_numbers;
 
 -- Clean up.
 DROP USER MAPPING FOR CURRENT_USER SERVER agg_bin_svr;


### PR DESCRIPTION
Add mappings to push down the following Postgres aggregate functions to ClickHouse:

*   `corr`
*   `covarpop`
*   `covarsamp`
*   `stddev_pop`
*   `stddev_samp` / `stddev`
*   `var_op`
*   `var_samp` / `variance`

These are the last remaining Postgres (non-ordered) aggregate functions with ClickHouse equivalents that were not yet pushed down. They each have the same names (or aliases for the same name) and signatures as in Postgres, except for `stddev()` and `variance()`, which are old names for `stddev_samp()`, and `var_samp()`, respectively, so we have to map to those aliases explicitly.

Add these functions to the list of supported aggregate functions in the docs, and add tests for each of these aggregates, ensuring that all supported signatures push down. The casting to `numeric` returns errors on ClickHouse 23.3, which requires precision and scale, but just ignore it for now.

While at it, update the ClickHouse window function doc links to the dedicated pages for each function.