### PR TITLE
Shorten timeout for binary driver in query_cancel

### DIFF
--- a/test/expected/query_cancel.out
+++ b/test/expected/query_cancel.out
@@ -64,7 +64,7 @@ SELECT count(*) FROM cancel_binary_ft;
 (1 row)
 
 -- The repeated CROSS JOINs intentionally create a large remote result set,
--- so the 10ms timeout fires while the remote query is still running.
+-- so the statement_timeout fires while the remote query is still running.
 -- HTTP streaming: exercises the curl progress-callback cancel path via
 -- the streaming implementation.
 BEGIN;
@@ -83,7 +83,7 @@ ERROR:  pg_clickhouse: query was aborted
 COMMIT;
 -- Binary: same test, exercising the OnProgress cancel path.
 BEGIN;
-SET LOCAL statement_timeout = '10ms';
+SET LOCAL statement_timeout = '1ms';
 SELECT count(*) FROM cancel_binary_ft a CROSS JOIN cancel_binary_ft b
     CROSS JOIN cancel_binary_ft c CROSS JOIN cancel_binary_ft d;
 ERROR:  pg_clickhouse: query was canceled

--- a/test/sql/query_cancel.sql
+++ b/test/sql/query_cancel.sql
@@ -36,7 +36,7 @@ SELECT count(*) FROM cancel_http_buf_ft;
 SELECT count(*) FROM cancel_binary_ft;
 
 -- The repeated CROSS JOINs intentionally create a large remote result set,
--- so the 10ms timeout fires while the remote query is still running.
+-- so the statement_timeout fires while the remote query is still running.
 -- HTTP streaming: exercises the curl progress-callback cancel path via
 -- the streaming implementation.
 BEGIN;
@@ -55,7 +55,7 @@ COMMIT;
 
 -- Binary: same test, exercising the OnProgress cancel path.
 BEGIN;
-SET LOCAL statement_timeout = '10ms';
+SET LOCAL statement_timeout = '1ms';
 SELECT count(*) FROM cancel_binary_ft a CROSS JOIN cancel_binary_ft b
     CROSS JOIN cancel_binary_ft c CROSS JOIN cancel_binary_ft d;
 COMMIT;


### PR DESCRIPTION
It was failing with `canceling statement due to statement timeout` rather than the expected `pg_clickhouse: query was canceled`.