### PR TITLE
Add ClickHouse server-version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [0.3.3] — Unreleased
+## [0.4.0] — Unreleased
 
 ### ⚡ Improvements
 
+*   Added the `clickhouse_server_version(server)` function, which reports the
+    ClickHouse server version ("major.minor.patch") for a foreign server
+    ([#293]).
 *   Added pushdown for more aggregate functions ([#290]):
     *   [corr]
     *   [covarpop]
@@ -57,7 +60,7 @@ All notable changes to this project will be documented in this file. It uses the
     Postgres ordered set aggregate functions, putting them under their own
     header, "Custom Ordered Set Aggregates".
 
-  [v0.3.3]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.2...v0.3.3
+  [v0.4.0]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.3.2...v0.4.0
   [#290]: https://github.com/ClickHouse/pg_clickhouse/pull/290
     "ClickHouse/pg_clickhouse#290 Add pushdown for statistical aggregate functions"
   [corr]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/corr
@@ -69,6 +72,8 @@ All notable changes to this project will be documented in this file. It uses the
   [var_samp/variance]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varSamp
   [#291]: https://github.com/ClickHouse/pg_clickhouse/pull/291
     "ClickHouse/pg_clickhouse#291 Push down ordered set aggregate functions"
+  [#293]: https://github.com/ClickHouse/pg_clickhouse/pull/293
+    "ClickHouse/pg_clickhouse#293 Add ClickHouse server-version detection plumbing"
   [#296]: https://github.com/ClickHouse/pg_clickhouse/pull/296
     "ClickHouse/pg_clickhouse#296 Fix benchmark queries that crash/hang with binary driver"
   [#300]: https://github.com/ClickHouse/pg_clickhouse/pull/300

--- a/META.json
+++ b/META.json
@@ -27,7 +27,7 @@
       "abstract": "Interfaces to query ClickHouse databases from Postgres",
       "docfile": "doc/pg_clickhouse.md",
       "file": "pg_clickhouse.control",
-      "version": "0.3.2"
+      "version": "0.4.0"
     }
   },
   "resources": {
@@ -49,5 +49,5 @@
     "pushdown",
     "aggregate"
   ],
-  "version": "0.3.2"
+  "version": "0.4.0"
 }

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1047,6 +1047,27 @@ SELECT clickhouse_raw_query(
 (1 row)
 ```
 
+#### `clickhouse_server_version`
+
+```sql
+SELECT clickhouse_server_version('taxi_srv');
+```
+
+Report the ClickHouse server version, as `major.minor.patch`, for the named
+foreign server, connecting if necessary using the server's options and the
+current user's user mapping:
+
+```sql
+ clickhouse_server_version
+---------------------------
+ 25.8.1
+(1 row)
+```
+
+Reads the version from the native-protocol connection handshake, or over HTTP
+from a single `SELECT version()` query, and caches it for the life of the
+connection.
+
 ### Pushdown Functions
 
 `pg_clickhouse` pushes down a subset of the PostgreSQL builtin functions used

--- a/pg_clickhouse.control
+++ b/pg_clickhouse.control
@@ -1,4 +1,4 @@
 comment = 'Interfaces to query ClickHouse databases from PostgreSQL'
-default_version = '0.3'
+default_version = '0.4'
 module_pathname = 'pg_clickhouse'
 relocatable = true

--- a/sql/pg_clickhouse--0.3--0.4.sql
+++ b/sql/pg_clickhouse--0.3--0.4.sql
@@ -1,0 +1,6 @@
+-- Report the ClickHouse server version ("major.minor.patch") for a foreign
+-- server, connecting if necessary.
+CREATE FUNCTION clickhouse_server_version(server_name TEXT)
+RETURNS TEXT
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;

--- a/sql/pg_clickhouse.sql
+++ b/sql/pg_clickhouse.sql
@@ -21,6 +21,13 @@ LANGUAGE C STRICT;
 -- explicit access.
 REVOKE EXECUTE ON FUNCTION clickhouse_raw_query(text, text) FROM PUBLIC;
 
+-- Report the ClickHouse server version ("major.minor.patch") for a foreign
+-- server, connecting if necessary.
+CREATE FUNCTION clickhouse_server_version(server_name TEXT)
+RETURNS TEXT
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
 CREATE FUNCTION clickhouse_fdw_validator(text[], oid)
 RETURNS VOID
 AS 'MODULE_PATHNAME'

--- a/src/binary/connection.c
+++ b/src/binary/connection.c
@@ -358,6 +358,37 @@ ch_binary_is_broken(const ch_binary_connection_t* conn) {
     return s ? s->broken : false;
 }
 
+/*
+ * Reports the ClickHouse server version (major.minor.patch) for a binary
+ * connection. The native protocol reports the server version during the
+ * handshake, so it reads the cached handshake info rather than issuing a
+ * query. Writes 0 to all out-params when the version is unavailable.
+ */
+void
+ch_binary_server_version(
+    const ch_binary_connection_t* conn,
+    int* major,
+    int* minor,
+    int* patch
+) {
+    *major = *minor = *patch = 0;
+    if (!conn) {
+        return;
+    }
+
+    const struct ch_binary_state* s = (const struct ch_binary_state*)conn->client;
+    if (!s || !s->client) {
+        return;
+    }
+
+    const chc_server_info* info = chc_client_server_info(s->client);
+    if (info) {
+        *major = (int)info->version_major;
+        *minor = (int)info->version_minor;
+        *patch = (int)info->version_patch;
+    }
+}
+
 void
 ch_binary_close(ch_binary_connection_t* conn) {
     if (!conn) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -262,6 +262,16 @@ chfdw_release_scan_connection(UserMapping* user, ch_scan_connection sconn) {
     }
 }
 
+ch_server_version
+chfdw_get_server_version(UserMapping* user) {
+    ch_connection conn = chfdw_get_connection(user);
+
+    if (conn.methods->server_version == NULL) {
+        return (ch_server_version){ 0, 0, 0 };
+    }
+    return conn.methods->server_version(conn.conn);
+}
+
 /*
  * Connection invalidation callback function
  *

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -186,6 +186,7 @@ PG_FUNCTION_INFO_V1(clickhouse_op_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_noop);
 PG_FUNCTION_INFO_V1(pgch_version);
+PG_FUNCTION_INFO_V1(clickhouse_server_version);
 static double time_used = 0;
 
 /*
@@ -391,6 +392,20 @@ clickhouse_raw_query(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_NULL();
+}
+
+/*
+ * Report the ClickHouse server version for a foreign server as
+ * "major.minor.patch", connecting if necessary.
+ */
+Datum
+clickhouse_server_version(PG_FUNCTION_ARGS) {
+    char* servername      = text_to_cstring(PG_GETARG_TEXT_P(0));
+    ForeignServer* server = GetForeignServerByName(servername, false);
+    UserMapping* user     = GetUserMapping(GetUserId(), server->serverid);
+    ch_server_version v   = chfdw_get_server_version(user);
+
+    PG_RETURN_TEXT_P(cstring_to_text(psprintf("%d.%d.%d", v.major, v.minor, v.patch)));
 }
 
 /* calculate difference */

--- a/src/http.c
+++ b/src/http.c
@@ -217,6 +217,72 @@ ch_http_simple_query(ch_http_connection_t* conn, const ch_query* query) {
     return resp;
 }
 
+/*
+ * Fetches and caches the ClickHouse server version via SELECT version().
+ * Writes 0 to all out-params when the version cannot be determined. Caches the
+ * result on the connection, so only the first call issues a query.
+ */
+void
+ch_http_server_version(ch_http_connection_t* conn, int* major, int* minor, int* patch) {
+    *major = *minor = *patch = 0;
+    if (conn == NULL) {
+        return;
+    }
+
+    /* conn is calloc'd (see ch_http_connect), so version.major == 0 reliably
+     * means the version has not been fetched and cached yet. */
+    if (conn->version.major == 0) {
+        ch_query query           = { "SELECT version()", 0, NULL, NULL, NULL, NULL };
+        ch_http_response_t* resp = ch_http_simple_query(conn, &query);
+
+        if (resp != NULL) {
+            if (resp->http_status == CH_HTTP_STATUS_OK && resp->data != NULL) {
+                int parsed, v_tweak;
+                char buf[32];
+                size_t n =
+                    resp->datasize < sizeof(buf) - 1 ? resp->datasize : sizeof(buf) - 1;
+
+                memcpy(buf, resp->data, n);
+                buf[n] = '\0';
+
+                /* Parse `major.minor.patch.tweak` from `version()` output. */
+                parsed = sscanf(
+                    buf,
+                    "%d.%d.%d.%d",
+                    &conn->version.major,
+                    &conn->version.minor,
+                    &conn->version.patch,
+                    &v_tweak
+                );
+                if (parsed < 4) {
+                    elog(
+                        WARNING,
+                        "pg_clickhouse: unexpected ClickHouse version() output \"%s\"",
+                        buf
+                    );
+                }
+                if (parsed < 2) {
+                    /* Version string probably trash; zero out. */
+                    conn->version.major = 0;
+                }
+            } else if (resp->http_status != CH_HTTP_STATUS_OK) {
+                elog(
+                    WARNING,
+                    "pg_clickhouse: SELECT version() failed (HTTP status %d): %.*s",
+                    (int)resp->http_status,
+                    resp->data ? (int)resp->datasize : 0,
+                    resp->data ? resp->data : ""
+                );
+            }
+            ch_http_response_free(resp);
+        }
+    }
+
+    *major = conn->version.major;
+    *minor = conn->version.minor;
+    *patch = conn->version.patch;
+}
+
 void
 ch_http_close(ch_http_connection_t* conn) {
     free(conn->base_url);

--- a/src/include/binary.h
+++ b/src/include/binary.h
@@ -41,6 +41,18 @@ ch_binary_close(ch_binary_connection_t* conn);
 extern bool
 ch_binary_is_broken(const ch_binary_connection_t* conn);
 
+/*
+ * Read the server version captured during the native-protocol handshake.
+ * Writes 0 to all out-params when the version is unavailable.
+ */
+extern void
+ch_binary_server_version(
+    const ch_binary_connection_t* conn,
+    int* major,
+    int* minor,
+    int* patch
+);
+
 /* SELECT. */
 extern ch_binary_response_t*
 ch_binary_simple_query(

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -25,6 +25,7 @@
 #include "nodes/execnodes.h"
 #include "nodes/pathnodes.h"
 #include "optimizer/optimizer.h"
+#include "server_version.h"
 #include "utils/relcache.h"
 
 #if PG_VERSION_NUM < 150000
@@ -86,6 +87,8 @@ typedef ch_cursor* (*streaming_query_method)(
 );
 typedef bool (*is_broken_method)(const void* conn);
 
+typedef ch_server_version (*server_version_method)(void* conn);
+
 typedef struct {
     disconnect_method disconnect;
     simple_query_method simple_query;
@@ -96,7 +99,8 @@ typedef struct {
                                                   * step needed */
     streaming_query_method streaming_query;      /* NULL if not supported */
     cursor_fetch_row_method streaming_fetch_row; /* NULL if not supported */
-    is_broken_method is_broken; /* NULL means connection is never broken */
+    is_broken_method is_broken;           /* NULL means connection is never broken */
+    server_version_method server_version; /* NULL if version is unavailable */
 } libclickhouse_methods;
 
 typedef struct {
@@ -111,6 +115,13 @@ ch_connection
 chfdw_http_connect(ch_connection_details* details);
 ch_connection
 chfdw_binary_connect(ch_connection_details* details);
+/*
+ * Return the ClickHouse server version for the connection bound to the given
+ * user mapping, connecting if necessary. Safe to call during planning.
+ * Returns {0, 0, 0} when the driver cannot report a version.
+ */
+ch_server_version
+chfdw_get_server_version(UserMapping* user);
 text*
 chfdw_http_fetch_raw_data(ch_cursor* cursor);
 List*

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -61,6 +61,8 @@ void
 ch_http_close(ch_http_connection_t* conn);
 ch_http_response_t*
 ch_http_simple_query(ch_http_connection_t* conn, const ch_query* query);
+void
+ch_http_server_version(ch_http_connection_t* conn, int* major, int* minor, int* patch);
 char*
 ch_http_last_error(void);
 

--- a/src/include/internal.h
+++ b/src/include/internal.h
@@ -2,12 +2,16 @@
 #define CLICKHOUSE_INTERNAL_H
 
 #include "curl/curl.h"
+#include "server_version.h"
 
 typedef struct ch_http_connection_t {
     CURL* curl;
     char* dbname;
     char* base_url;
     long ssl_version; /* CURLOPT_SSLVERSION min; DEFAULT means unset */
+    /* Server version, fetched lazily via SELECT version() then cached; a major
+     * of 0 means not fetched yet. */
+    ch_server_version version;
 } ch_http_connection_t;
 
 typedef struct ch_binary_connection_t {

--- a/src/include/server_version.h
+++ b/src/include/server_version.h
@@ -1,0 +1,27 @@
+/*
+ * server_version.h
+ *
+ * The ClickHouse server version reported by an active connection. Kept in its
+ * own dependency-free header so it can be shared between the low-level driver
+ * state in internal.h (which pulls in no Postgres headers) and the FDW layer
+ * in fdw.h, without coupling the two.
+ */
+
+#ifndef CLICKHOUSE_SERVER_VERSION_H
+#define CLICKHOUSE_SERVER_VERSION_H
+
+#include <stdbool.h>
+
+typedef struct ch_server_version {
+    int major;
+    int minor;
+    int patch;
+} ch_server_version;
+
+/* True if version v is at least major.minor. */
+static inline bool
+chfdw_version_ge(ch_server_version v, int major, int minor) {
+    return v.major > major || (v.major == major && v.minor >= minor);
+}
+
+#endif /* CLICKHOUSE_SERVER_VERSION_H */

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -53,6 +53,8 @@ static void
 char_to_datum(ChFdwScanRowContext* ctx, int attnum, char* data, size_t len);
 static void
 report_http_stream_query_failure(void* conn, const ch_query* query, HttpStream* stream);
+static ch_server_version
+http_server_version(void* conn);
 
 static libclickhouse_methods http_methods = {
     .disconnect          = http_disconnect,
@@ -62,6 +64,7 @@ static libclickhouse_methods http_methods = {
     .insert_tuple        = http_insert_tuple,
     .streaming_query     = http_streaming_query,
     .streaming_fetch_row = http_streaming_fetch_row,
+    .server_version      = http_server_version,
 };
 
 static void
@@ -96,6 +99,8 @@ extern char*
 ch_quote_literal(const char* rawstr);
 extern const char*
 ch_quote_ident(const char* rawstr);
+static ch_server_version
+binary_server_version(void* conn);
 
 static libclickhouse_methods binary_methods = {
     .disconnect          = binary_disconnect,
@@ -107,6 +112,7 @@ static libclickhouse_methods binary_methods = {
     .streaming_query     = NULL,
     .streaming_fetch_row = NULL,
     .is_broken           = binary_is_broken,
+    .server_version      = binary_server_version,
 };
 
 static int
@@ -195,6 +201,14 @@ http_disconnect(void* conn) {
     if (conn != NULL) {
         ch_http_close((ch_http_connection_t*)conn);
     }
+}
+
+static ch_server_version
+http_server_version(void* conn) {
+    ch_server_version v = { 0, 0, 0 };
+
+    ch_http_server_version((ch_http_connection_t*)conn, &v.major, &v.minor, &v.patch);
+    return v;
 }
 
 /*
@@ -899,6 +913,16 @@ binary_disconnect(void* conn) {
 static bool
 binary_is_broken(const void* conn) {
     return ch_binary_is_broken((const ch_binary_connection_t*)conn);
+}
+
+static ch_server_version
+binary_server_version(void* conn) {
+    ch_server_version v = { 0, 0, 0 };
+
+    ch_binary_server_version(
+        (ch_binary_connection_t*)conn, &v.major, &v.minor, &v.patch
+    );
+    return v;
 }
 
 static ch_cursor*

--- a/test/expected/server_version.out
+++ b/test/expected/server_version.out
@@ -1,0 +1,28 @@
+-- Verify the server-version plumbing: clickhouse_server_version() reports a
+-- plausible ClickHouse version over both the binary and HTTP drivers. The
+-- exact version is environment-specific, so assert only that a real version is
+-- returned in "major.minor.patch" form with a non-zero major.
+-- Suppress the env-dependent "drop cascades to user mapping for <user>" notice.
+SET client_min_messages = warning;
+CREATE SERVER srv_ver_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER srv_ver_binary;
+CREATE SERVER srv_ver_http FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER srv_ver_http;
+SELECT clickhouse_server_version('srv_ver_binary') ~ '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+           AS binary_well_formed;
+ binary_well_formed 
+--------------------
+ t
+(1 row)
+
+SELECT clickhouse_server_version('srv_ver_http') ~ '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+           AS http_well_formed;
+ http_well_formed 
+------------------
+ t
+(1 row)
+
+DROP SERVER srv_ver_binary CASCADE;
+DROP SERVER srv_ver_http CASCADE;

--- a/test/sql/server_version.sql
+++ b/test/sql/server_version.sql
@@ -1,0 +1,23 @@
+-- Verify the server-version plumbing: clickhouse_server_version() reports a
+-- plausible ClickHouse version over both the binary and HTTP drivers. The
+-- exact version is environment-specific, so assert only that a real version is
+-- returned in "major.minor.patch" form with a non-zero major.
+
+-- Suppress the env-dependent "drop cascades to user mapping for <user>" notice.
+SET client_min_messages = warning;
+CREATE SERVER srv_ver_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER srv_ver_binary;
+
+CREATE SERVER srv_ver_http FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (driver 'http');
+CREATE USER MAPPING FOR CURRENT_USER SERVER srv_ver_http;
+
+SELECT clickhouse_server_version('srv_ver_binary') ~ '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+           AS binary_well_formed;
+
+SELECT clickhouse_server_version('srv_ver_http') ~ '^[1-9][0-9]*\.[0-9]+\.[0-9]+$'
+           AS http_well_formed;
+
+DROP SERVER srv_ver_binary CASCADE;
+DROP SERVER srv_ver_http CASCADE;


### PR DESCRIPTION
Exposes the ClickHouse server version to the planner via
`chfdw_get_server_version(UserMapping*)`, with a `chfdw_version_ge()`
comparison helper. This is the reusable plumbing a follow-up will use to gate
subquery pushdown on the server version, so older ClickHouse releases degrade
gracefully instead of erroring on SQL their analyzer cannot handle.

## What's here

- A `server_version` method on the `libclickhouse_methods` vtable, backed by a
  small dependency-free `ch_server_version` struct (shared between the
  Postgres-free driver internals and the FDW layer).
- **Binary driver:** reads the version straight from the native-protocol
  handshake (`chc_client_server_info`) — free once the connection exists.
- **HTTP driver:** ClickHouse exposes no version over HTTP (no response header,
  and the "connection" is just a curl handle with no server round-trip), so it
  fetches `SELECT version()` once and caches it on the connection.
- A `clickhouse_server_version(text)` SQL function returning
  `major.minor.patch`, which exercises both drivers and is covered by the new
  `server_version` regression test.

## Notes

- No behavior change to existing flows: nothing calls the getter at plan time
  yet, so planning still opens no connection. The (amortized, once-per-session)
  plan-time connect arrives with the gate in the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
