### PR TITLE
binary driver autoflush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this project will be documented in this file. It uses the
     day, and second component, replacing nested
     `addMonths`/`addDays`/`addSeconds` calls that mishandled day arithmetic on
     dates and drifted across DST boundaries ([#301]).
+*   Binary driver now flushes insert block once it buffers 64MiB,
+    bounding memory for large `COPY FROM` and `INSERT SELECT` ([#303]).
 
 ### 🐞 Bug Fixes
 
@@ -73,6 +75,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#300 fix(http): handle subsecond precision"
   [#301]: https://github.com/ClickHouse/pg_clickhouse/pull/301
     "ClickHouse/pg_clickhouse#301 improve interval support"
+  [#303]: https://github.com/ClickHouse/pg_clickhouse/pull/303
+    "ClickHouse/pg_clickhouse#303 Flush buffered data during binary insert"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -679,11 +679,15 @@ try=# COPY logs FROM stdin CSV;
 >> COPY 3
 ```
 
-> **⚠️ Batch API Limitations**
->
-> pg_clickhouse has not yet implemented support for the PostgreSQL FDW batch
-> insert API. Thus [COPY] currently uses [INSERT](#insert) statements to
-> insert records. This will be improved in a future release.
+`COPY FROM` streams the rows to ClickHouse in bulk.
+
+`COPY TO` directly from a foreign table is not supported: PostgreSQL itself
+rejects `COPY <foreign_table> TO` with the hint to use the `COPY (SELECT ...) TO`
+variant. Use that variant to copy rows out of a ClickHouse foreign table:
+
+```pgsql
+try=# COPY (SELECT * FROM logs) TO stdout CSV;
+```
 
 ### LOAD
 

--- a/src/binary/insert.c
+++ b/src/binary/insert.c
@@ -1239,6 +1239,28 @@ build_lc_dict(
     *out_n_rows    = n_rows;
 }
 
+/*
+ * Flush once insert buffered reaches 64MiB, so large COPY or INSERT SELECT
+ * streams blocks instead of accumulating all rows in memory. Server coalesces
+ * small blocks within one INSERT via min_insert_block_size_rows/bytes.
+ */
+void
+ch_binary_insert_autoflush(ch_binary_insert_state* state) {
+    ch_binary_insert_handle* h = state->insert_block;
+
+    if (h) {
+        size_t total = 0;
+        for (size_t i = 0; i < h->ncols; i++) {
+            const ic_col* c = &h->cols[i];
+            total += c->body.len + c->nulls.len +
+                     (c->body_offs.len + c->arr_offs.len) * sizeof(uint64_t);
+        }
+        if (total >= 64 * 1024 * 1024) {
+            ch_binary_flush_block(h);
+        }
+    }
+}
+
 void
 ch_binary_flush_block(ch_binary_insert_handle* h) {
     MemoryContext old     = MemoryContextSwitchTo(h->cxt);

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -3465,13 +3465,11 @@ clickhouse_fdw_handler(PG_FUNCTION_ARGS) {
     routine->ExecForeignInsert  = clickhouseExecForeignInsert;
 
     /*
-     * TODO:Add support for ClickHouse 25.8 and later.
+     * No ExecForeignBatchInsert / GetForeignModifyBatchSize: both drivers
+     * already buffer rows and stream them as a single INSERT to ClickHouse, so
+     * PG's batch-insert API would add nothing.
      *
-     * routine->ExecForeignBatchInsert = XXX;
-     *
-     * routine->ExecForeignUpdate = XXX;
-     *
-     * routine->ExecForeignDelete = XXX;
+     * TODO ExecForeignUpdate / ExecForeignDelete via ClickHouse mutations.
      */
 
     routine->EndForeignInsert = clickhouseEndForeignInsert;

--- a/src/include/binary.h
+++ b/src/include/binary.h
@@ -129,6 +129,8 @@ extern void
 ch_binary_insert_columns(ch_binary_insert_state* state);
 extern void
 ch_binary_column_append_data(ch_binary_insert_state* state, size_t colidx);
+extern void
+ch_binary_insert_autoflush(ch_binary_insert_state* state);
 extern void*
 ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc, Oid relid);
 extern void

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -1221,6 +1221,8 @@ binary_insert_tuple(void* istate, TupleTableSlot* slot) {
         for (size_t i = 0; i < state->outdesc->natts; i++) {
             ch_binary_column_append_data(state, i);
         }
+
+        ch_binary_insert_autoflush(state);
     } else {
         ch_binary_insert_columns(state);
     }

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -505,6 +505,25 @@ SELECT * FROM not_nullable ORDER BY c1;
   2 | x  | x  | lc
 (2 rows)
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+ 20 | 21 | 22 | 23
+ 21 | 22 | 23 | 24
+(2 rows)
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2  
+----+-----
+ 20 | 200
+ 21 |    
+ 22 | 220
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -496,6 +496,25 @@ SELECT * FROM not_nullable ORDER BY c1;
   2 | x  | x  | lc
 (2 rows)
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+ 20 | 21 | 22 | 23
+ 21 | 22 | 23 | 24
+(2 rows)
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2  
+----+-----
+ 20 | 200
+ 21 |    
+ 22 | 220
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
  clickhouse_raw_query 

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -481,6 +481,25 @@ SELECT * FROM default_vals;
   1 |  0 |  0 |  0 |  0 |  0 |  0 |  0 |  0 |   0 |   0 | 0.0 | 0.0 | 0.0 |   0 |     |     |     | 1970-01-01 | 1970-01-01 | 1969-12-31 16:00:00-08 | 1969-12-31 16:00:00-08 | {0} | 00000000-0000-0000-0000-000000000000 | 0.0.0.0 | ::
 (1 row)
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+ 20 | 21 | 22 | 23
+ 21 | 22 | 23 | 24
+(2 rows)
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2  
+----+-----
+ 20 | 200
+ 21 |    
+ 22 | 220
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -472,6 +472,25 @@ SELECT * FROM default_vals;
   1 |  0 |  0 |  0 |  0 |  0 |  0 |  0 |  0 |   0 |   0 | 0.0 | 0.0 | 0.0 |   0 |     |     |     | 1970-01-01 | 1970-01-01 | 1969-12-31 16:00:00-08 | 1969-12-31 16:00:00-08 | {0} | 00000000-0000-0000-0000-000000000000 | 0.0.0.0 | ::
 (1 row)
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+ 20 | 21 | 22 | 23
+ 21 | 22 | 23 | 24
+(2 rows)
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2  
+----+-----
+ 20 | 200
+ 21 |    
+ 22 | 220
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 

--- a/test/expected/http_inserts_2.out
+++ b/test/expected/http_inserts_2.out
@@ -510,6 +510,25 @@ SELECT * FROM default_vals;
 ----+----+----+----+----+----+----+----+----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----
 (0 rows)
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2 | c3 | c4 
+----+----+----+----
+ 20 | 21 | 22 | 23
+ 21 | 22 | 23 | 24
+(2 rows)
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+ c1 | c2  
+----+-----
+ 20 | 200
+ 21 |    
+ 22 | 220
+(3 rows)
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
  clickhouse_raw_query 

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -262,6 +262,21 @@ SELECT * FROM default_vals;
 INSERT INTO not_nullable VALUES (1, 'x', 'x', NULL), (2, 'x', 'x', 'lc');
 SELECT * FROM not_nullable ORDER BY c1;
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+20	21	22	23
+21	22	23	24
+\.
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+20	200
+21	\N
+22	220
+\.
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
 DROP SERVER binary_inserts_loopback CASCADE;

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -249,6 +249,21 @@ INSERT INTO default_vals VALUES(
 
 SELECT * FROM default_vals;
 
+/* COPY FROM bulk-loads rows into the remote table. */
+COPY ints (c1, c2, c3, c4) FROM stdin;
+20	21	22	23
+21	22	23	24
+\.
+SELECT c1, c2, c3, c4 FROM ints WHERE c1 >= 20 ORDER BY c1;
+
+/* NULLs, plus a ClickHouse-partitioned target. */
+COPY null_ints (c1, c2) FROM stdin;
+20	200
+21	\N
+22	220
+\.
+SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
+
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
 DROP SERVER http_inserts_loopback CASCADE;


### PR DESCRIPTION
binary driver was batching insert or `COPY FROM` in memory, extend so that after 64MiB it flushes. Keeps memory usage streaming while ClickHouse combines flushed blocks on its end within an insert

`ExecForeignBatchInsert` not needed for pg_clickhouse as buffering/flushing is already implemented