### PR TITLE
Push down ordered set aggregate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,22 @@ All notable changes to this project will be documented in this file. It uses the
     *   [stddev_samp/stddev]
     *   [var_op]
     *   [var_samp/variance]
+*   Mapped the following PostgreSQL ordered set aggregate functions to push
+    down to corresponding ClickHouse parametric aggregate functions ([#291]):
+    *   `percentile_cont(double[])` → `quantiles()`
+    *   `percentile_disc(double)` → `quantileExactLow()`
+    *   `percentile_disc(double[])` → `quantilesExactLow()`
+
+### 📚 Documentation
+
+*   Separated the list of custom ordered set aggregate functions provided by
+    pg_clickhouse (currently `quantile()` and `quantileExact()`) from the
+    Postgres ordered set aggregate functions, putting them under their own
+    header, "Custom Ordered Set Aggregates".
 
   [v0.3.3]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.2...v0.3.3
-  [#290]: https://github.com/ClickHouse/pg_clickhouse/pull/281
-    "ClickHouse/pg_clickhouse#281 Add pushdown for statistical aggregate functions"
+  [#290]: https://github.com/ClickHouse/pg_clickhouse/pull/290
+    "ClickHouse/pg_clickhouse#290 Add pushdown for statistical aggregate functions"
   [corr]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/corr
   [covarpop]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarpop
   [covarsamp]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/covarsamp
@@ -30,6 +42,8 @@ All notable changes to this project will be documented in this file. It uses the
   [stddev_samp/stddev]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/stddevsamp
   [var_op]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varPop
   [var_samp/variance]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varSamp
+  [#291]: https://github.com/ClickHouse/pg_clickhouse/pull/291
+    "ClickHouse/pg_clickhouse#291 Push down ordered set aggregate functions"
 
 ## [v0.3.2] — 2026-06-16
 
@@ -703,7 +717,7 @@ pg_clickhouse v0.1 will get its benefits on reload without needing to
 *   Mapped PostgreSQL `extract()` to push down to equivalent ClickHouse
     DateTime extraction functions (already mapped to `date_part()`)
 *   Mapped PostgreSQL `percentile_cont()` ordered set aggregate function to
-    push down to ClickHouse `quantile()` parametrized
+    push down to the ClickHouse `quantile()` parametric aggregate function
 *   Mapped the `COUNT()` return value to `bigint`
 *   Added the query text and, for the http engine, the status code to error
     messages

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1267,7 +1267,7 @@ an exception.
 
 ### Pushdown Ordered Set Aggregates
 
-These [ordered-set aggregate functions] map to ClickHouse [Parametric
+These [ordered-set aggregate functions] map to ClickHouse [parametric
 aggregate functions] by passing their *direct argument* as a parameter and
 their `ORDER BY` expressions as arguments. For example, this PostgreSQL query:
 
@@ -1285,8 +1285,19 @@ Note that the non-default `ORDER BY` suffixes `DESC` and `NULLS FIRST`
 are not supported and will raise an error.
 
 *   `percentile_cont(double)`: [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
-*   `quantile(double)`: [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
-*   `quantileExact(double)`: [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
+*   `percentile_cont(double[])`: [quantiles](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantiles)
+*   `percentile_disc(double)`: [quantileExactLow](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileExactLow)
+*   `percentile_disc(double[])`: [quantilesExactLow](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantilesExactLow)
+
+### Custom Ordered Set Aggregates
+
+These custom [ordered-set aggregate functions] created by `pg_clickhouse`
+provide foreign query pushdown for select ClickHouse [parametric aggregate
+functions]. If any of these functions cannot be pushed down they will raise an
+exception.
+
+*   [quantile](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantile)
+*   [quantileExact](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/quantileexact)
 
 ### Pushdown Window Functions
 
@@ -1526,7 +1537,7 @@ Copyright (c) 2025-2026, ClickHouse.
   [shared library preloading]: https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-PRELOAD
     "PostgreSQL Docs: Shared Library Preloading"
   [ordered-set aggregate functions]: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
-  [Parametric aggregate functions]: https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions
+  [parametric aggregate functions]: https://clickhouse.com/docs/sql-reference/aggregate-functions/parametric-functions
   [ClickHouse settings]: https://clickhouse.com/docs/operations/settings/settings
     "ClickHouse Docs: Session Settings"
   [dollar quoting]: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -39,6 +39,11 @@
 #define F_DATE_PART_TEXT_DATE 1384
 #define F_PERCENTILE_CONT_FLOAT8_FLOAT8 3974
 #define F_PERCENTILE_CONT_FLOAT8_INTERVAL 3976
+#define F_PERCENTILE_DISC_FLOAT8_ANYELEMENT 3972
+#define F_PERCENTILE_DISC__FLOAT8_ANYELEMENT 3978
+#define F_PERCENTILE_CONT__FLOAT8_FLOAT8 3980
+#define F_PERCENTILE_CONT__FLOAT8_INTERVAL 3982
+
 #define F_ARRAY_AGG_ANYNONARRAY 2335
 #define F_TO_TIMESTAMP_FLOAT8 1158
 #define F_TRANSACTION_TIMESTAMP 2647
@@ -320,7 +325,7 @@ init_custom_entry(CustomObjectDef* entry) {
 }
 
 /*
- * Return true if ordered aggregate funcid maps to a parameterized ClickHouse
+ * Return true if ordered aggregate funcid maps to a parametric ClickHouse
  * aggregate function.
  */
 inline bool
@@ -328,6 +333,10 @@ chfdw_check_for_ordered_aggregate(Aggref* agg) {
     switch (agg->aggfnoid) {
     case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
     case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
+    case F_PERCENTILE_DISC_FLOAT8_ANYELEMENT:
+    case F_PERCENTILE_DISC__FLOAT8_ANYELEMENT:
+    case F_PERCENTILE_CONT__FLOAT8_FLOAT8:
+    case F_PERCENTILE_CONT__FLOAT8_INTERVAL:
         /* Ordered aggregates that map to ClickHouse functions. */
         return true;
     }
@@ -508,6 +517,18 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
     case F_PERCENTILE_CONT_FLOAT8_FLOAT8:
     case F_PERCENTILE_CONT_FLOAT8_INTERVAL:
         def->ch_name = "quantile";
+        return true;
+    case F_PERCENTILE_CONT__FLOAT8_FLOAT8:
+    case F_PERCENTILE_CONT__FLOAT8_INTERVAL:
+        def->cf_type = CF_PARAM_LIST_AGG;
+        def->ch_name = "quantiles";
+        return true;
+    case F_PERCENTILE_DISC_FLOAT8_ANYELEMENT:
+        def->ch_name = "quantileExactLow";
+        return true;
+    case F_PERCENTILE_DISC__FLOAT8_ANYELEMENT:
+        def->cf_type = CF_PARAM_LIST_AGG;
+        def->ch_name = "quantilesExactLow";
         return true;
     case F_ARRAY_AGG_ANYNONARRAY:
         def->ch_name = "groupArray";

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -18,6 +18,7 @@
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/sysattr.h"
+#include "access/table.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
@@ -43,10 +44,6 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
-
-#if PG_VERSION_NUM >= 120000
-#include "access/table.h"
-#endif
 
 #include "fdw.h"
 
@@ -4238,8 +4235,9 @@ deparseAggref(Aggref* node, deparse_expr_cxt* context) {
     bool aggfilter            = false;
     bool sign_count_filter    = false;
     uint8 brcount             = 1;
+    char* name                = get_func_name(node->aggfnoid);
+    bool omit_star            = false; /* Explained below. */
     bool use_variadic;
-    char* name = get_func_name(node->aggfnoid);
 
     /* Only basic, non-split aggregation accepted. */
     Assert(node->aggsplit == AGGSPLIT_SIMPLE);
@@ -4266,13 +4264,13 @@ deparseAggref(Aggref* node, deparse_expr_cxt* context) {
     }
 
     /*
-     * groupConcat(delimiter)(expr): emit delimiter as parameterized arg, then
+     * groupConcat(delimiter)(expr): emit delimiter as parametric arg, then
      * only the first non-junk arg (the expression).
      */
     if (context->func && context->func->cf_type == CF_STRING_AGG) {
         ListCell* arg;
 
-        /* Emit delimiter (2nd non-junk arg) as parameterized arg. */
+        /* Emit delimiter (2nd non-junk arg) as parametric arg. */
         appendStringInfoChar(buf, '(');
         foreach (arg, node->args) {
             TargetEntry* tle = (TargetEntry*)lfirst(arg);
@@ -4299,36 +4297,48 @@ deparseAggref(Aggref* node, deparse_expr_cxt* context) {
         return;
     }
 
-    appendStringInfoChar(buf, '(');
-
-    /* Explained below. */
-    bool omit_star = false;
-
     if (AGGKIND_IS_ORDERED_SET(node->aggkind)) {
-        /* Emit direct args as ClickHouse parameterized args. */
-        ListCell* arg;
-        bool first = true;
-
+        /* Need to emit the parametric args. */
         Assert(!node->aggvariadic);
         Assert(node->aggorder != NIL);
 
-        foreach (arg, node->aggdirectargs) {
-            if (!first) {
-                appendStringInfoString(buf, ", ");
-            }
-            first = false;
+        if (context->func && context->func->cf_type == CF_PARAM_LIST_AGG) {
+            /* Convert array to list of parametric args. */
+            ListCell* arg = list_head(node->aggdirectargs);
+            Node* array   = lfirst(arg);
+            bool atup     = context->array_as_tuple;
 
-            deparseExpr((Expr*)lfirst(arg), context);
+            Assert(list_length(node->aggdirectargs) == 1);
+            Assert(nodeTag(array) == T_Const);
+            context->array_as_tuple = true; /* Formats with () instead of []. */
+            deparseArray(((Const*)array)->constvalue, context);
+            context->array_as_tuple = atup;
+        } else {
+            /* Emit direct args as ClickHouse parametric args. */
+            ListCell* arg;
+            bool first = true;
+
+            appendStringInfoChar(buf, '(');
+            foreach (arg, node->aggdirectargs) {
+                if (!first) {
+                    appendStringInfoString(buf, ", ");
+                }
+                first = false;
+
+                deparseExpr((Expr*)lfirst(arg), context);
+            }
+            appendStringInfoChar(buf, ')');
         }
 
         /* Close parameter args and start regular args. */
-        appendStringInfoString(buf, ")(");
+        appendStringInfoChar(buf, '(');
         /* Emit `WITHIN GROUP (ORDER BY ..)` args with no closing paren. */
         context->no_sort_parens = true;
         appendAggOrderBy(node->aggorder, node->args, context);
         context->no_sort_parens = false;
     } else {
         /* Add DISTINCT */
+        appendStringInfoChar(buf, '(');
         if (node->aggdistinct != NIL) {
             appendStringInfoString(buf, "DISTINCT ");
         }

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -389,6 +389,8 @@ typedef enum {
     CF_TO_CHAR,                /* to_char(timestamp[tz], fmt) →
                                 * formatDateTime, with strict format
                                 * translation */
+    CF_PARAM_LIST_AGG,         /* ordered set agg with array prams → parametric
+                                * list aggregate function */
 } custom_object_type;
 
 typedef enum {

--- a/test/expected/engines.out
+++ b/test/expected/engines.out
@@ -278,6 +278,24 @@ SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP
 ---+----------
 (0 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (percentile_disc('0.75'::double precision) WITHIN GROUP (ORDER BY f))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, quantileExactLowMerge(0.75)(f) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (((percentile_disc('0.75'::double precision) WITHIN GROUP (ORDER BY f))::numeric / sum(d)))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, (quantileExactLowMerge(0.75)(f) / sum(d)) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');
  clickhouse_raw_query 

--- a/test/expected/engines_1.out
+++ b/test/expected/engines_1.out
@@ -255,6 +255,24 @@ SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP
 ---+----------
 (0 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (percentile_disc('0.75'::double precision) WITHIN GROUP (ORDER BY f))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, quantileExactLowMerge(0.75)(f) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: a, (((percentile_disc('0.75'::double precision) WITHIN GROUP (ORDER BY f))::numeric / sum(d)))
+   Relations: Aggregate on (t4)
+   Remote SQL: SELECT a, (quantileExactLowMerge(0.75)(f) / sum(d)) FROM engines_test.t4 GROUP BY a
+(4 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');
  clickhouse_raw_query 

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -620,6 +620,162 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantiles(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+          percentile_cont           
+------------------------------------
+ {1546425720,1546426260,1546426692}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_cont('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY ((a)::double precision)) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_cont 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_cont 
+-----------------
+ {1.75,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.25)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.95'::double precision) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLow(0.95)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ percentile_disc 
+-----------------
+      1546426800
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('0.25'::double precision) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantileExactLowIf(0.25)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+               1
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+               2
+(1 row)
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "NULLS FIRST" in aggregate expressions
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+ERROR:  pg_clickhouse: ClickHouse does not support "DESC" in aggregate expressions
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.25,0.5,0.75)(a) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.9,0.95,0.99}'::double precision[]) WITHIN GROUP (ORDER BY (date_part('epoch'::text, timezone('UTC'::text, c)))))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+ERROR:  pg_clickhouse: could not cast value from bigint[] to double precision[]
+DETAIL:  Remote Query: SELECT quantilesExactLow(0.9,0.95,0.99)(toUnixTimestamp(toTimeZone(c, 'UTC'))) FROM functions_test.t1
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (percentile_disc('{0.25,0.5,0.75}'::double precision[]) WITHIN GROUP (ORDER BY a) FILTER (WHERE (b = 1)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT quantilesExactLowIf(0.25,0.5,0.75)(a,(((b = 1)) > 0)) FROM functions_test.t1
+(4 rows)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+ percentile_disc 
+-----------------
+ {1,1,1}
+(1 row)
+
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+ percentile_disc 
+-----------------
+ {2,2,2}
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/sql/engines.sql
+++ b/test/sql/engines.sql
@@ -73,6 +73,9 @@ SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
 SELECT a, percentile_cont(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) FROM t4 GROUP BY a;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE engines_test');
 DROP SERVER engines_loopback CASCADE;

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -179,6 +179,34 @@ SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
 SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
 
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+SELECT percentile_cont(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_cont(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+SELECT percentile_disc(0.95) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a DESC) FROM t1;
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a NULLS FIRST) FROM t1;
+SELECT percentile_disc(0.25) WITHIN GROUP (ORDER BY a USING >) FROM t1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+SELECT percentile_disc(ARRAY[0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY date_part('epoch', timezone('UTC', c))) FROM t1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
+SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 


### PR DESCRIPTION
To flesh out the support for pushing down Postgres ordered set aggregate functions to ClickHouse parametric aggregate functions introduced with the implementation of `percentile_cont(double)` in 087cfdc (#36), add mappings for others with reasonable equivalents:

*   `percentile_cont(double[])` → `quantiles()`
*   `percentile_disc(double)` → `quantileExactLow()`
*   `percentile_disc(double[])` → `quantilesExactLow()`

The mapping of the array argument to a ClickHouse list of parameters is handled by setting the new `CF_PARAM_LIST_AGG` value for `cf_type`. The `deparseAggref()` function recognizes this flag and calls `deparseArray()` when it's set, rather than deparsing each argument (assertions ensure there is only one constant expression). Since `deparseArray()` emits parentheses (because we make `array_as_tuple` true), move the opening of the parens into the other conditional branches. Also move `omit_star` to the top of the function and fix old references to "parameterized" to the more correct "parametric".

Add tests for the new functions and list them in the reference documentation. Split out the custom ordered set aggregate functions created by pg_clickhouse into their own section, mirroring the treatment of aggregate functions elsewhere in the docs.

Also fix a pasto for the #290 URL and the changelog item when `percentile_cont(double)` pushdown was added.

Remove an old `PG_VERSION_NUM` conditional that's no longer needed, as we don't support Postgres 12 or earlier.

With this commit, all Postgres aggregate functions with known corresponding ClickHouse functions now push down.

Closes #37.