### PR TITLE
Fix benchmark queries that crash/hang with binary driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ All notable changes to this project will be documented in this file. It uses the
     *   `percentile_disc(double)` → `quantileExactLow()`
     *   `percentile_disc(double[])` → `quantilesExactLow()`
 
+### 🐞 Bug Fixes
+
+*   Fixed crashes when a single query ran more than one foreign scan on the
+    binary (native-protocol) driver at once, such as a correlated subquery or a
+    nested-loop join over foreign tables, colliding in the single connection.
+    Each concurrently active scan now gets its own connection
+    ([#296]).
+*   Fixed a use-after-free of a foreign scan's batch memory context on rescan
+    that could corrupt memory and hang ([#296]).
+
 ### 📚 Documentation
 
 *   Separated the list of custom ordered set aggregate functions provided by
@@ -44,6 +54,8 @@ All notable changes to this project will be documented in this file. It uses the
   [var_samp/variance]: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/varSamp
   [#291]: https://github.com/ClickHouse/pg_clickhouse/pull/291
     "ClickHouse/pg_clickhouse#291 Push down ordered set aggregate functions"
+  [#296]: https://github.com/ClickHouse/pg_clickhouse/pull/296
+    "ClickHouse/pg_clickhouse#296 Fix benchmark queries that crash/hang with binary driver"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -35,8 +35,19 @@
  * Connection cache (initialized on first use)
  */
 static HTAB* ConnectionHash = NULL;
+
+/*
+ * Private (non-cached) connections handed to foreign scans that needed a
+ * connection while the cached one was already serving a live ancestor scan.
+ * Tracked so a transaction-end callback can close any whose scan did not
+ * release cleanly (e.g. on error).
+ */
+static List* PrivateConnections = NIL;
+
 static void
 chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue);
+static void
+chfdw_xact_callback(XactEvent event, void* arg);
 
 static ch_connection
 clickhouse_connect(ForeignServer* server, UserMapping* user) {
@@ -83,8 +94,8 @@ clickhouse_connect(ForeignServer* server, UserMapping* user) {
     }
 }
 
-ch_connection
-chfdw_get_connection(UserMapping* user) {
+static ConnCacheEntry*
+get_connection_entry(UserMapping* user) {
     bool found;
     ConnCacheEntry* entry;
     ConnCacheKey key;
@@ -108,6 +119,7 @@ chfdw_get_connection(UserMapping* user) {
          */
         CacheRegisterSyscacheCallback(FOREIGNSERVEROID, chfdw_inval_callback, (Datum)0);
         CacheRegisterSyscacheCallback(USERMAPPINGOID, chfdw_inval_callback, (Datum)0);
+        RegisterXactCallback(chfdw_xact_callback, NULL);
     }
 
     /* Create hash key for the entry. Assume no pad bytes in key struct */
@@ -178,7 +190,76 @@ chfdw_get_connection(UserMapping* user) {
         );
     }
 
-    return entry->gate;
+    return entry;
+}
+
+ch_connection
+chfdw_get_connection(UserMapping* user) {
+    return get_connection_entry(user)->gate;
+}
+
+ch_scan_connection
+chfdw_get_scan_connection(UserMapping* user) {
+    ConnCacheEntry* entry = get_connection_entry(user);
+    ch_scan_connection sconn;
+
+    if (!entry->busy) {
+        entry->busy      = true;
+        sconn.gate       = entry->gate;
+        sconn.is_private = false;
+        return sconn;
+    }
+
+    /*
+     * The cached connection is already serving a live ancestor scan (e.g. the
+     * outer scan of a correlated subquery). ClickHouse allows only one query in
+     * flight per connection, so open a private one for this scan and remember
+     * it so chfdw_xact_callback can close it if the scan does not release.
+     */
+    {
+        ForeignServer* server = GetForeignServer(user->serverid);
+        ch_connection* held;
+        MemoryContext old;
+
+        old                = MemoryContextSwitchTo(CacheMemoryContext);
+        held               = palloc(sizeof(ch_connection));
+        *held              = clickhouse_connect(server, user);
+        PrivateConnections = lappend(PrivateConnections, held);
+        MemoryContextSwitchTo(old);
+
+        sconn.gate       = *held;
+        sconn.is_private = true;
+        return sconn;
+    }
+}
+
+void
+chfdw_release_scan_connection(UserMapping* user, ch_scan_connection sconn) {
+    if (sconn.is_private) {
+        ListCell* lc;
+
+        foreach (lc, PrivateConnections) {
+            ch_connection* held = (ch_connection*)lfirst(lc);
+
+            if (held->conn == sconn.gate.conn) {
+                PrivateConnections = foreach_delete_current(PrivateConnections, lc);
+                pfree(held);
+                break;
+            }
+        }
+        if (sconn.gate.conn != NULL) {
+            sconn.gate.methods->disconnect(sconn.gate.conn);
+        }
+    } else if (ConnectionHash != NULL) {
+        /* Communal: drop the busy lease only; the cache owns closing it. */
+        ConnCacheKey key      = { user->umid };
+        bool found            = false;
+        ConnCacheEntry* entry = hash_search(ConnectionHash, &key, HASH_FIND, &found);
+
+        if (found && entry != NULL) {
+            entry->busy = false;
+        }
+    }
 }
 
 /*
@@ -216,6 +297,42 @@ chfdw_inval_callback(Datum arg, int cacheid, uint32 hashvalue) {
             (cacheid == FOREIGNSERVEROID && entry->server_hashvalue == hashvalue) ||
             (cacheid == USERMAPPINGOID && entry->mapping_hashvalue == hashvalue)) {
             entry->invalidated = true;
+        }
+    }
+}
+
+/*
+ * Transaction-end cleanup. By the end of a transaction no foreign scan is live,
+ * so close any private scan connections that were not released (e.g. a scan
+ * whose End was skipped on error) and clear any leftover busy markers on cached
+ * connections so they can be reused.
+ */
+static void
+chfdw_xact_callback(XactEvent event, void* arg) {
+    ListCell* lc;
+
+    if (event != XACT_EVENT_COMMIT && event != XACT_EVENT_ABORT &&
+        event != XACT_EVENT_PARALLEL_COMMIT && event != XACT_EVENT_PARALLEL_ABORT) {
+        return;
+    }
+
+    foreach (lc, PrivateConnections) {
+        ch_connection* held = (ch_connection*)lfirst(lc);
+
+        if (held->conn != NULL) {
+            held->methods->disconnect(held->conn);
+        }
+    }
+    list_free_deep(PrivateConnections);
+    PrivateConnections = NIL;
+
+    if (ConnectionHash != NULL) {
+        HASH_SEQ_STATUS scan;
+        ConnCacheEntry* entry;
+
+        hash_seq_init(&scan, ConnectionHash);
+        while ((entry = (ConnCacheEntry*)hash_seq_search(&scan)) != NULL) {
+            entry->busy = false;
         }
     }
 }

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -116,12 +116,13 @@ typedef struct ChFdwScanState {
     List* retrieved_attrs; /* list of retrieved attribute numbers */
 
     /* for remote query execution */
-    ch_connection conn;        /* connection for the scan */
-    int numParams;             /* number of parameters passed to query */
-    Oid* param_oids;           /* output parameter type OIDs them */
-    List* param_exprs;         /* executable expressions for param values */
-    const char** param_values; /* textual values of query parameters */
-    ch_cursor* ch_cursor;      /* result of query from clickhouse */
+    ch_scan_connection scan_conn; /* connection leased for this scan */
+    UserMapping* user;            /* user mapping, for releasing scan_conn */
+    int numParams;                /* number of parameters passed to query */
+    Oid* param_oids;              /* output parameter type OIDs them */
+    List* param_exprs;            /* executable expressions for param values */
+    const char** param_values;    /* textual values of query parameters */
+    ch_cursor* ch_cursor;         /* result of query from clickhouse */
 
     /* for storing result tuple */
     HeapTuple tuple; /* array of currently-retrieved tuples */
@@ -215,6 +216,8 @@ static void
 clickhouseBeginForeignScan(ForeignScanState* node, int eflags);
 static TupleTableSlot*
 clickhouseIterateForeignScan(ForeignScanState* node);
+static void
+clickhouseReScanForeignScan(ForeignScanState* node);
 static void
 clickhouseEndForeignScan(ForeignScanState* node);
 static List*
@@ -1016,9 +1019,12 @@ clickhouseBeginForeignScan(ForeignScanState* node, int eflags) {
 
     /*
      * Get connection to the foreign server. Connection manager will establish
-     * new connection if necessary.
+     * a new connection if necessary. A scan whose ancestor already holds the
+     * cached connection gets a private one, since ClickHouse permits only one
+     * query in flight per connection.
      */
-    fsstate->conn = chfdw_get_connection(user);
+    fsstate->user      = user;
+    fsstate->scan_conn = chfdw_get_scan_connection(user);
 
     /* Get private info created by planner functions. */
     fsstate->query = strVal(list_nth(fsplan->fdw_private, FdwScanPrivateSelectSql));
@@ -1104,11 +1110,11 @@ fetch_tuple(ChFdwScanState* fsstate, TupleDesc tupdesc) {
 
     /* In both cases (binary and non binary), NULL means end of tuples. */
     {
-        cursor_fetch_row_method fetch_fn = fsstate->conn.methods->fetch_row;
+        cursor_fetch_row_method fetch_fn = fsstate->scan_conn.gate.methods->fetch_row;
 
         if (fsstate->is_streaming) {
-            Assert(fsstate->conn.methods->streaming_fetch_row != NULL);
-            fetch_fn = fsstate->conn.methods->streaming_fetch_row;
+            Assert(fsstate->scan_conn.gate.methods->streaming_fetch_row != NULL);
+            fetch_fn = fsstate->scan_conn.gate.methods->streaming_fetch_row;
         }
 
         if (fetch_fn(&ctx) == NULL) {
@@ -1189,16 +1195,18 @@ clickhouseIterateForeignScan(ForeignScanState* node) {
         }
 
         fsstate->is_streaming =
-            fsstate->fetch_size > 0 && fsstate->conn.methods->streaming_query != NULL;
+            fsstate->fetch_size > 0 &&
+            fsstate->scan_conn.gate.methods->streaming_query != NULL;
 
         if (fsstate->is_streaming) {
-            fsstate->ch_cursor = fsstate->conn.methods->streaming_query(
-                fsstate->conn.conn, &query, fsstate->fetch_size
+            fsstate->ch_cursor = fsstate->scan_conn.gate.methods->streaming_query(
+                fsstate->scan_conn.gate.conn, &query, fsstate->fetch_size
             );
         } else {
             /* Binary still falls back to the simple path for now. */
-            fsstate->ch_cursor =
-                fsstate->conn.methods->simple_query(fsstate->conn.conn, &query);
+            fsstate->ch_cursor = fsstate->scan_conn.gate.methods->simple_query(
+                fsstate->scan_conn.gate.conn, &query
+            );
         }
 
         time_used += fsstate->ch_cursor->request_time;
@@ -1222,6 +1230,54 @@ clickhouseIterateForeignScan(ForeignScanState* node) {
 }
 
 /*
+ * dispose_scan
+ *		Close the current cursor (freeing its response, and for the binary driver
+ *		draining the connection so it stays reusable) and dispose of the per-scan
+ *		batch context. Shared by the rescan and end callbacks.
+ *
+ *		When reset_batch_cxt is true (a rescan) the batch context is reset rather
+ *		than deleted, because more IterateForeignScan calls follow and rebuild the
+ *		cursor and response inside it. The cursor and response contexts are
+ *		children of batch_cxt, so deleting it on a rescan would leave the next
+ *		iteration allocating in a freed context, corrupting the response context
+ *		and hanging its teardown on the following rescan of a correlated subquery.
+ *		At end of scan (reset_batch_cxt false) it is deleted.
+ */
+static void
+dispose_scan(ChFdwScanState* fsstate, bool reset_batch_cxt) {
+    if (!fsstate) {
+        return;
+    }
+
+    if (fsstate->ch_cursor) {
+        MemoryContextDelete(fsstate->ch_cursor->memcxt);
+        fsstate->ch_cursor = NULL;
+    }
+
+    if (fsstate->batch_cxt) {
+        if (reset_batch_cxt) {
+            MemoryContextReset(fsstate->batch_cxt);
+        } else {
+            MemoryContextDelete(fsstate->batch_cxt);
+        }
+    }
+}
+
+/*
+ * clickhouseReScanForeignScan
+ *		Dispose of the current cursor and tuple batch so the next iteration
+ *		re-runs the query. Keeps the connection: the scan is not finished, and
+ *		(for a correlated subquery) will run again with a new parameter value.
+ */
+static void
+clickhouseReScanForeignScan(ForeignScanState* node) {
+    ChFdwScanState* fsstate = (ChFdwScanState*)node->fdw_state;
+
+    time_used = 0;
+    dispose_scan(fsstate, true); /* reset batch_cxt; more iterations follow */
+}
+
+/*
  * clickhouseEndForeignScan
  *		Finish scanning foreign table and dispose objects used for this scan
  */
@@ -1230,12 +1286,9 @@ clickhouseEndForeignScan(ForeignScanState* node) {
     ChFdwScanState* fsstate = (ChFdwScanState*)node->fdw_state;
 
     time_used = 0;
+    dispose_scan(fsstate, false); /* delete batch_cxt; scan is finished */
     if (fsstate) {
-        if (fsstate->ch_cursor) {
-            MemoryContextDelete(fsstate->ch_cursor->memcxt);
-            fsstate->ch_cursor = NULL;
-        }
-        MemoryContextDelete(fsstate->batch_cxt);
+        chfdw_release_scan_connection(fsstate->user, fsstate->scan_conn);
     }
 }
 
@@ -3390,7 +3443,7 @@ clickhouse_fdw_handler(PG_FUNCTION_ARGS) {
     routine->GetForeignPlan     = clickhouseGetForeignPlan;
     routine->BeginForeignScan   = clickhouseBeginForeignScan;
     routine->IterateForeignScan = clickhouseIterateForeignScan;
-    routine->ReScanForeignScan  = clickhouseEndForeignScan;
+    routine->ReScanForeignScan  = clickhouseReScanForeignScan;
     routine->EndForeignScan     = clickhouseEndForeignScan;
 
     /* Functions for updating foreign tables */

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -249,6 +249,28 @@ chfdw_find_em_expr_for_rel(EquivalenceClass* ec, RelOptInfo* rel);
 /* in connection.c */
 extern ch_connection
 chfdw_get_connection(UserMapping* user);
+/*
+ * A connection leased to a foreign scan. When is_private, the scan opened it
+ * exclusively and chfdw_release_scan_connection closes it; otherwise gate is the
+ * shared cached connection and release only drops its busy lease (the connection
+ * cache, not the scan, owns the cached connection's lifetime).
+ */
+typedef struct ch_scan_connection {
+    ch_connection gate;
+    bool is_private;
+} ch_scan_connection;
+
+/*
+ * Acquire a connection for a foreign scan. Returns the cached connection if it
+ * is free, marking it busy; otherwise (a live ancestor scan already holds it)
+ * returns a freshly-opened private connection. ClickHouse permits only one query
+ * in flight per connection, so concurrent scans must not share one. Pair with
+ * chfdw_release_scan_connection at end of scan.
+ */
+extern ch_scan_connection
+chfdw_get_scan_connection(UserMapping* user);
+extern void
+chfdw_release_scan_connection(UserMapping* user, ch_scan_connection sconn);
 extern void
 chfdw_exec_query(ch_connection conn, const char* query);
 extern void
@@ -336,6 +358,7 @@ typedef struct ConnCacheEntry {
     ch_connection gate; /* connection to foreign server, or NULL */
     /* Remaining fields are invalid when conn is NULL: */
     bool invalidated;         /* true if reconnect is pending */
+    bool busy;                /* gate is held by a live foreign scan */
     uint32 server_hashvalue;  /* hash value of foreign server OID */
     uint32 mapping_hashvalue; /* hash value of user mapping OID */
 } ConnCacheEntry;

--- a/test/expected/concurrent_scans.out
+++ b/test/expected/concurrent_scans.out
@@ -1,0 +1,90 @@
+-- Regression test for crashes/hangs when one query runs more than one
+-- binary-driver foreign scan at once (correlated subquery, nested-loop join).
+-- Previously such scans collided on a single shared connection (crash), and a
+-- rescan reused a freed batch context (hang). See PR #296.
+CREATE SERVER concur_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'concur_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS concur_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE concur_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE TABLE concur_test.sales (
+    sale_id Int32, item_id Int32, amount Decimal(15, 2)
+) ENGINE = MergeTree ORDER BY sale_id;');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$INSERT INTO concur_test.sales VALUES
+    (1, 1, 100), (2, 1, 150), (3, 2, 200), (8, 1, 250)$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE SCHEMA concur;
+IMPORT FOREIGN SCHEMA concur_test FROM SERVER concur_loopback INTO concur;
+-- Correlated subquery: the inner foreign scan runs while the outer cursor is
+-- still open.
+SELECT s.sale_id
+    FROM concur.sales s
+    WHERE s.amount > (
+        SELECT avg(s2.amount) FROM concur.sales s2 WHERE s2.item_id = s.item_id
+    )
+    ORDER BY s.sale_id;
+ sale_id 
+---------
+       8
+(1 row)
+
+-- Nested-loop join over the same foreign table rescans the inner side per row.
+SET enable_hashjoin = off;
+SET enable_mergejoin = off;
+SELECT a.sale_id, b.sale_id
+    FROM concur.sales a
+    JOIN concur.sales b ON a.item_id = b.item_id
+    ORDER BY a.sale_id, b.sale_id;
+ sale_id | sale_id 
+---------+---------
+       1 |       1
+       1 |       2
+       1 |       8
+       2 |       1
+       2 |       2
+       2 |       8
+       3 |       3
+       8 |       1
+       8 |       2
+       8 |       8
+(10 rows)
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+-- LIMIT exercises the binary driver's premature-close path.
+SELECT sale_id FROM concur.sales ORDER BY sale_id LIMIT 2;
+ sale_id 
+---------
+       1
+       2
+(2 rows)
+
+DROP FOREIGN TABLE concur.sales;
+DROP USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
+DROP SERVER concur_loopback;
+DROP SCHEMA concur;
+SELECT clickhouse_raw_query('DROP DATABASE concur_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+

--- a/test/sql/concurrent_scans.sql
+++ b/test/sql/concurrent_scans.sql
@@ -1,0 +1,46 @@
+-- Regression test for crashes/hangs when one query runs more than one
+-- binary-driver foreign scan at once (correlated subquery, nested-loop join).
+-- Previously such scans collided on a single shared connection (crash), and a
+-- rescan reused a freed batch context (hang). See PR #296.
+CREATE SERVER concur_loopback FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'concur_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS concur_test');
+SELECT clickhouse_raw_query('CREATE DATABASE concur_test');
+SELECT clickhouse_raw_query('CREATE TABLE concur_test.sales (
+    sale_id Int32, item_id Int32, amount Decimal(15, 2)
+) ENGINE = MergeTree ORDER BY sale_id;');
+SELECT clickhouse_raw_query($$INSERT INTO concur_test.sales VALUES
+    (1, 1, 100), (2, 1, 150), (3, 2, 200), (8, 1, 250)$$);
+
+CREATE SCHEMA concur;
+IMPORT FOREIGN SCHEMA concur_test FROM SERVER concur_loopback INTO concur;
+
+-- Correlated subquery: the inner foreign scan runs while the outer cursor is
+-- still open.
+SELECT s.sale_id
+    FROM concur.sales s
+    WHERE s.amount > (
+        SELECT avg(s2.amount) FROM concur.sales s2 WHERE s2.item_id = s.item_id
+    )
+    ORDER BY s.sale_id;
+
+-- Nested-loop join over the same foreign table rescans the inner side per row.
+SET enable_hashjoin = off;
+SET enable_mergejoin = off;
+SELECT a.sale_id, b.sale_id
+    FROM concur.sales a
+    JOIN concur.sales b ON a.item_id = b.item_id
+    ORDER BY a.sale_id, b.sale_id;
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+
+-- LIMIT exercises the binary driver's premature-close path.
+SELECT sale_id FROM concur.sales ORDER BY sale_id LIMIT 2;
+
+DROP FOREIGN TABLE concur.sales;
+DROP USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
+DROP SERVER concur_loopback;
+DROP SCHEMA concur;
+SELECT clickhouse_raw_query('DROP DATABASE concur_test');


### PR DESCRIPTION
clickhouse-cpp read eagerly (buffered the whole result, freeing the
connection immediately), while clickhouse-c reads lazily (streams one
block at a time, holding connection open through iteration).

Two independent bugs, both in the FDW layer (binary driver untouched):

1. Concurrent foreign scans no longer share one connection.
   The binary driver streams results, holding a connection open through
   iteration, and ClickHouse's native protocol has no cursors to use to
   multiplex result sets on a single connection. So two scans live at
   once (a correlated subquery's inner + outer; a nestloop's inner)
   collided and crashed.

2. Had a `batch_cxt` use-after-free on rescan.
   ReScanForeignScan was wired to EndForeignScan, which deleted the
   per-scan `batch_cxt` and never recreated it, so the next
   `IterateForeignScan` built its cursor and response in freed memory.
   This bug exists on main and is driver-agnostic. It only hangs with
   clickhouse-c backing, whose cursor teardown deletes a nested context
   (`resp->cxt`) over the freed arena and loops; the buffering drivers
   (clickhouse-cpp before, HTTP today) don't do this during teardown.
   With clickhouse-c, the connection collision crashed first, further
   hiding this bug.

A new `ch_scan_connection` handle leases the cached connection to the
first scan and hands any scan that begins in the meantime its own
private connection; release closes private connections and only drops
the busy lease on the cached one (the connection cache owns the cached
connection's lifetime, not the scan). A transaction-end callback
reclaims private connections left by error paths.

Split `ReScanForeignScan` and `EndForeignScan`: `ReScan` resets
`batch_cxt` (keeps it live for the next iteration); `End` deletes it.
