### PR TITLE
Fix misc undefined behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ All notable changes to this project will be documented in this file. It uses the
 *   Fixed a use-after-free of a foreign scan's batch memory context on rescan
     that could corrupt memory and hang ([#296]).
 *   Fixed subsecond precision lost inserting timestamps over HTTP ([#300]).
+*   Fixed undefined behavior: out-of-bounds reads in key/value iteration, and
+    binary driver's simple query path; `CollapsingMergeTree` validation; missing
+    rejection of non-`Const`/null units in `date_trunc`/`date_part` pushdown;
+    NULL handling in record conversion; unchecked `curl_easy_escape` failures;
+    and unbounded `DateTime64` scale lookups ([#313]).
 
 ### 📚 Documentation
 
@@ -109,6 +114,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#309 add binary support to clickhouse_raw_query, add clickhouse_query"
   [#310]: https://github.com/ClickHouse/pg_clickhouse/pull/310
     "ClickHouse/pg_clickhouse#310 Disable MinMaxAgg without impacting overall query planner costs"
+  [#313]: https://github.com/ClickHouse/pg_clickhouse/pull/313
+    "ClickHouse/pg_clickhouse#313 Fix misc undefined behavior"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ OBJS = $(subst .c,.o, $(wildcard src/*.c src/*/*.c))
 # CH_C_DIR to point elsewhere when developing against a local checkout.
 CH_C_DIR ?= vendor/clickhouse-c
 
-# Add include directories.
-PG_CPPFLAGS = -I./src/include -I$(CH_C_DIR)
+# Own headers via -I; vendored and PG server headers via -isystem so their
+# own warnings (eg -Wsign-compare in PG array.h macros) don't trip -Werror.
+PG_CPPFLAGS = -I./src/include -isystem $(CH_C_DIR) -isystem $(shell $(PG_CONFIG) --includedir-server)
 
 # Link OpenSSL (for TLS in the binary driver), curl (for the HTTP driver),
 # libuuid (for http_streaming.c's query-id generator), and lz4 / zstd
@@ -36,8 +37,11 @@ ifneq ($(OS),darwin)
 	PG_LDFLAGS += -luuid
 endif
 
-# Suppress annoying pre-c99 warning, error on other warnings, include curl.
-PG_CFLAGS = -Wno-declaration-after-statement -Wall -Werror $(shell $(CURL_CONFIG) --cflags)
+# -Wclobbered catches vars live across PG_TRY's setjmp that aren't volatile.
+# GCC-only: Probe $(CC) before adding.
+WCLOBBERED = $(shell $(CC) -Werror -Wclobbered -x c -c /dev/null -o /dev/null >/dev/null 2>&1 && echo -Wclobbered)
+
+PG_CFLAGS = -Wno-declaration-after-statement -Wall $(WCLOBBERED) -Wsign-compare -Werror $(shell $(CURL_CONFIG) --cflags)
 
 # Clean up generated files.
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql src/include/version.h compile_commands.json test/schedule $(EXTENSION)-$(DISTVERSION).zip

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -307,7 +307,7 @@ CREATE FOREIGN TABLE acts (
     sign       smallint
 ) SERVER taxi_srv OPTIONS(
     table_name 'acts',
-    engine 'CollapsingMergeTree'
+    engine 'CollapsingMergeTree(sign)'
 );
 ```
 

--- a/src/binary/binary.c
+++ b/src/binary/binary.c
@@ -99,7 +99,6 @@ raise_chc(const chc_err* err, int sqlstate, const char* prefix) {
     const char* m = (err && err->msg[0]) ? err->msg : "unknown error";
 
     ereport(
-        ERROR,
-        (errcode(sqlstate), errmsg("pg_clickhouse: %s%s", prefix ? prefix : "", m))
+        ERROR, errcode(sqlstate), errmsg("pg_clickhouse: %s%s", prefix ? prefix : "", m)
     );
 }

--- a/src/binary/connection.c
+++ b/src/binary/connection.c
@@ -58,9 +58,9 @@ parse_compression(const char* s) {
 
     ereport(
         ERROR,
-        (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
-         errmsg("pg_clickhouse: invalid compression \"%s\"", s),
-         errhint("valid values: none, lz4, zstd"))
+        errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+        errmsg("pg_clickhouse: invalid compression \"%s\"", s),
+        errhint("valid values: none, lz4, zstd")
     );
 }
 
@@ -106,10 +106,10 @@ tcp_connect(const char* host, int port) {
     if (rc != 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg(
-                 "pg_clickhouse: getaddrinfo(%s:%d): %s", host, port, gai_strerror(rc)
-             ))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg(
+                "pg_clickhouse: getaddrinfo(%s:%d): %s", host, port, gai_strerror(rc)
+            )
         );
     }
 
@@ -133,10 +133,10 @@ tcp_connect(const char* host, int port) {
     if (fd < 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg(
-                 "pg_clickhouse: connect(%s:%d): %s", host, port, strerror(save_errno)
-             ))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg(
+                "pg_clickhouse: connect(%s:%d): %s", host, port, strerror(save_errno)
+            )
         );
     }
 
@@ -182,9 +182,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
     if (!s->ssl_ctx) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: failed to initialize opensssl"),
-             errdetail("SSL_CTX_new failed"))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: failed to initialize opensssl"),
+            errdetail("SSL_CTX_new failed")
         );
     }
 
@@ -193,9 +193,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
     if (min_proto != 0 && SSL_CTX_set_min_proto_version(s->ssl_ctx, min_proto) != 1) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: failed to initialize openssl"),
-             errdetail("could not set minimum TLS protocol version"))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: failed to initialize openssl"),
+            errdetail("could not set minimum TLS protocol version")
         );
     }
     /* Authenticate server: verify chain against system CAs and hostname. */
@@ -203,9 +203,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
     if (SSL_CTX_set_default_verify_paths(s->ssl_ctx) != 1) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: failed to initialize openssl"),
-             errdetail("could not load default CA certificates"))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: failed to initialize openssl"),
+            errdetail("could not load default CA certificates")
         );
     }
 
@@ -213,9 +213,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
     if (!s->ssl) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: failed to initialize opensssl"),
-             errdetail("SSL_new failed"))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: failed to initialize opensssl"),
+            errdetail("SSL_new failed")
         );
     }
     SSL_set_tlsext_host_name(s->ssl, host);
@@ -223,9 +223,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
     if (SSL_set1_host(s->ssl, host) != 1) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: failed to initialize openssl"),
-             errdetail("could not set certificate verification host"))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: failed to initialize openssl"),
+            errdetail("could not set certificate verification host")
         );
     }
     SSL_set_fd(s->ssl, s->fd);
@@ -250,9 +250,9 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-             errmsg("pg_clickhouse: openssl failed to connect"),
-             errdetail("%s", ebuf))
+            errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+            errmsg("pg_clickhouse: openssl failed to connect"),
+            errdetail("%s", ebuf)
         );
     }
 }
@@ -260,7 +260,8 @@ tls_connect(struct ch_binary_state* s, const char* host, tls_version min_version
 ch_binary_connection_t*
 ch_binary_connect(ch_connection_details* details) {
     const char* host = details->host ? details->host : "127.0.0.1";
-    int port         = details->port;
+    /* volatile: set before PG_TRY setjmp, read inside */
+    volatile int port = details->port;
     bool tls;
 
     switch (details->tls) {

--- a/src/binary/convert.c
+++ b/src/binary/convert.c
@@ -14,6 +14,7 @@
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 
@@ -113,6 +114,19 @@ convert_record(ch_convert_state* state, Datum val) {
 
     for (size_t i = 0; i < slot->len; i++) {
         ch_convert_state* s = state->conversion_states[i];
+
+        /* Null fields carry no value to convert or to build state from. */
+        if (slot->nulls[i]) {
+            continue;
+        }
+
+        if (s == NULL && slot->types[i] == RECORDOID) {
+            MemoryContext oldcxt = MemoryContextSwitchTo(GetMemoryChunkContext(state));
+
+            s = ch_binary_init_convert_state(slot->datums[i], RECORDOID, RECORDOID);
+            MemoryContextSwitchTo(oldcxt);
+            state->conversion_states[i] = s;
+        }
 
         if (s) {
             slot->datums[i] = s->func(s, slot->datums[i]);
@@ -267,12 +281,12 @@ convert_array(ch_convert_state* state, Datum val) {
         if (slot->ndim > MAXDIM) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-                 errmsg(
-                     "pg_clickhouse: nested array depth %d exceeds maximum %d",
-                     slot->ndim,
-                     MAXDIM
-                 ))
+                errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+                errmsg(
+                    "pg_clickhouse: nested array depth %d exceeds maximum %d",
+                    slot->ndim,
+                    MAXDIM
+                )
             );
         }
 
@@ -448,15 +462,19 @@ ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype) {
         for (size_t i = 0; i < slot->len; ++i) {
             Oid item_type = slot->types[i];
 
-            if (slot->types[i] == ANYARRAYOID) {
+            if (!slot->nulls[i] && slot->types[i] == ANYARRAYOID) {
                 ch_binary_array_t* arr =
                     (ch_binary_array_t*)DatumGetPointer(slot->datums[i]);
 
                 item_type = arr->array_type;
             }
-            state->conversion_states[i] = ch_binary_init_convert_state(
-                slot->datums[i], slot->types[i], item_type
-            );
+
+            /* Null fields hold Datum 0, convert_record lazily fills these. */
+            state->conversion_states[i] =
+                slot->nulls[i] ? NULL
+                               : ch_binary_init_convert_state(
+                                     slot->datums[i], slot->types[i], item_type
+                                 );
 
             TupleDescInitEntry(state->indesc, (AttrNumber)i + 1, "", item_type, -1, 0);
         }
@@ -482,12 +500,12 @@ ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype) {
                 if (typentry->tupDesc == NULL) {
                     ereport(
                         ERROR,
-                        (errcode(ERRCODE_WRONG_OBJECT_TYPE),
-                         errmsg(
-                             "pg_clickhouse: cannot return %s as %s",
-                             slot->ch_type_name ? slot->ch_type_name : "?",
-                             format_type_be(outtype)
-                         ))
+                        errcode(ERRCODE_WRONG_OBJECT_TYPE),
+                        errmsg(
+                            "pg_clickhouse: cannot return %s as %s",
+                            slot->ch_type_name ? slot->ch_type_name : "?",
+                            format_type_be(outtype)
+                        )
                     );
                 }
 
@@ -548,12 +566,12 @@ ch_binary_init_convert_state(Datum val, Oid intype, Oid outtype) {
             default:
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                     errmsg(
-                         "pg_clickhouse: could not cast value from %s to %s",
-                         format_type_be(intype),
-                         format_type_be(outtype)
-                     ))
+                    errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                    errmsg(
+                        "pg_clickhouse: could not cast value from %s to %s",
+                        format_type_be(intype),
+                        format_type_be(outtype)
+                    )
                 );
             }
         }
@@ -602,12 +620,12 @@ init_output_convert_state(ch_convert_output_state* state) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg(
-                 "pg_clickhouse: could not find a casting path from %s to %s",
-                 format_type_be(state->intype),
-                 format_type_be(state->outtype)
-             ))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg(
+                "pg_clickhouse: could not find a casting path from %s to %s",
+                format_type_be(state->intype),
+                format_type_be(state->outtype)
+            )
         );
     }
 }
@@ -677,14 +695,14 @@ ch_binary_make_tuple_map(TupleDesc indesc, TupleDesc outdesc, Oid relid) {
         if (curstate->attnum == 0) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_DATATYPE_MISMATCH),
-                 errmsg_internal("pg_clickhouse: could not create conversion map"),
-                 errdetail(
-                     "Attribute \"%s\" of type %s does not exist in type %s.",
-                     outattname,
-                     format_type_be(indesc->tdtypeid),
-                     format_type_be(outdesc->tdtypeid)
-                 ))
+                errcode(ERRCODE_DATATYPE_MISMATCH),
+                errmsg_internal("pg_clickhouse: could not create conversion map"),
+                errdetail(
+                    "Attribute \"%s\" of type %s does not exist in type %s.",
+                    outattname,
+                    format_type_be(indesc->tdtypeid),
+                    format_type_be(outdesc->tdtypeid)
+                )
             );
         }
     }
@@ -752,7 +770,7 @@ ch_binary_do_output_conversion(
     Datum* out_values = insert_state->values;
     bool* out_nulls   = insert_state->nulls;
 
-    for (size_t i = 0; i < insert_state->outdesc->natts; i++) {
+    for (size_t i = 0; i < (size_t)insert_state->outdesc->natts; i++) {
         ch_convert_output_state* cstate =
             &((ch_convert_output_state*)insert_state->conversion_states)[i];
         AttrNumber attnum = cstate->attnum;
@@ -772,13 +790,13 @@ ch_binary_do_output_conversion(
                 if (ndim > MAXDIM) {
                     ereport(
                         ERROR,
-                        (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-                         errmsg(
-                             "pg_clickhouse: inserted array depth %d exceeds maximum "
-                             "%d",
-                             ndim,
-                             MAXDIM
-                         ))
+                        errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+                        errmsg(
+                            "pg_clickhouse: inserted array depth %d exceeds maximum "
+                            "%d",
+                            ndim,
+                            MAXDIM
+                        )
                     );
                 }
 

--- a/src/binary/decode.c
+++ b/src/binary/decode.c
@@ -98,8 +98,8 @@ ch_kind_to_pg_oid(const chc_type* type) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg("pg_clickhouse: unsupported column type"))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg("pg_clickhouse: unsupported column type")
         );
     }
     /* unreachable */
@@ -191,7 +191,7 @@ format_decimal_text(
 
     /* emit MSD-first, inserting '.' before `scale` trailing digits */
     for (int i = n - 1; i >= 0; i--) {
-        if (i + 1 == scale) {
+        if (i + 1 == (int)scale) {
             *p++ = '.';
         }
         *p++ = buf[i];
@@ -221,8 +221,7 @@ read_decimal(const chc_column* col, const chc_type* type, uint64_t row) {
     rc = format_decimal_text(p + row * es, es, scale, buf, sizeof(buf));
     if (rc < 0) {
         ereport(
-            ERROR,
-            (errcode(ERRCODE_FDW_ERROR), errmsg("pg_clickhouse: decimal too wide"))
+            ERROR, errcode(ERRCODE_FDW_ERROR), errmsg("pg_clickhouse: decimal too wide")
         );
     }
     return DirectFunctionCall3(
@@ -391,8 +390,8 @@ read_lc_string(
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: unexpected LowCardinality key size %d", ks))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: unexpected LowCardinality key size %d", ks)
         );
     }
 
@@ -416,8 +415,8 @@ read_lc_string(
     if (chc_column_layout(dict) != CHC_COL_STRING) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg("pg_clickhouse: unsupported LowCardinality inner type"))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg("pg_clickhouse: unsupported LowCardinality inner type")
         );
     }
     return read_string_as_text(dict, k);
@@ -457,11 +456,11 @@ read_array(
     if (slot->array_type == InvalidOid) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg(
-                 "pg_clickhouse: could not find array type for column type \"%s\"",
-                 chc_type_name(leaf, NULL)
-             ))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg(
+                "pg_clickhouse: could not find array type for column type \"%s\"",
+                chc_type_name(leaf, NULL)
+            )
         );
     }
 
@@ -504,8 +503,8 @@ read_tuple(
     if (n == 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: returned tuple is empty"))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: returned tuple is empty")
         );
     }
 
@@ -594,8 +593,8 @@ read_value(
         if (v > (uint64_t)PG_INT64_MAX) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-                 errmsg("value %" PRIu64 " is out of range of bigint", v))
+                errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                errmsg("value %" PRIu64 " is out of range of bigint", v)
             );
         }
         *valtype = INT8OID;
@@ -664,8 +663,8 @@ read_value(
         if (scale >= lengthof(pow10i)) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                 errmsg("pg_clickhouse: DateTime64 scale %u out of range", scale))
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg("pg_clickhouse: DateTime64 scale %u out of range", scale)
             );
         }
         int64 power = pow10i[scale];
@@ -694,8 +693,8 @@ read_value(
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg("pg_clickhouse: unsupported type in binary protocol"))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg("pg_clickhouse: unsupported type in binary protocol")
         );
     }
     /* unreachable */

--- a/src/binary/encode.c
+++ b/src/binary/encode.c
@@ -62,11 +62,11 @@ ch_kind_to_pg_oid_for_insert(const chc_type* type, const char* colname) {
         if (array_type == InvalidOid) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                 errmsg(
-                     "pg_clickhouse: could not find array type for column \"%s\"",
-                     colname ? colname : "?"
-                 ))
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg(
+                    "pg_clickhouse: could not find array type for column \"%s\"",
+                    colname ? colname : "?"
+                )
             );
         }
         return array_type;
@@ -79,12 +79,12 @@ ch_kind_to_pg_oid_for_insert(const chc_type* type, const char* colname) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg(
-                 "pg_clickhouse: unsupported column type \"%s\" for \"%s\"",
-                 chc_type_name(type, NULL),
-                 colname ? colname : "?"
-             ))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg(
+                "pg_clickhouse: unsupported column type \"%s\" for \"%s\"",
+                chc_type_name(type, NULL),
+                colname ? colname : "?"
+            )
         );
     }
     return InvalidOid;
@@ -335,10 +335,8 @@ append_one(
             if (fam != expected) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_DATATYPE_MISMATCH),
-                     errmsg(
-                         "pg_clickhouse: inet family mismatch for column %zu", colidx
-                     ))
+                    errcode(ERRCODE_DATATYPE_MISMATCH),
+                    errmsg("pg_clickhouse: inet family mismatch for column %zu", colidx)
                 );
             }
             addr    = ip_addr(ipa);
@@ -376,8 +374,8 @@ append_one(
 type_mismatch:
     ereport(
         ERROR,
-        (errcode(ERRCODE_DATATYPE_MISMATCH),
-         errmsg("pg_clickhouse: unexpected PG/CH type pair for column %zu", colidx))
+        errcode(ERRCODE_DATATYPE_MISMATCH),
+        errmsg("pg_clickhouse: unexpected PG/CH type pair for column %zu", colidx)
     );
 }
 

--- a/src/binary/insert.c
+++ b/src/binary/insert.c
@@ -187,11 +187,11 @@ classify_column(ic_col* ic, const chc_type* t) {
         if (chc_type_kind(base) != CHC_STRING) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                 errmsg(
-                     "pg_clickhouse: unsupported LowCardinality variant: %s",
-                     chc_type_name(base, NULL)
-                 ))
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg(
+                    "pg_clickhouse: unsupported LowCardinality variant: %s",
+                    chc_type_name(base, NULL)
+                )
             );
         }
 
@@ -223,11 +223,11 @@ classify_column(ic_col* ic, const chc_type* t) {
         if (elem_nullable) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                 errmsg(
-                     "pg_clickhouse: %s not currently supported",
-                     chc_type_name(base, NULL)
-                 ))
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg(
+                    "pg_clickhouse: %s not currently supported",
+                    chc_type_name(base, NULL)
+                )
             );
         }
         chc_kind ek = chc_type_kind(base);
@@ -243,11 +243,11 @@ classify_column(ic_col* ic, const chc_type* t) {
         } else {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                 errmsg(
-                     "pg_clickhouse: unsupported Array element type: %s",
-                     chc_type_name(base, NULL)
-                 ))
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg(
+                    "pg_clickhouse: unsupported Array element type: %s",
+                    chc_type_name(base, NULL)
+                )
             );
         }
         if (ndim > 1) {
@@ -269,7 +269,16 @@ classify_column(ic_col* ic, const chc_type* t) {
         ic->layout    = IC_FIXED;
         ic->elem_size = es;
         if (k == CHC_DATETIME64) {
-            ic->dt64_precision = (uint32_t)chc_type_datetime64_scale(t);
+            int scale = chc_type_datetime64_scale(t);
+
+            if (scale < 0 || (size_t)scale >= lengthof(pow10i)) {
+                ereport(
+                    ERROR,
+                    errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                    errmsg("pg_clickhouse: DateTime64 scale %d out of range", scale)
+                );
+            }
+            ic->dt64_precision = (uint32_t)scale;
         }
         return;
     }
@@ -280,11 +289,11 @@ classify_column(ic_col* ic, const chc_type* t) {
     }
     ereport(
         ERROR,
-        (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-         errmsg(
-             "pg_clickhouse: could not prepare insert - unsupported column type: %s",
-             chc_type_name(t, NULL)
-         ))
+        errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+        errmsg(
+            "pg_clickhouse: could not prepare insert - unsupported column type: %s",
+            chc_type_name(t, NULL)
+        )
     );
 }
 
@@ -313,8 +322,8 @@ recv_initial_block(struct ch_binary_state* s, ch_binary_insert_handle* h) {
             chc_packet_clear(s->client, &pkt);
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_ERROR),
-                 errmsg("pg_clickhouse: could not prepare insert - %s", msg_copy))
+                errcode(ERRCODE_FDW_ERROR),
+                errmsg("pg_clickhouse: could not prepare insert - %s", msg_copy)
             );
         }
         if (pkt.kind == CHC_PKT_DATA && pkt.block &&
@@ -501,12 +510,12 @@ resolve_col(ch_binary_insert_handle* h, size_t col_idx, bool isnull) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_NOT_NULL_VIOLATION),
-             errmsg(
-                 "pg_clickhouse: cannot append NULL to NOT NULL %.*s column",
-                 (int)tnlen,
-                 tname ? tname : "?"
-             ))
+            errcode(ERRCODE_NOT_NULL_VIOLATION),
+            errmsg(
+                "pg_clickhouse: cannot append NULL to NOT NULL %.*s column",
+                (int)tnlen,
+                tname ? tname : "?"
+            )
         );
     }
     if (!h->array_active && c->is_nullable) {
@@ -548,8 +557,8 @@ decimal_text_to_bytes(const char* s, uint32_t scale, size_t width, uint8_t* out)
     if (!s) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-             errmsg("pg_clickhouse: decimal parse failure"))
+            errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+            errmsg("pg_clickhouse: decimal parse failure")
         );
     }
     if (*s == '-') {
@@ -577,10 +586,10 @@ decimal_text_to_bytes(const char* s, uint32_t scale, size_t width, uint8_t* out)
         if (c < '0' || c > '9') {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
-                 errmsg(
-                     "pg_clickhouse: cannot encode \"%s\" as ClickHouse Decimal", input
-                 ))
+                errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+                errmsg(
+                    "pg_clickhouse: cannot encode \"%s\" as ClickHouse Decimal", input
+                )
             );
         }
         uint64_t carry = (uint64_t)(c - '0');
@@ -646,8 +655,8 @@ append_int_kind(ic_col* c, int64_t val) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATATYPE_MISMATCH),
-             errmsg("pg_clickhouse: int value into non-integer column"))
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg("pg_clickhouse: int value into non-integer column")
         );
     }
 }
@@ -783,12 +792,10 @@ ch_binary_append_bytes(
         if (!found) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-                 errmsg(
-                     "pg_clickhouse: enum value '%.*s' not found",
-                     (int)n,
-                     (const char*)p
-                 ))
+                errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                errmsg(
+                    "pg_clickhouse: enum value '%.*s' not found", (int)n, (const char*)p
+                )
             );
         }
         if (k == CHC_ENUM8) {
@@ -814,8 +821,8 @@ ch_binary_append_bytes(
     }
     ereport(
         ERROR,
-        (errcode(ERRCODE_DATATYPE_MISMATCH),
-         errmsg("pg_clickhouse: bytes into non-text column"))
+        errcode(ERRCODE_DATATYPE_MISMATCH),
+        errmsg("pg_clickhouse: bytes into non-text column")
     );
 }
 
@@ -848,8 +855,8 @@ ch_binary_append_decimal(
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATATYPE_MISMATCH),
-             errmsg("pg_clickhouse: decimal into non-decimal column"))
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg("pg_clickhouse: decimal into non-decimal column")
         );
     }
     uint8_t raw[32] = {};
@@ -931,8 +938,8 @@ ch_binary_append_inet(
     }
     ereport(
         ERROR,
-        (errcode(ERRCODE_DATATYPE_MISMATCH),
-         errmsg("pg_clickhouse: cannot insert inet into non-inet column"))
+        errcode(ERRCODE_DATATYPE_MISMATCH),
+        errmsg("pg_clickhouse: cannot insert inet into non-inet column")
     );
 }
 
@@ -959,8 +966,8 @@ ch_binary_append_date_seconds(
     } else {
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATATYPE_MISMATCH),
-             errmsg("pg_clickhouse: date into non-date column"))
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg("pg_clickhouse: date into non-date column")
         );
     }
     MemoryContextSwitchTo(old);
@@ -1007,8 +1014,8 @@ ch_binary_array_begin(ch_binary_insert_handle* h, size_t col) {
     if (idx >= h->ncols) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: array_begin: col out of range"))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: array_begin: col out of range")
         );
     }
     ic_col* c = &h->cols[idx];
@@ -1017,15 +1024,15 @@ ch_binary_array_begin(ch_binary_insert_handle* h, size_t col) {
         c->layout != IC_ARRAY_NESTED_FIXED && c->layout != IC_ARRAY_NESTED_STRING) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: array_begin: column is not Array"))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: array_begin: column is not Array")
         );
     }
     if (c->array_depth >= c->ndim) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: array_begin: nesting exceeds column ndim"))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: array_begin: nesting exceeds column ndim")
         );
     }
     if (c->array_depth == 0) {
@@ -1540,8 +1547,8 @@ ch_binary_finalize_insert(ch_binary_insert_handle* h) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: could not finish INSERT - %s", parent_msg))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: could not finish INSERT - %s", parent_msg)
         );
     }
 }

--- a/src/binary/select.c
+++ b/src/binary/select.c
@@ -261,11 +261,12 @@ ch_binary_simple_query(
         settings = palloc0(n_settings * sizeof(*settings));
         size_t i = 0;
 
-        for (kv_iter it = new_kv_iter(query->settings); !kv_iter_done(&it);
-             kv_iter_next(&it), i++) {
+        kv_iter it = new_kv_iter(query->settings);
+        while (kv_iter_next(&it)) {
             settings[i].name      = it.name;
             settings[i].value     = it.value;
             settings[i].important = true;
+            i++;
         }
         if (want_json_as_string) {
             settings[i].name      = "output_format_native_write_json_as_string";

--- a/src/connection.c
+++ b/src/connection.c
@@ -88,8 +88,8 @@ clickhouse_connect(ForeignServer* server, UserMapping* user) {
     } else {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
-             errmsg("invalid ClickHouse connection driver"))
+            errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+            errmsg("invalid ClickHouse connection driver")
         );
     }
 }
@@ -131,10 +131,11 @@ get_connection_entry(UserMapping* user) {
     entry = hash_search(ConnectionHash, &key, HASH_ENTER, &found);
     if (!found) {
         /*
-         * We need only clear "conn" here; remaining fields will be filled
-         * later when "conn" is set.
+         * Clear "conn" and "busy"; remaining fields are filled later when
+         * "conn" is set.
          */
         entry->gate.conn = NULL;
+        entry->busy      = false;
     }
 
     /*
@@ -379,8 +380,8 @@ connstring_parse(const char* connstring) {
         } else if (strcmp(pname, "") != 0) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_SYNTAX_ERROR),
-                 errmsg("pg_clickhouse: invalid connection option \"%s\"", pname))
+                errcode(ERRCODE_SYNTAX_ERROR),
+                errmsg("pg_clickhouse: invalid connection option \"%s\"", pname)
             );
         }
     }

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -1086,18 +1086,28 @@ chfdw_apply_custom_table_options(CHFdwRelationInfo* fpinfo, Oid relid) {
             if (strncasecmp(val, collapsing_text, strlen(collapsing_text)) == 0) {
                 char *start = index(val, '('), *end = rindex(val, ')');
                 char sign[CH_ESCAPED_NAMEDATALEN];
+                Size sign_len;
 
-                if (end - start - 1 > (CH_ESCAPED_NAMEDATALEN - 1)) {
+                if (start == NULL || end == NULL || end <= start + 1) {
                     ereport(
                         ERROR,
-                        (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-                         errmsg("pg_clickhouse: invalid engine parameter"))
+                        errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+                        errmsg("pg_clickhouse: invalid engine parameter")
+                    );
+                }
+
+                sign_len = end - start - 1;
+                if (sign_len > CH_ESCAPED_NAMEDATALEN - 1) {
+                    ereport(
+                        ERROR,
+                        errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+                        errmsg("pg_clickhouse: invalid engine parameter")
                     );
                 }
 
                 fpinfo->ch_table_engine = CH_COLLAPSING_MERGE_TREE;
-                strncpy(sign, start + 1, end - start - 1);
-                sign[end - start - 1] = '\0';
+                memcpy(sign, start + 1, sign_len);
+                sign[sign_len] = '\0';
                 strlcpy(
                     fpinfo->ch_table_sign_field,
                     ch_quote_ident(sign),

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -168,7 +168,7 @@ typedef struct deparse_expr_cxt {
 #define CSTRING_TOLOWER(str)                                                           \
     do {                                                                               \
         for (int i = 0; str[i]; i++) {                                                 \
-            str[i] = tolower(str[i]);                                                  \
+            str[i] = tolower((unsigned char)str[i]);                                   \
         }                                                                              \
     } while (0)
 
@@ -1851,8 +1851,8 @@ deparseTargetList(
         )) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("clickhouse does not support system columns"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("clickhouse does not support system columns")
         );
     }
 
@@ -2336,8 +2336,8 @@ deparseColumnRef(
     if (varattno <= 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("ClickHouse does not support system attributes"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("ClickHouse does not support system attributes")
         );
     }
 
@@ -2669,8 +2669,8 @@ ch_timestamp_out(PG_FUNCTION_ARGS) {
     } else {
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
-             errmsg("timestamp out of range"))
+            errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+            errmsg("timestamp out of range")
         );
     }
 
@@ -2805,8 +2805,8 @@ deparseArray(Datum arr, deparse_expr_cxt* context) {
     if (context->array_as_tuple && ndims > 1) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("pg_clickhouse: tuple-formatted arrays must be one-dimensional"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("pg_clickhouse: tuple-formatted arrays must be one-dimensional")
         );
     }
 
@@ -2927,8 +2927,8 @@ deparseConst(Const* node, deparse_expr_cxt* context, int showtype) {
         if (ival->month != 0) {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                 errmsg("cannot convert interval with months into clickhouse"))
+                errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                errmsg("cannot convert interval with months into clickhouse")
             );
         }
 
@@ -3158,11 +3158,11 @@ deparseSubPlan(SubPlan* node, deparse_expr_cxt* context) {
         /* Unreachable unless a new SubLinkType is added above. */
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg(
-                 "pg_clickhouse: unsupported SubLink type for deparse: %d",
-                 (int)node->subLinkType
-             ))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg(
+                "pg_clickhouse: unsupported SubLink type for deparse: %d",
+                (int)node->subLinkType
+            )
         );
     }
 }
@@ -3843,8 +3843,8 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             } else {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("date_trunc cannot be exported for: %s", trunctype))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg("date_trunc cannot be exported for: %s", trunctype)
                 );
             }
 
@@ -3893,8 +3893,8 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             } else {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("date_part cannot be exported for: %s", parttype))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg("date_part cannot be exported for: %s", parttype)
                 );
             }
 
@@ -4110,8 +4110,8 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             } else {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("encode cannot be exported for: %s", format))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg("encode cannot be exported for: %s", format)
                 );
             }
 
@@ -4397,11 +4397,11 @@ deparseOpExpr(OpExpr* node, deparse_expr_cxt* context) {
             } else {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg(
-                         "pg_clickhouse supports hstore fetchval "
-                         "only for scalars"
-                     ))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg(
+                        "pg_clickhouse supports hstore fetchval "
+                        "only for scalars"
+                    )
                 );
             }
 
@@ -4521,8 +4521,8 @@ deparseOpExpr(OpExpr* node, deparse_expr_cxt* context) {
             } else {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("unsupported type of interval"))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg("unsupported type of interval")
                 );
             }
             pfree(s);
@@ -4666,11 +4666,11 @@ deparseScalarArrayOpExpr(ScalarArrayOpExpr* node, deparse_expr_cxt* context) {
     if (optype == 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg(
-                 "pg_clickhouse supports only equal (not equal) operations on ANY/ALL "
-                 "functions"
-             ))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg(
+                "pg_clickhouse supports only equal (not equal) operations on ANY/ALL "
+                "functions"
+            )
         );
     }
 
@@ -4880,20 +4880,20 @@ appendAggOrderBySuffix(
         /* appendStringInfoString(buf, " DESC"); */
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg(
-                 "pg_clickhouse: ClickHouse does not support \"DESC\" in aggregate "
-                 "expressions"
-             ))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg(
+                "pg_clickhouse: ClickHouse does not support \"DESC\" in aggregate "
+                "expressions"
+            )
         );
     } else {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg(
-                 "pg_clickhouse: ClickHouse does not support \"USING\" in aggregate "
-                 "expressions"
-             ))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg(
+                "pg_clickhouse: ClickHouse does not support \"USING\" in aggregate "
+                "expressions"
+            )
         );
     }
 
@@ -4901,11 +4901,11 @@ appendAggOrderBySuffix(
         /* appendStringInfoString(buf, " NULLS FIRST"); */
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg(
-                 "pg_clickhouse: ClickHouse does not support \"NULLS FIRST\" in "
-                 "aggregate expressions"
-             ))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg(
+                "pg_clickhouse: ClickHouse does not support \"NULLS FIRST\" in "
+                "aggregate expressions"
+            )
         );
     } else {
         /*

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -380,11 +380,11 @@ clickhouse_raw_query(PG_FUNCTION_ARGS) {
     } else {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
-             errmsg(
-                 "pg_clickhouse: invalid ClickHouse connection driver \"%s\"",
-                 details->driver
-             ))
+            errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+            errmsg(
+                "pg_clickhouse: invalid ClickHouse connection driver \"%s\"",
+                details->driver
+            )
         );
     }
 
@@ -453,15 +453,15 @@ clickhouse_query(PG_FUNCTION_ARGS) {
     if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo)) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("set-valued function called in context that cannot accept a set"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("set-valued function called in context that cannot accept a set")
         );
     }
     if (!(rsinfo->allowedModes & SFRM_Materialize)) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("materialize mode required, but it is not allowed in this context"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("materialize mode required, but it is not allowed in this context")
         );
     }
 
@@ -469,8 +469,8 @@ clickhouse_query(PG_FUNCTION_ARGS) {
     if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("a column definition list is required for clickhouse_query"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("a column definition list is required for clickhouse_query")
         );
     }
 
@@ -556,11 +556,11 @@ get_fetch_size_option(DefElem* def) {
     if (fetch_size < 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-             errmsg(
-                 "invalid value for option \"%s\": %s", def->defname, defGetString(def)
-             ),
-             errhint("fetch_size must be greater than or equal to 0"))
+            errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+            errmsg(
+                "invalid value for option \"%s\": %s", def->defname, defGetString(def)
+            ),
+            errhint("fetch_size must be greater than or equal to 0")
         );
     }
 
@@ -1506,15 +1506,15 @@ clickhousePlanForeignModify(
     case CMD_UPDATE:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("ClickHouse does not support updates"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("ClickHouse does not support updates")
         );
         break;
     case CMD_DELETE:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-             errmsg("ClickHouse does not support deletes"))
+            errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+            errmsg("ClickHouse does not support deletes")
         );
         break;
     default:

--- a/src/http.c
+++ b/src/http.c
@@ -9,10 +9,10 @@
 #include <internal.h>
 
 static char curl_error_buffer[CURL_ERROR_SIZE];
-static bool curl_error_happened = false;
-static long curl_verbose        = 0;
-static void* curl_progressfunc  = NULL;
-static bool curl_initialized    = false;
+static bool curl_error_happened                 = false;
+static long curl_verbose                        = 0;
+static curl_xferinfo_callback curl_progressfunc = NULL;
+static bool curl_initialized                    = false;
 static char ch_query_id_prefix[5];
 
 void
@@ -27,11 +27,11 @@ ch_http_init(int verbose, uint32_t query_id_prefix) {
 }
 
 void
-ch_http_set_progress_func(void* progressfunc) {
+ch_http_set_progress_func(curl_xferinfo_callback progressfunc) {
     curl_progressfunc = progressfunc;
 }
 
-void*
+curl_xferinfo_callback
 ch_http_get_progress_func(void) {
     return curl_progressfunc;
 }
@@ -127,11 +127,18 @@ ch_http_connection(ch_connection_details* details) {
 
     if (username) {
         username = curl_easy_escape(conn->curl, username, 0);
+        if (username == NULL) {
+            goto cleanup;
+        }
         len += strlen(username);
     }
 
     if (password) {
         password = curl_easy_escape(conn->curl, password, 0);
+        if (password == NULL) {
+            curl_free(username);
+            goto cleanup;
+        }
         len += strlen(password);
     }
 

--- a/src/http_streaming.c
+++ b/src/http_streaming.c
@@ -96,8 +96,8 @@ setup_curl(HttpStream* stream, const ch_query* query) {
     snprintf(temp_buf, sizeof(temp_buf), "query_id=%s", stream->query_id);
     curl_url_set(cu, CURLUPART_QUERY, temp_buf, CURLU_APPENDQUERY | CURLU_URLENCODE);
 
-    for (kv_iter iter = new_kv_iter(query->settings); !kv_iter_done(&iter);
-         kv_iter_next(&iter)) {
+    kv_iter iter = new_kv_iter(query->settings);
+    while (kv_iter_next(&iter)) {
         if (strcmp(iter.name, "date_time_output_format") == 0 ||
             strcmp(iter.name, "format_tsv_null_representation") == 0 ||
             strcmp(iter.name, "output_format_tsv_crlf_end_of_line") == 0) {

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -6,6 +6,7 @@
 #include "engine.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
+#include <curl/curl.h>
 
 #define CH_HTTP_QUERY_ID_LEN 37
 
@@ -50,8 +51,8 @@ typedef struct {
 void
 ch_http_init(int verbose, uint32_t query_id_prefix);
 void
-ch_http_set_progress_func(void* progressfunc);
-void*
+ch_http_set_progress_func(curl_xferinfo_callback progressfunc);
+curl_xferinfo_callback
 ch_http_get_progress_func(void);
 long
 ch_http_get_verbose(void);

--- a/src/include/kv_list.h
+++ b/src/include/kv_list.h
@@ -18,15 +18,19 @@ typedef struct kv_list {
 } kv_list;
 
 /*
- * Iterator for a kv_list. Use new_kv_iter() to create.
+ * Iterator for a kv_list. Use new_kv_iter() to create; name and value are
+ * valid only after kv_iter_next() returns true.
  *
- *     for (kv_iter iter = new_kv_iter(kv); !kv_iter_done(&iter); kv_iter_next(&iter))
+ *     kv_iter iter = new_kv_iter(kv);
+ *     while (kv_iter_next(&iter))
  *     {
- *         printf("%i, %s => %s\n", iter.num, iter.name, iter.value);
+ *         printf("%s => %s\n", iter.name, iter.value);
  *     }
  */
 typedef struct kv_iter {
     int togo;
+    /* Next unread name; one past end after last pair, never dereferenced. */
+    char* next;
     char* name;
     char* value;
 } kv_iter;
@@ -53,12 +57,8 @@ new_kv_list_from_pg_list(List* list, int allocate);
 kv_iter
 new_kv_iter(const kv_list* ns);
 
-/* Iterate to the next item. Returns false if there are no items. */
+/* Advance to the next item. Returns false when no items remain. */
 bool
 kv_iter_next(kv_iter* state);
-
-/* Returns true if iteration by kv_iter is complete. */
-bool
-kv_iter_done(kv_iter* state);
 
 #endif /* PG_CLICKHOUSE_KV_LIST_H */

--- a/src/kv_list.c
+++ b/src/kv_list.c
@@ -24,12 +24,13 @@ allocate_list(size_t size, int allocate) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR), errmsg("unknown kv_pair_alloc %i", allocate))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("unknown kv_pair_alloc %i", allocate)
         );
     }
 
     if (!pairs) {
-        ereport(ERROR, (errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory")));
+        ereport(ERROR, errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory"));
     }
 
     return pairs;
@@ -80,16 +81,12 @@ new_kv_list_from_pg_list(List* list, int allocate) {
 
 extern kv_iter
 new_kv_iter(const kv_list* ns) {
-    char* name;
-
-    /* The list may be NULL or empty. */
-    if (!ns || ns->length < 1) {
+    /* The list may be NULL. */
+    if (!ns) {
         return (kv_iter){ 0 };
     }
 
-    /* Grab the number of pairs point to the first name and value. */
-    name = (char*)ns->data;
-    return (kv_iter){ ns->length, name, name + strlen(name) + 1 };
+    return (kv_iter){ ns->length, (char*)ns->data, NULL, NULL };
 }
 
 extern bool
@@ -97,15 +94,10 @@ kv_iter_next(kv_iter* iter) {
     if (iter->togo == 0) {
         return false;
     }
-
-    /* Point to the the next name and value. */
     iter->togo--;
-    iter->name  = iter->value + strlen(iter->value) + 1;
-    iter->value = iter->name + strlen(iter->name) + 1;
-    return true;
-}
 
-extern bool
-kv_iter_done(kv_iter* iter) {
-    return iter->togo == 0;
+    iter->name  = iter->next;
+    iter->value = iter->name + strlen(iter->name) + 1;
+    iter->next  = iter->value + strlen(iter->value) + 1;
+    return true;
 }

--- a/src/option.c
+++ b/src/option.c
@@ -131,9 +131,9 @@ clickhouse_fdw_validator(PG_FUNCTION_ARGS) {
 
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
-                 errmsg("invalid option \"%s\"", def->defname),
-                 errhint("Valid options in this context are: %s", buf.data))
+                errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+                errmsg("invalid option \"%s\"", def->defname),
+                errhint("Valid options in this context are: %s", buf.data)
             );
         }
 
@@ -151,9 +151,9 @@ clickhouse_fdw_validator(PG_FUNCTION_ARGS) {
                 strcmp(val, "auto") != 0) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
-                     errmsg("invalid value for option \"secure\": \"%s\"", val),
-                     errhint("Valid values are: on, off, auto."))
+                    errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
+                    errmsg("invalid value for option \"secure\": \"%s\"", val),
+                    errhint("Valid values are: on, off, auto.")
                 );
             }
         }
@@ -165,11 +165,9 @@ clickhouse_fdw_validator(PG_FUNCTION_ARGS) {
             if (!parse_min_tls_version(val, &v)) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
-                     errmsg(
-                         "invalid value for option \"min_tls_version\": \"%s\"", val
-                     ),
-                     errhint("Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3."))
+                    errcode(ERRCODE_FDW_INVALID_STRING_FORMAT),
+                    errmsg("invalid value for option \"min_tls_version\": \"%s\"", val),
+                    errhint("Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.")
                 );
             }
         }
@@ -221,7 +219,7 @@ InitChFdwOptions(void) {
         sizeof(ChFdwOption) * num_ch_opts + sizeof(non_ch_options)
     );
     if (clickhouse_fdw_options == NULL) {
-        ereport(ERROR, (errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory")));
+        ereport(ERROR, errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory"));
     }
 
     popt = clickhouse_fdw_options;
@@ -257,11 +255,11 @@ validate_fetch_size_option(DefElem* def) {
     if (fetch_size < 0) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
-             errmsg(
-                 "invalid value for option \"%s\": %s", def->defname, defGetString(def)
-             ),
-             errhint("fetch_size must be greater than or equal to 0"))
+            errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+            errmsg(
+                "invalid value for option \"%s\": %s", def->defname, defGetString(def)
+            ),
+            errhint("fetch_size must be greater than or equal to 0")
         );
     }
 }
@@ -535,12 +533,12 @@ chfdw_parse_options(const char* options_string, bool with_comma, bool with_equal
             if (cp2 == pval) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_SYNTAX_ERROR),
-                     errmsg(
-                         "pg_clickhouse: missing value for parameter \"%s\" in options "
-                         "string",
-                         pname
-                     ))
+                    errcode(ERRCODE_SYNTAX_ERROR),
+                    errmsg(
+                        "pg_clickhouse: missing value for parameter \"%s\" in options "
+                        "string",
+                        pname
+                    )
                 );
             }
         } else {
@@ -581,12 +579,12 @@ chfdw_parse_options(const char* options_string, bool with_comma, bool with_equal
                 } else if (*cp != '\0') {
                     ereport(
                         ERROR,
-                        (errcode(ERRCODE_SYNTAX_ERROR),
-                         errmsg(
-                             "pg_clickhouse: missing comma after \"%s\" value in "
-                             "options string",
-                             pname
-                         ))
+                        errcode(ERRCODE_SYNTAX_ERROR),
+                        errmsg(
+                            "pg_clickhouse: missing comma after \"%s\" value in "
+                            "options string",
+                            pname
+                        )
                     );
                 }
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -32,7 +32,8 @@ inline static void
 ch_http_parse_error(const char* msg) {
     ereport(
         ERROR,
-        (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION), errmsg("pg_clickhouse: %s", msg))
+        errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+        errmsg("pg_clickhouse: %s", msg)
     );
 }
 
@@ -152,8 +153,8 @@ ch_http_read_next(ch_http_read_state* state, bool is_array) {
     if (data[state->curpos] != '\n') {
         ereport(
             ERROR,
-            (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-             errmsg("unexpected byte (%d) after array", data[state->curpos]))
+            errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+            errmsg("unexpected byte (%d) after array", data[state->curpos])
         );
     }
 

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -118,10 +118,10 @@ static libclickhouse_methods binary_methods = {
 static int
 http_progress_callback(
     void* clientp,
-    double dltotal,
-    double dlnow,
-    double ultotal,
-    double ulnow
+    curl_off_t dltotal,
+    curl_off_t dlnow,
+    curl_off_t ultotal,
+    curl_off_t ulnow
 ) {
     if (ProcDiePending || QueryCancelPending) {
         return 1;
@@ -182,8 +182,8 @@ chfdw_http_connect(ch_connection_details* details) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-             errmsg("could not connect to server: %s", error))
+            errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+            errmsg("could not connect to server: %s", error)
         );
     }
 
@@ -218,7 +218,7 @@ static char*
 format_error(char* errstring) {
     size_t n = strlen(errstring);
 
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         if (strncmp(errstring + i, "version", 7) == 0) {
             return pnstrdup(errstring, i - 2);
         }
@@ -270,19 +270,19 @@ report_http_stream_query_failure(
             kill_query(conn, qid);
             ereport(
                 ERROR,
-                (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-                 errmsg("pg_clickhouse: query was aborted"))
+                errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+                errmsg("pg_clickhouse: query was aborted")
             );
         } else if (status == CH_HTTP_STATUS_TRANSPORT_ERROR) {
             const char* err = ch_http_stream_error(stream);
 
             ereport(
                 ERROR,
-                (errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-                 errmsg(
-                     "pg_clickhouse: communication error: %s",
-                     err ? err : "connection error"
-                 ))
+                errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+                errmsg(
+                    "pg_clickhouse: communication error: %s",
+                    err ? err : "connection error"
+                )
             );
         } else {
             char* error = pnstrdup(
@@ -291,12 +291,11 @@ report_http_stream_query_failure(
 
             ereport(
                 ERROR,
-                (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-                 errmsg("pg_clickhouse: %s", format_error(error)),
-                 status < 404
-                     ? 0
-                     : errdetail_internal("Remote Query: %.64000s", query->sql),
-                 errcontext("HTTP status code: %li", status))
+                errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+                errmsg("pg_clickhouse: %s", format_error(error)),
+                status < 404 ? 0
+                             : errdetail_internal("Remote Query: %.64000s", query->sql),
+                errcontext("HTTP status code: %li", status)
             );
         }
     }
@@ -307,8 +306,14 @@ report_http_stream_query_failure(
 
 static ch_cursor*
 http_simple_query(void* conn, const ch_query* query) {
-    int attempts          = 0;
-    MemoryContext tempcxt = NULL, oldcxt;
+    int attempts = 0;
+    /*
+     * volatile: changed after setjmp (PG_TRY) and read after longjmp
+     * (PG_CATCH); longjmp needn't restore register-cached locals, so a
+     * non-volatile such local has an indeterminate value per C setjmp rules.
+     */
+    volatile MemoryContext tempcxt = NULL;
+    MemoryContext oldcxt;
     ch_cursor* cursor;
     ch_http_response_t* resp;
 
@@ -317,7 +322,7 @@ http_simple_query(void* conn, const ch_query* query) {
 again:
     resp = ch_http_simple_query(conn, query);
     if (resp == NULL) {
-        ereport(ERROR, (errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory")));
+        ereport(ERROR, errcode(ERRCODE_FDW_OUT_OF_MEMORY), errmsg("out of memory"));
     }
 
     attempts++;
@@ -332,8 +337,8 @@ again:
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-             errmsg("pg_clickhouse: communication error: %s", error))
+            errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+            errmsg("pg_clickhouse: communication error: %s", error)
         );
     } else if (resp->http_status == CH_HTTP_STATUS_CANCELED) {
         kill_query(conn, resp->query_id);
@@ -341,8 +346,8 @@ again:
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: query was aborted"))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: query was aborted")
         );
     } else if (resp->http_status != CH_HTTP_STATUS_OK) {
         char* error = pnstrdup(resp->data, resp->datasize);
@@ -352,11 +357,10 @@ again:
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: %s", format_error(error)),
-             status < 404 ? 0
-                          : errdetail_internal("Remote Query: %.64000s", query->sql),
-             errcontext("HTTP status code: %li", status))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: %s", format_error(error)),
+            status < 404 ? 0 : errdetail_internal("Remote Query: %.64000s", query->sql),
+            errcontext("HTTP status code: %li", status)
         );
     }
 
@@ -413,8 +417,8 @@ http_simple_insert(void* conn, const ch_query* query) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
-             errmsg("pg_clickhouse: communication error: %s", error))
+            errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+            errmsg("pg_clickhouse: communication error: %s", error)
         );
     }
 
@@ -426,11 +430,10 @@ http_simple_insert(void* conn, const ch_query* query) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: %s", format_error(error)),
-             status < 404 ? 0
-                          : errdetail_internal("Remote Query: %.64000s", query->sql),
-             errcontext("HTTP status code: %li", status))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: %s", format_error(error)),
+            status < 404 ? 0 : errdetail_internal("Remote Query: %.64000s", query->sql),
+            errcontext("HTTP status code: %li", status)
         );
     }
 
@@ -455,8 +458,14 @@ http_streaming_cursor_free(void* c) {
  */
 static ch_cursor*
 http_streaming_query(void* conn, const ch_query* query, int32 fetch_size) {
-    int attempts          = 0;
-    MemoryContext tempcxt = NULL, oldcxt;
+    int attempts = 0;
+    /*
+     * volatile: changed after setjmp (PG_TRY) and read after longjmp
+     * (PG_CATCH); longjmp needn't restore register-cached locals, so a
+     * non-volatile such local has an indeterminate value per C setjmp rules.
+     */
+    volatile MemoryContext tempcxt = NULL;
+    MemoryContext oldcxt;
     ch_cursor* cursor;
     HttpStream* stream;
 
@@ -467,8 +476,8 @@ again:
     if (stream == NULL) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_INTERNAL_ERROR),
-             errmsg("pg_clickhouse: failed to initialize HTTP stream"))
+            errcode(ERRCODE_INTERNAL_ERROR),
+            errmsg("pg_clickhouse: failed to initialize HTTP stream")
         );
     }
 
@@ -559,18 +568,18 @@ http_streaming_fetch_row(ChFdwScanRowContext* ctx) {
                 kill_query(cursor->conn, qid);
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-                     errmsg("pg_clickhouse: query was aborted"))
+                    errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+                    errmsg("pg_clickhouse: query was aborted")
                 );
             }
             ereport(
                 ERROR,
-                (errcode(ERRCODE_CONNECTION_FAILURE),
-                 errmsg(
-                     "pg_clickhouse: streaming error - %s",
-                     ch_http_stream_error(stream) ? ch_http_stream_error(stream)
-                                                  : "unknown"
-                 ))
+                errcode(ERRCODE_CONNECTION_FAILURE),
+                errmsg(
+                    "pg_clickhouse: streaming error - %s",
+                    ch_http_stream_error(stream) ? ch_http_stream_error(stream)
+                                                 : "unknown"
+                )
             );
         }
 
@@ -606,9 +615,9 @@ http_fetch_row_from_state(ChFdwScanRowContext* ctx, ch_http_read_state* state) {
 
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_ERROR),
-             errmsg("pg_clickhouse: unexpected response for a zero-column result"),
-             errdetail("Expected a NULL marker (\\N) in the TabSeparated response."))
+            errcode(ERRCODE_FDW_ERROR),
+            errmsg("pg_clickhouse: unexpected response for a zero-column result"),
+            errdetail("Expected a NULL marker (\\N) in the TabSeparated response.")
         );
     }
 
@@ -637,7 +646,7 @@ http_fetch_row_from_state(ChFdwScanRowContext* ctx, ch_http_read_state* state) {
     /* No TupleDesc, everything is text. */
     else {
         values = palloc(attcount * sizeof(Datum));
-        for (int idx = 0; idx < attcount; idx++) {
+        for (size_t idx = 0; idx < attcount; idx++) {
             rc = ch_http_read_next(state, false);
             if (state->is_null) {
                 values[idx] = (Datum)0;
@@ -650,13 +659,13 @@ http_fetch_row_from_state(ChFdwScanRowContext* ctx, ch_http_read_state* state) {
     if (attcount > 0 && rc != CH_EOL && rc != CH_EOF) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATATYPE_MISMATCH),
-             errmsg_internal("pg_clickhouse: columns mismatch"),
-             errdetail(
-                 "Number of returned columns does not match "
-                 "expected column count (%lu).",
-                 attcount
-             ))
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg_internal("pg_clickhouse: columns mismatch"),
+            errdetail(
+                "Number of returned columns does not match "
+                "expected column count (%lu).",
+                attcount
+            )
         );
     }
 
@@ -693,20 +702,22 @@ http_fetch_row(ChFdwScanRowContext* ctx) {
  */
 static void
 char_to_datum(ChFdwScanRowContext* ctx, int attidx, char* data, size_t len) {
-    Oid pgtype = TupleDescAttr(ctx->tupdesc, attidx)->atttypid;
+    static const char time_prefix[] = "1970-01-01T";
+    Oid pgtype                      = TupleDescAttr(ctx->tupdesc, attidx)->atttypid;
 
-    if (data && len > 0 && (pgtype == TIMEOID || pgtype == TIMETZOID) &&
-        data[len - 1] == 'Z') {
+    if (data && len > sizeof(time_prefix) - 1 &&
+        (pgtype == TIMEOID || pgtype == TIMETZOID) && data[len - 1] == 'Z') {
         /*
          * date_time_output_format=iso formats times as ISO timestamps. Remove
          * the leading `YYYY-mm-ddT`.
          */
-        data += strlen("1970-01-01T");
+        data += sizeof(time_prefix) - 1;
     } else if (pgtype == BYTEAOID) {
         /* Postgres input function won't work, we have raw data. */
         ctx->nulls[attidx] = data == NULL;
         ctx->values[attidx] =
-            PointerGetDatum((bytea*)cstring_to_text_with_len(data, len));
+            data == NULL ? (Datum)0
+                         : PointerGetDatum((bytea*)cstring_to_text_with_len(data, len));
         return;
     }
 
@@ -795,9 +806,9 @@ chfdw_datum_to_ch_literal(Datum value, Oid type) {
     default:
         ereport(
             ERROR,
-            (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-             errmsg("cannot convert value to clickhouse value"),
-             errhint("Value data type: %u", type))
+            errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+            errmsg("cannot convert value to clickhouse value"),
+            errhint("Value data type: %u", type)
         );
     }
 }
@@ -883,7 +894,7 @@ http_insert_tuple(void* istate, TupleTableSlot* slot) {
     extend_insert_query(state, slot);
 
     if ((slot == NULL && state->sql.len > 0) ||
-        state->sql.len > (MaxAllocSize / 2 /* 512MB */)) {
+        (size_t)state->sql.len > (MaxAllocSize / 2 /* 512MB */)) {
         ch_query query = new_query(state->sql.data, 0, NULL, NULL, NULL);
 
         http_simple_insert(state->conn, &query);
@@ -942,9 +953,9 @@ binary_simple_query(void* conn, const ch_query* query) {
         CHECK_FOR_INTERRUPTS();
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: %s", error),
-             errdetail_internal("Remote Query: %.64000s", query->sql))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: %s", error),
+            errdetail_internal("Remote Query: %.64000s", query->sql)
         );
     }
 
@@ -962,6 +973,30 @@ binary_simple_query(void* conn, const ch_query* query) {
     cursor->columns_count = ch_binary_response_columns(resp);
     ch_binary_read_state_init(cursor->read_state, resp);
     cursor->conversion_states = palloc0(sizeof(uintptr_t) * cursor->columns_count);
+    cursor->memcxt            = tempcxt;
+    cursor->callback.func     = binary_cursor_free;
+    cursor->callback.arg      = cursor;
+    MemoryContextRegisterResetCallback(tempcxt, &cursor->callback);
+
+    /*
+     * Validate declared shape before any per-column access. Empty attr_nums
+     * keeps the zero-attribute NULL sentinel handled at fetch time. Ignore
+     * columns_count == 0 (DDL) to support callers passing a placeholder
+     * column list since clickhouse_query() requires one syntactically.
+     */
+    if (query->tupdesc && query->attr_nums && cursor->columns_count > 0 &&
+        (size_t)list_length(query->attr_nums) != cursor->columns_count) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg_internal(
+                "pg_clickhouse: returned %lu columns, expected %lu",
+                (unsigned long)cursor->columns_count,
+                (unsigned long)list_length(query->attr_nums)
+            ),
+            errdetail_internal("Remote Query: %.64000s", query->sql)
+        );
+    }
 
     /*
      * CH JSON columns default to JSONBOID in state->coltypes. When foreign
@@ -985,10 +1020,6 @@ binary_simple_query(void* conn, const ch_query* query) {
         }
     }
 
-    cursor->memcxt        = tempcxt;
-    cursor->callback.func = binary_cursor_free;
-    cursor->callback.arg  = cursor;
-    MemoryContextRegisterResetCallback(tempcxt, &cursor->callback);
     MemoryContextSwitchTo(oldcxt);
 
     if (state->error) {
@@ -996,9 +1027,9 @@ binary_simple_query(void* conn, const ch_query* query) {
         CHECK_FOR_INTERRUPTS();
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: %s", state->error),
-             errdetail_internal("Remote Query: %.64000s", query->sql))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: %s", state->error),
+            errdetail_internal("Remote Query: %.64000s", query->sql)
         );
     }
 
@@ -1080,8 +1111,8 @@ chfdw_binary_fetch_raw_data(ch_cursor* cursor) {
     if (state->error) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: %s", state->error))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: %s", state->error)
         );
     }
 
@@ -1139,8 +1170,8 @@ binary_fetch_row(ChFdwScanRowContext* ctx) {
         CHECK_FOR_INTERRUPTS();
         ereport(
             ERROR,
-            (errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
-             errmsg("pg_clickhouse: error while reading row: %s", state->error))
+            errcode(ERRCODE_SQL_ROUTINE_EXCEPTION),
+            errmsg("pg_clickhouse: error while reading row: %s", state->error)
         );
     }
 
@@ -1156,22 +1187,22 @@ binary_fetch_row(ChFdwScanRowContext* ctx) {
         } else {
             ereport(
                 ERROR,
-                (errcode(ERRCODE_FDW_ERROR),
-                 errmsg(
-                     "pg_clickhouse: unexpected state: attributes "
-                     "count == 0 and haven't got NULL in the response"
-                 ))
+                errcode(ERRCODE_FDW_ERROR),
+                errmsg(
+                    "pg_clickhouse: unexpected state: attributes "
+                    "count == 0 and haven't got NULL in the response"
+                )
             );
         }
     } else if (attcount != ch_binary_response_columns(state->resp)) {
         ereport(
             ERROR,
-            (errcode(ERRCODE_DATATYPE_MISMATCH),
-             errmsg_internal(
-                 "pg_clickhouse: returned %lu columns, expected %lu",
-                 ch_binary_response_columns(state->resp),
-                 attcount
-             ))
+            errcode(ERRCODE_DATATYPE_MISMATCH),
+            errmsg_internal(
+                "pg_clickhouse: returned %lu columns, expected %lu",
+                ch_binary_response_columns(state->resp),
+                attcount
+            )
         );
     }
 
@@ -1273,7 +1304,7 @@ binary_prepare_insert(
     MemoryContext tempcxt, oldcxt;
 
     if (table_name == NULL) {
-        ereport(ERROR, (errcode(ERRCODE_FDW_ERROR), errmsg("expected table name")));
+        ereport(ERROR, errcode(ERRCODE_FDW_ERROR), errmsg("expected table name"));
     }
 
     tempcxt = AllocSetContextCreate(
@@ -1330,7 +1361,7 @@ binary_insert_tuple(void* istate, TupleTableSlot* slot) {
 
         ch_binary_do_output_conversion(state, slot);
 
-        for (size_t i = 0; i < state->outdesc->natts; i++) {
+        for (size_t i = 0; i < (size_t)state->outdesc->natts; i++) {
             ch_binary_column_append_data(state, i);
         }
 
@@ -1419,17 +1450,27 @@ parse_type(
     char* pos      = strstr(typepart, "(");
 
     if (pos != NULL) {
-        char* insidebr = pnstrdup(pos + 1, strrchr(typepart, ')') - pos - 1);
+        char* end = strrchr(typepart, ')');
+        char* insidebr;
+
+        if (end == NULL || end < pos) {
+            ereport(
+                ERROR,
+                errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                errmsg("pg_clickhouse: malformed ClickHouse type \"%s\"", typepart)
+            );
+        }
+        insidebr = pnstrdup(pos + 1, end - pos - 1);
 
         if (strncmp(typepart, "Decimal", strlen("Decimal")) == 0) {
             if (strstr(insidebr, ",") == NULL) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                     errmsg(
-                         "pg_clickhouse: could not import Decimal field, "
-                         "should be two parameters on definition"
-                     ))
+                    errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                    errmsg(
+                        "pg_clickhouse: could not import Decimal field, "
+                        "should be two parameters on definition"
+                    )
                 );
             }
 
@@ -1461,8 +1502,8 @@ parse_type(
             if (is_nullable == NULL) {
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("pg_clickhouse: nested Nullable is not supported"))
+                    errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                    errmsg("pg_clickhouse: nested Nullable is not supported")
                 );
             }
 
@@ -1485,8 +1526,8 @@ parse_type(
                 }
                 ereport(
                     ERROR,
-                    (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
-                     errmsg("pg_clickhouse: expected comma in AggregateFunction"))
+                    errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
+                    errmsg("pg_clickhouse: expected comma in AggregateFunction")
                 );
             }
 
@@ -1516,12 +1557,12 @@ parse_type(
 
     ereport(
         ERROR,
-        (errmsg(
+        errmsg(
             "pg_clickhouse: could not map %s.%s type <%s>",
             quote_identifier(table_name),
             quote_identifier(colname),
             part
-        ))
+        )
     );
 }
 

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -228,6 +228,14 @@ chfdw_is_shippable(
              * pushdown.
              */
             switch (cdef->cf_type) {
+            case CF_DATE_TRUNC:
+            case CF_DATE_PART: {
+                Expr* unit = (Expr*)linitial(((FuncExpr*)node)->args);
+
+                if (!IsA(unit, Const) || ((Const*)unit)->constisnull) {
+                    return false;
+                }
+            } break;
             case CF_ARRAY_SORT_DESC: {
                 /*
                  * If the boolean argument passed to array_sort(arr,

--- a/test/expected/binary.out
+++ b/test/expected/binary.out
@@ -438,6 +438,28 @@ LINE 1: SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1'...
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1, 2') AS t(x int);
 ERROR:  pg_clickhouse: returned 2 columns, expected 1
 DETAIL:  Remote Query: SELECT 1, 2
+-- more columns declared than returned is rejected
+SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1') AS t(x int, y text);
+ERROR:  pg_clickhouse: returned 1 columns, expected 2
+DETAIL:  Remote Query: SELECT 1
+-- mismatch is rejected even when query returns no rows
+SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0')
+    AS t(x int, y text);
+ERROR:  pg_clickhouse: returned 1 columns, expected 2
+DETAIL:  Remote Query: SELECT 1 WHERE 0
+-- DDL returns zero columns, required placeholder column list is ignored
+SELECT * FROM clickhouse_query(
+    'binary_loopback', 'CREATE TABLE ddl (c1 Int32) ENGINE = Memory'
+) AS t(x int);
+ x 
+---
+(0 rows)
+
+SELECT * FROM clickhouse_query('binary_loopback', 'DROP TABLE ddl') AS t(x int);
+ x 
+---
+(0 rows)
+
 -- value not coercible to the declared type is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT ''abc''') AS t(x int);
 ERROR:  invalid input syntax for type integer: "abc"
@@ -445,6 +467,75 @@ DETAIL:  Remote Query: SELECT 'abc'
 -- unknown server is rejected
 SELECT * FROM clickhouse_query('no_such_server', 'SELECT 1') AS t(x int);
 ERROR:  server "no_such_server" does not exist
+-- Nullable(Tuple(...)) is Beta, off by default, and only exists from CH 26
+-- onward; older servers reject the type outright regardless of settings.
+SELECT split_part(clickhouse_server_version('binary_loopback'), '.', 1)::int >= 26
+    AS ch_nullable_tuple \gset
+\if :ch_nullable_tuple
+-- null nested tuple in first row, conversion state initializes lazily
+SELECT * FROM clickhouse_query(
+    'binary_loopback',
+    $$
+    SELECT tuple(
+        if(number = 0,
+           CAST(NULL, 'Nullable(Tuple(Int32))'),
+           CAST(tuple(toInt32(number)), 'Nullable(Tuple(Int32))'))
+    )
+    FROM numbers(2)
+    ORDER BY number
+    SETTINGS allow_experimental_nullable_tuple_type = 1
+    $$
+) AS t(v text);
+    v    
+---------
+ ()
+ ("(1)")
+(2 rows)
+
+-- non-null nested tuple first, later null row skips cached converter
+SELECT * FROM clickhouse_query(
+    'binary_loopback',
+    $$
+    SELECT tuple(
+        if(number = 0,
+           CAST(NULL, 'Nullable(Tuple(Int32))'),
+           CAST(tuple(toInt32(number)), 'Nullable(Tuple(Int32))'))
+    )
+    FROM numbers(2)
+    ORDER BY number DESC
+    SETTINGS allow_experimental_nullable_tuple_type = 1
+    $$
+) AS t(v text);
+    v    
+---------
+ ("(1)")
+ ()
+(2 rows)
+
+-- same shape declared as a composite type; null nested tuple yields NULL field
+CREATE TYPE nested_tup_inner AS (a int);
+CREATE TYPE nested_tup AS (t nested_tup_inner);
+SELECT * FROM clickhouse_query(
+    'binary_loopback',
+    $$
+    SELECT tuple(
+        if(number = 0,
+           CAST(NULL, 'Nullable(Tuple(Int32))'),
+           CAST(tuple(toInt32(number)), 'Nullable(Tuple(Int32))'))
+    )
+    FROM numbers(2)
+    ORDER BY number
+    SETTINGS allow_experimental_nullable_tuple_type = 1
+    $$
+) AS t(v nested_tup);
+    v    
+---------
+ ()
+ ("(1)")
+(2 rows)
+
+DROP TYPE nested_tup, nested_tup_inner;
+\endif
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_test');
  clickhouse_raw_query 

--- a/test/expected/binary_1.out
+++ b/test/expected/binary_1.out
@@ -2,9 +2,17 @@ SET datestyle = 'ISO';
 CREATE SERVER binary_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'binary_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 -- integer types
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
@@ -13,10 +21,19 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
     c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
     FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 -- date and string types
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
@@ -25,6 +42,11 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
@@ -34,33 +56,64 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
     ''two'',
     ''three''
     FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 -- array types
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 -- nested arrays
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 -- ragged nested arrays must error: postgres requires hyper-rectangles
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.tuples (
     c1 Int8,
@@ -68,11 +121,20 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_test.tuples (
     c3 UInt8
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
     number % 2
     FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
     c1 Int8,
@@ -80,11 +142,20 @@ SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
     c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
     number,
     SHA1(''val'' || toString(number)),
     MD5(''val'' || toString(number))
     FROM numbers(10);');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 CREATE FOREIGN TABLE fints (
 	c1 int2,
@@ -99,7 +170,6 @@ CREATE FOREIGN TABLE fints (
     c10 float8,
     c11 bool
 ) SERVER binary_loopback OPTIONS (table_name 'ints');
-
 CREATE FOREIGN TABLE ftypes (
 	c1 date,
 	c2 timestamp with time zone,
@@ -109,107 +179,294 @@ CREATE FOREIGN TABLE ftypes (
     c6 text, -- Enum8
     c7 text  -- Enum16
 ) SERVER binary_loopback OPTIONS (table_name 'types');
-
 CREATE FOREIGN TABLE farrays (
 	c1 int[],
     c2 text[]
 ) SERVER binary_loopback OPTIONS (table_name 'arrays');
-
 CREATE FOREIGN TABLE farrays2 (
 	c1 int8[],
     c2 text[]
 ) SERVER binary_loopback OPTIONS (table_name 'arrays');
-
 CREATE FOREIGN TABLE fnested_arrays (
     c1 int2,
     c2 int[],
     c3 text[]
 ) SERVER binary_loopback OPTIONS (table_name 'nested_arrays');
-
 CREATE FOREIGN TABLE fragged_arrays (
     c1 int2,
     c2 int[]
 ) SERVER binary_loopback OPTIONS (table_name 'ragged_arrays');
-
 CREATE TYPE tupformat AS (a int, b text, c float4);
 CREATE FOREIGN TABLE ftuples (
     c1 int,
     c2 tupformat,
     c3 bool
 ) SERVER binary_loopback OPTIONS (table_name 'tuples');
-
 CREATE FOREIGN TABLE fbytes(
     c1 int,
     c2 BYTEA,
     c3 BYTEA
 ) SERVER binary_loopback OPTIONS (table_name 'bytes');
-
 COPY fints FROM stdin;
-\.
-
 -- integers
 SELECT * FROM fints ORDER BY c1;
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |  c9  | c10  | c11 
+----+----+----+----+----+----+----+----+------+------+-----
+  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8.1 |  9.2 | f
+  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9.1 | 10.2 | t
+  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10.1 | 11.2 | f
+  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11.1 | 12.2 | t
+  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12.1 | 13.2 | f
+  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13.1 | 14.2 | t
+  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14.1 | 15.2 | f
+  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15.1 | 16.2 | t
+  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16.1 | 17.2 | f
+  9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17.1 | 18.2 | t
+(10 rows)
+
 SELECT c2, c1, c8, c3, c4, c7, c6, c5 FROM fints ORDER BY c1;
+ c2 | c1 | c8 | c3 | c4 | c7 | c6 | c5 
+----+----+----+----+----+----+----+----
+  1 |  0 |  7 |  2 |  3 |  6 |  5 |  4
+  2 |  1 |  8 |  3 |  4 |  7 |  6 |  5
+  3 |  2 |  9 |  4 |  5 |  8 |  7 |  6
+  4 |  3 | 10 |  5 |  6 |  9 |  8 |  7
+  5 |  4 | 11 |  6 |  7 | 10 |  9 |  8
+  6 |  5 | 12 |  7 |  8 | 11 | 10 |  9
+  7 |  6 | 13 |  8 |  9 | 12 | 11 | 10
+  8 |  7 | 14 |  9 | 10 | 13 | 12 | 11
+  9 |  8 | 15 | 10 | 11 | 14 | 13 | 12
+ 10 |  9 | 16 | 11 | 12 | 15 | 14 | 13
+(10 rows)
+
 SELECT a, b FROM (SELECT c1 * 10 as a, c8 * 11 as b FROM fints ORDER BY a LIMIT 2) t1;
+ a  | b  
+----+----
+  0 | 77
+ 10 | 88
+(2 rows)
+
 SELECT NULL FROM fints LIMIT 2;
+ ?column? 
+----------
+ 
+ 
+(2 rows)
+
 SELECT c2, NULL, c1, NULL FROM fints ORDER BY c2 LIMIT 2;
+ c2 | ?column? | c1 | ?column? 
+----+----------+----+----------
+  1 |          |  0 | 
+  2 |          |  1 | 
+(2 rows)
 
 -- types
 SELECT * FROM ftypes ORDER BY c1;
+     c1     |           c2           |    c3    |  c4   |                  c5                  | c6  |  c7   
+------------+------------------------+----------+-------+--------------------------------------+-----+-------
+ 1990-01-01 | 1990-01-01 02:00:00-08 | number 0 | num 0 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e0 | two | three
+ 1990-01-02 | 1990-01-02 02:01:01-08 | number 1 | num 1 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e1 | two | three
+ 1990-01-03 | 1990-01-03 02:02:02-08 | number 2 | num 2 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e2 | two | three
+ 1990-01-04 | 1990-01-04 02:03:03-08 | number 3 | num 3 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e3 | two | three
+ 1990-01-05 | 1990-01-05 02:04:04-08 | number 4 | num 4 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e4 | two | three
+ 1990-01-06 | 1990-01-06 02:05:05-08 | number 5 | num 5 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e5 | two | three
+ 1990-01-07 | 1990-01-07 02:06:06-08 | number 6 | num 6 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e6 | two | three
+ 1990-01-08 | 1990-01-08 02:07:07-08 | number 7 | num 7 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e7 | two | three
+ 1990-01-09 | 1990-01-09 02:08:08-08 | number 8 | num 8 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e8 | two | three
+ 1990-01-10 | 1990-01-10 02:09:09-08 | number 9 | num 9 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e9 | two | three
+(10 rows)
+
 SELECT c2, c1, c4, c3, c5, c7, c6 FROM ftypes ORDER BY c1;
+           c2           |     c1     |  c4   |    c3    |                  c5                  |  c7   | c6  
+------------------------+------------+-------+----------+--------------------------------------+-------+-----
+ 1990-01-01 02:00:00-08 | 1990-01-01 | num 0 | number 0 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e0 | three | two
+ 1990-01-02 02:01:01-08 | 1990-01-02 | num 1 | number 1 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e1 | three | two
+ 1990-01-03 02:02:02-08 | 1990-01-03 | num 2 | number 2 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e2 | three | two
+ 1990-01-04 02:03:03-08 | 1990-01-04 | num 3 | number 3 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e3 | three | two
+ 1990-01-05 02:04:04-08 | 1990-01-05 | num 4 | number 4 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e4 | three | two
+ 1990-01-06 02:05:05-08 | 1990-01-06 | num 5 | number 5 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e5 | three | two
+ 1990-01-07 02:06:06-08 | 1990-01-07 | num 6 | number 6 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e6 | three | two
+ 1990-01-08 02:07:07-08 | 1990-01-08 | num 7 | number 7 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e7 | three | two
+ 1990-01-09 02:08:08-08 | 1990-01-09 | num 8 | number 8 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e8 | three | two
+ 1990-01-10 02:09:09-08 | 1990-01-10 | num 9 | number 9 | f4bf890f-f9dc-4332-ad5c-0c18e73f28e9 | three | two
+(10 rows)
 
 -- arrays
 SELECT * FROM farrays ORDER BY c1;
-SELECT * FROM farrays2 ORDER BY c1;
+   c1   |      c2      
+--------+--------------
+ {0,1}  | {num0,num1}
+ {1,2}  | {num1,num2}
+ {2,3}  | {num2,num3}
+ {3,4}  | {num3,num4}
+ {4,5}  | {num4,num5}
+ {5,6}  | {num5,num6}
+ {6,7}  | {num6,num7}
+ {7,8}  | {num7,num8}
+ {8,9}  | {num8,num9}
+ {9,10} | {num9,num10}
+(10 rows)
 
+SELECT * FROM farrays2 ORDER BY c1;
+ERROR:  pg_clickhouse: could not cast value from integer[] to bigint[]
+DETAIL:  Remote Query: SELECT c1, c2 FROM binary_test.arrays ORDER BY c1 ASC NULLS LAST
 -- nested arrays
 SELECT * FROM fnested_arrays ORDER BY c1;
-SELECT * FROM fragged_arrays ORDER BY c1;
+ c1 |      c2       |      c3       
+----+---------------+---------------
+  1 | {{1,2},{3,4}} | {{a,b},{c,d}}
+  2 | {{5,6},{7,8}} | {{e,f},{g,h}}
+(2 rows)
 
+SELECT * FROM fragged_arrays ORDER BY c1;
+ERROR:  malformed array literal: "{{"1","2","3"},{"4"}}"
+DETAIL:  Remote Query: SELECT c1, c2 FROM binary_test.ragged_arrays ORDER BY c1 ASC NULLS LAST
 -- tuples
 SELECT * FROM ftuples ORDER BY c1;
+ c1 |    c2    | c3 
+----+----------+----
+  0 | (0,0,1)  | f
+  1 | (1,1,2)  | t
+  2 | (2,2,3)  | f
+  3 | (3,3,4)  | t
+  4 | (4,4,5)  | f
+  5 | (5,5,6)  | t
+  6 | (6,6,7)  | f
+  7 | (7,7,8)  | t
+  8 | (8,8,9)  | f
+  9 | (9,9,10) | t
+(10 rows)
 
 -- Bytes.
 SELECT * FROM fbytes ORDER BY c1;
+ c1 |                     c2                     |                 c3                 
+----+--------------------------------------------+------------------------------------
+  0 | \x24e3800ca47f2504c25917d3b07306a28d0ac6fc | \x8664dccd1d83673d4fa8ef755ae88439
+  1 | \x5e6e4c0fb8ef47b4f1d6eea3e6c51152dbee94ec | \x8de92ce2033cf3ca03fa8cc63e7a703f
+  2 | \x4f47fdcd4e8d3b4802d50f990b401066bbfe0379 | \x38ceaa3b09c5a07d329888ba1ccde9ad
+  3 | \xb6a0af46ee8d92da3f0c176da8d88517a1b21c54 | \x9163c8c66d03c512404cca8549a250e7
+  4 | \xba42461dcb3e24f04e0d236f61d6804a4f4b3bee | \xa8516b0468eb31028c3dd669867c15b1
+  5 | \x483d5aa3a98e3d1d9f3f40c26ac15c9d42c2f6b8 | \x294a6e0d759cdbcf55753c4a58161721
+  6 | \x7d6934814141b108771faa00ba53750372cb413c | \x1b18b7cd2d63787cbe1d97e57a54853c
+  7 | \xd750c9d1e88df77272d3bde4a0ad16ca7ca6f14a | \x7e526a670883f267ce15deff74740a6e
+  8 | \x7673723fea187e3e78522d4b19ea97eb1a3d6787 | \xeafd00c5d025e9d71e9ed588f7f97e4b
+  9 | \xda1a828a08d9d57450ce10a89cb5ee91dc2feed7 | \xa2da4af9e1d8f4d37887f719cda60bda
+(10 rows)
 
 -- clickhouse_raw_query over the binary protocol
 SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
+ clickhouse_raw_query 
+----------------------
+ 1       x           +
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('SELECT number FROM numbers(3) ORDER BY number', 'driver=binary port=9000');
+ clickhouse_raw_query 
+----------------------
+ 0                   +
+ 1                   +
+ 2                   +
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('SELECT [1,2,3] AS arr, (1, ''a'') AS tup', 'driver=binary port=9000');
+ clickhouse_raw_query 
+----------------------
+ {1,2,3} (1,a)       +
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('SELECT NULL', 'driver=binary port=9000');
+ clickhouse_raw_query 
+----------------------
+ \N                  +
+ 
+(1 row)
+
 SELECT clickhouse_raw_query('CREATE TABLE binary_test.raw (c1 Int32) ENGINE = Memory', 'driver=binary port=9000');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 -- explicit http driver still works
 SELECT clickhouse_raw_query('SELECT 1', 'driver=http port=8123');
+ clickhouse_raw_query 
+----------------------
+ 1                   +
+ 
+(1 row)
+
 -- unknown driver is rejected
 SELECT clickhouse_raw_query('SELECT 1', 'driver=bogus');
-
+ERROR:  pg_clickhouse: invalid ClickHouse connection driver "bogus"
 -- clickhouse_query: server-based typed rowset over the binary driver
 SELECT * FROM clickhouse_query(
     'binary_loopback', 'SELECT c1, c3 FROM ints ORDER BY c1 LIMIT 3'
 ) AS t(c1 int2, c3 int);
+ c1 | c3 
+----+----
+  0 |  2
+  1 |  3
+  2 |  4
+(3 rows)
+
 SELECT * FROM clickhouse_query(
     'binary_loopback', 'SELECT toInt32(number) AS n, toString(number) AS s FROM numbers(3) ORDER BY n'
 ) AS t(n int, s text);
+ n | s 
+---+---
+ 0 | 0
+ 1 | 1
+ 2 | 2
+(3 rows)
+
 -- empty result yields no rows
 SELECT count(*) FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0') AS t(x int);
+ count 
+-------
+     0
+(1 row)
+
 -- missing column definition list is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1');
+ERROR:  a column definition list is required for functions returning "record"
+LINE 1: SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1'...
+                      ^
 -- fewer columns declared than returned is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1, 2') AS t(x int);
+ERROR:  pg_clickhouse: returned 2 columns, expected 1
+DETAIL:  Remote Query: SELECT 1, 2
 -- more columns declared than returned is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1') AS t(x int, y text);
+ERROR:  pg_clickhouse: returned 1 columns, expected 2
+DETAIL:  Remote Query: SELECT 1
 -- mismatch is rejected even when query returns no rows
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0')
     AS t(x int, y text);
+ERROR:  pg_clickhouse: returned 1 columns, expected 2
+DETAIL:  Remote Query: SELECT 1 WHERE 0
 -- DDL returns zero columns, required placeholder column list is ignored
 SELECT * FROM clickhouse_query(
     'binary_loopback', 'CREATE TABLE ddl (c1 Int32) ENGINE = Memory'
 ) AS t(x int);
+ x 
+---
+(0 rows)
+
 SELECT * FROM clickhouse_query('binary_loopback', 'DROP TABLE ddl') AS t(x int);
+ x 
+---
+(0 rows)
+
 -- value not coercible to the declared type is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT ''abc''') AS t(x int);
+ERROR:  invalid input syntax for type integer: "abc"
+DETAIL:  Remote Query: SELECT 'abc'
 -- unknown server is rejected
 SELECT * FROM clickhouse_query('no_such_server', 'SELECT 1') AS t(x int);
+ERROR:  server "no_such_server" does not exist
 -- Nullable(Tuple(...)) is Beta, off by default, and only exists from CH 26
 -- onward; older servers reject the type outright regardless of settings.
 SELECT split_part(clickhouse_server_version('binary_loopback'), '.', 1)::int >= 26
@@ -261,8 +518,20 @@ SELECT * FROM clickhouse_query(
 ) AS t(v nested_tup);
 DROP TYPE nested_tup, nested_tup_inner;
 \endif
-
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE binary_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
 
 DROP SERVER binary_loopback CASCADE;
+NOTICE:  drop cascades to 8 other objects
+DETAIL:  drop cascades to foreign table fints
+drop cascades to foreign table ftypes
+drop cascades to foreign table farrays
+drop cascades to foreign table farrays2
+drop cascades to foreign table fnested_arrays
+drop cascades to foreign table fragged_arrays
+drop cascades to foreign table ftuples
+drop cascades to foreign table fbytes

--- a/test/expected/engine_args.out
+++ b/test/expected/engine_args.out
@@ -233,7 +233,23 @@ OPTIONS (
   engine 'CollapsingMergeTree()'
 );
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_var5;
-ERROR:  pg_clickhouse: invalid identifier
+ERROR:  pg_clickhouse: invalid engine parameter
+-- Should fail with no parameter delimiters.
+CREATE FOREIGN TABLE engine_args_test.name_bare (id INT) SERVER engine_args_svr
+OPTIONS (
+  table_name 'innocuous',
+  engine 'CollapsingMergeTree'
+);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_bare;
+ERROR:  pg_clickhouse: invalid engine parameter
+-- Should fail with no closing delimiter.
+CREATE FOREIGN TABLE engine_args_test.name_open (id INT) SERVER engine_args_svr
+OPTIONS (
+  table_name 'innocuous',
+  engine 'CollapsingMergeTree(id'
+);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_open;
+ERROR:  pg_clickhouse: invalid engine parameter
 -- Should fail with parameter length > 63.
 CREATE FOREIGN TABLE engine_args_test.name_var6 (id INT) SERVER engine_args_svr
 OPTIONS (
@@ -288,7 +304,7 @@ SELECT clickhouse_raw_query('DROP DATABASE engine_args_test');
 (1 row)
 
 DROP SERVER engine_args_svr CASCADE;
-NOTICE:  drop cascades to 15 other objects
+NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to foreign table engine_args_test.dr_evil
 drop cascades to foreign table engine_args_test.dr_evil2
 drop cascades to foreign table engine_args_test.dr_evil3
@@ -300,6 +316,8 @@ drop cascades to foreign table engine_args_test.name_var3a
 drop cascades to foreign table engine_args_test.name_var4
 drop cascades to foreign table engine_args_test.name_var4a
 drop cascades to foreign table engine_args_test.name_var5
+drop cascades to foreign table engine_args_test.name_bare
+drop cascades to foreign table engine_args_test.name_open
 drop cascades to foreign table engine_args_test.name_var6
 drop cascades to foreign table engine_args_test.name_var7
 drop cascades to foreign table engine_args_test.name_var8

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_0.out
+++ b/test/expected/functions_0.out
@@ -942,7 +942,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1
 
 -- Unsupported non-ASCII unit raises a clean error.
 SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
-ERROR:  unit "É" not recognized for type timestamp without time zone
+ERROR:  timestamp units "É" not recognized
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -969,8 +969,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val, 'av') AS a, btrim(val, '1l2') AS 
 (4 rows)
 
 SELECT ltrim(val, 'av') AS a, btrim(val, '1l2') AS b, rtrim(val, 'l1') AS c FROM t4 GROUP BY a,b,c ORDER BY a;
-ERROR:  pg_clickhouse: DB::Exception: Syntax error: failed at position 17 (','): , 'av'), trimBoth(val, '1l2'), rtrim(val, 'l1') FROM functions_test.t4 GROUP BY (ltrim(val, 'av')), (trimBoth(val, '1l2')), (rtrim(val, 'l1')) ORDER BY ltrim(va. Expected one of: token, Dot, ClosingRoundBracket, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS, identifier
-DETAIL:  Remote Query: SELECT ltrim(val, 'av'), trimBoth(val, '1l2'), rtrim(val, 'l1') FROM functions_test.t4 GROUP BY (ltrim(val, 'av')), (trimBoth(val, '1l2')), (rtrim(val, 'l1')) ORDER BY ltrim(val, 'av') ASC NULLS LAST
+ a  | b  |  c   
+----+----+------
+ l1 | va | va
+ l2 | va | val2
+(2 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT strpos(val, 'val') AS a FROM t4 GROUP BY a ORDER BY a;
                                                                         QUERY PLAN                                                                         
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1666,8 +1670,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < statement_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < statement_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -1677,8 +1685,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < transaction_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < transaction_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
@@ -1688,8 +1700,12 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < clock_timestamp();
 (3 rows)
 
 SELECT * FROM t1 WHERE c < clock_timestamp() ORDER BY a LIMIT 2;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function nowInBlock64. Maybe you meant: ['nowInBlock']: While processing SELECT a, b, c FROM functions_test.t1 WHERE c < nowInBlock64(6, 'America/Los_Angeles') ORDER BY a ASC NULLS LAST LIMIT 2
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((c < nowInBlock64(6, 'America/Los_Angeles'))) ORDER BY a ASC NULLS LAST LIMIT 2
+ a | b |          c          
+---+---+---------------------
+ 1 | 1 | 2019-01-01 02:00:00
+ 2 | 2 | 2019-01-02 02:00:00
+(2 rows)
+
 -- Check SQL Value functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < CURRENT_DATE;
                                               QUERY PLAN                                              
@@ -1911,8 +1927,11 @@ SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:0
 (3 rows)
 
 SELECT * FROM t1 WHERE concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00';
-ERROR:  pg_clickhouse: DB::Exception: Illegal type Int32 of argument 2 of function concatWithSeparator: While processing concatWithSeparator(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'
-DETAIL:  Remote Query: SELECT a, b, c FROM functions_test.t1 WHERE ((concat_ws(',', a, b, 'foo', c) = '2,3,foo,2019-01-02 10:00:00'))
+ a | b |          c          
+---+---+---------------------
+ 2 | 3 | 2019-01-02 02:00:00
+(1 row)
+
 -- Test fuzzystrmatch pushdown.
 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 -- soundex pushes down with same name.
@@ -1943,8 +1962,12 @@ SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
 (3 rows)
 
 SELECT * FROM t4 WHERE levenshtein(val, 'val1') <= 1;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function editDistanceUTF8. Maybe you meant: ['ngramDistanceUTF8']: While processing editDistanceUTF8(val, 'val1') <= 1
-DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((editDistanceUTF8(val, 'val1') <= 1))
+ val  
+------
+ val1
+ val2
+(2 rows)
+
 -- 5-arg levenshtein (custom costs) evaluates locally.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t4 WHERE levenshtein(val, 'val1', 1, 1, 2) <= 1;
@@ -2191,8 +2214,13 @@ SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
 (3 rows)
 
 SELECT a FROM t3 WHERE mod(a::numeric, 3::numeric) = 0 ORDER BY a;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing (CAST(a, 'Nullable(Decimal)') % 3) = 0
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((modulo(cast(a, 'Nullable(Decimal)'), 3) = 0)) ORDER BY a ASC NULLS LAST
+ a 
+---
+ 3
+ 6
+ 9
+(3 rows)
+
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
                                             QUERY PLAN                                             
@@ -2203,8 +2231,11 @@ SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
 (3 rows)
 
 SELECT a FROM t3 WHERE pow(a::numeric, 2::numeric) = 25;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing pow(CAST(a, 'Nullable(Decimal)'), 2) = 25
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+ a 
+---
+ 5
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
                                             QUERY PLAN                                             
@@ -2215,8 +2246,11 @@ SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
 (3 rows)
 
 SELECT a FROM t3 WHERE power(a::numeric, 2::numeric) = 25;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing pow(CAST(a, 'Nullable(Decimal)'), 2) = 25
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((pow(cast(a, 'Nullable(Decimal)'), 2) = 25))
+ a 
+---
+ 5
+(1 row)
+
 -- abs() pushes down for int / float / numeric.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a FROM t3 WHERE abs(a - 5) = 2 ORDER BY a;
@@ -2259,8 +2293,11 @@ SELECT a FROM t3 WHERE abs(a::numeric) = 5;
 (3 rows)
 
 SELECT a FROM t3 WHERE abs(a::numeric) = 5;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing abs(CAST(a, 'Nullable(Decimal)')) = 5
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((abs(cast(a, 'Nullable(Decimal)')) = 5))
+ a 
+---
+ 5
+(1 row)
+
 -- factorial(int8) pushes down.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a FROM t3 WHERE factorial(a) = 120;
@@ -2303,8 +2340,11 @@ SELECT a FROM t3 WHERE round(a::numeric) = 5;
 (3 rows)
 
 SELECT a FROM t3 WHERE round(a::numeric) = 5;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing round(CAST(a, 'Nullable(Decimal)'), 0) = 5
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((round(cast(a, 'Nullable(Decimal)'), 0) = 5))
+ a 
+---
+ 5
+(1 row)
+
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
                                                  QUERY PLAN                                                  
@@ -2315,8 +2355,10 @@ SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
 (3 rows)
 
 SELECT a FROM t3 WHERE round((a::numeric) / 3, 2) = 1.67;
-ERROR:  pg_clickhouse: DB::Exception: Decimal data type family must have exactly two arguments: precision and scale: While processing round(CAST(a, 'Nullable(Decimal)') / 3, 2) = 1.67
-DETAIL:  Remote Query: SELECT a FROM functions_test.t3 WHERE ((round((cast(a, 'Nullable(Decimal)') / 3), 2) = 1.67))
+ a 
+---
+(0 rows)
+
 -- Trig functions push down at f64 = 0 where PG and CH agree exactly.
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT i64 FROM t6 WHERE i64 = 0 AND sin(f64) = 0;
@@ -2680,19 +2722,7 @@ SELECT current_setting('server_version_num')::int >= 180000 AS pg18 \gset
 \if :pg18
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Foreign Scan on public.t4
-   Output: val
-   Remote SQL: SELECT val FROM functions_test.t4 WHERE ((reverse(CAST(val AS bytea(0))) = 'olleh'))
-(3 rows)
-
 SELECT val FROM t4 WHERE reverse(val::bytea) = 'olleh'::bytea;
-  val  
--------
- hello
-(1 row)
-
 \endif
 -- date(timestamp) and date(timestamptz) push down as CH date (alias for toDate).
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -2836,17 +2866,7 @@ SELECT current_setting('server_version_num')::int >= 190000 AS pg19 \gset
 \if :pg19
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT encode(val::bytea, 'base64url') AS b FROM t4 GROUP BY b ORDER BY b;
-                                                                                             QUERY PLAN                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan
-   Output: (encode((val)::bytea, 'base64url'::text))
-   Relations: Aggregate on (t4)
-   Remote SQL: SELECT base64URLEncode(CAST(val AS bytea(0))) FROM functions_test.t4 GROUP BY (base64URLEncode(CAST(val AS bytea(0)))) ORDER BY base64URLEncode(CAST(val AS bytea(0))) ASC NULLS LAST
-(4 rows)
-
 SELECT encode(val::bytea, 'base64url') AS b FROM t4 GROUP BY b ORDER BY b;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function base64URLEncode. Maybe you meant: ['base64Encode','base64Decode']
-DETAIL:  Remote Query: SELECT base64URLEncode(CAST(val AS bytea(0))) FROM functions_test.t4 GROUP BY (base64URLEncode(CAST(val AS bytea(0)))) ORDER BY base64URLEncode(CAST(val AS bytea(0))) ASC NULLS LAST
 -- The 60-byte input crosses base64's 76-char line break boundary, exercising
 -- that base64url emits no newline; matching against PG's own output of the same
 -- bytes confirms they agree byte-for-byte.
@@ -2855,8 +2875,6 @@ WHERE encode(val::bytea, 'base64url') IN (
     encode(repeat('a', 57)::bytea, 'base64url'),
     encode(repeat('a', 60)::bytea, 'base64url')
 ) ORDER BY n;
-ERROR:  pg_clickhouse: DB::Exception: Unknown function base64URLEncode. Maybe you meant: ['base64Encode','base64Decode']: While processing base64URLEncode(CAST(val, 'bytea(0)')) IN ('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh', 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh')
-DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((base64URLEncode(CAST(val AS bytea(0))) IN ('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh','YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh'))) ORDER BY length(val) ASC NULLS LAST
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 SELECT clickhouse_raw_query('DROP DATABASE functions_test');
@@ -2866,7 +2884,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2875,3 +2893,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table times

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  timestamp units "É" not recognized
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_9.out
+++ b/test/expected/functions_9.out
@@ -921,6 +921,28 @@ SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY
  1546426800
 (3 rows)
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_trunc(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: date_part(t4.val, t5.ts)
+   Relations: (t4) INNER JOIN (t5)
+   Remote SQL: SELECT r1.val, r2.ts FROM  functions_test.t4 r1 ALL INNER JOIN functions_test.t5 r2 ON (TRUE) LIMIT 1
+(4 rows)
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+ERROR:  unit "É" not recognized for type timestamp without time zone
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -23,6 +23,16 @@ NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value i
  join_use_nulls     | 1
 (3 rows)
 
+      name      | value 
+----------------+-------
+ join_use_nulls | 1
+(1 row)
+
+      name      | value 
+----------------+-------
+ join_use_nulls | 1
+(1 row)
+
        pg_clickhouse.session_settings        
 ---------------------------------------------
                                             +

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -1016,6 +1016,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1175,7 +1239,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1187,5 +1251,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -1014,6 +1014,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1173,7 +1237,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1185,5 +1249,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -1014,6 +1014,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1173,7 +1237,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1185,5 +1249,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -1014,6 +1014,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1173,7 +1237,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1185,5 +1249,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -1014,6 +1014,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1173,7 +1237,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1185,5 +1249,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -1016,6 +1016,70 @@ FROM ft_nullmark ORDER BY id;
  4  | ordinary        |      8 | f
 (4 rows)
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+ id |      v       | is_null | octet_length 
+----+--------------+---------+--------------
+ 1  |              | t       |             
+ 2  | \x           | f       |            0
+ 3  | \x610062     | f       |            3
+ 4  | \x706c61696e | f       |            5
+(4 rows)
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+SELECT v FROM ft_timestr WHERE id = '3';
+    v     
+----------
+ 00:00:00
+(1 row)
+
+SELECT v FROM ft_timestr WHERE id = '1';
+ERROR:  invalid input syntax for type time: "Z"
+SELECT v FROM ft_timestr WHERE id = '2';
+ERROR:  invalid input syntax for type time: "xZ"
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */
@@ -1175,7 +1239,7 @@ NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;
 NOTICE:  drop cascades to foreign table ft6
 DROP SERVER http_loopback CASCADE;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 15 other objects
 DETAIL:  drop cascades to foreign table ft1
 drop cascades to foreign table ft1_stream
 drop cascades to foreign table ft2
@@ -1187,5 +1251,7 @@ drop cascades to foreign table ft_brk
 drop cascades to foreign table ft_brk_stream
 drop cascades to foreign table ft_brk_mix
 drop cascades to foreign table ft_nullmark
+drop cascades to foreign table ft_bytea
+drop cascades to foreign table ft_timestr
 drop cascades to foreign table ft_nested_arrays
 drop cascades to foreign table ft_ragged_arrays

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -36,6 +36,18 @@ array_functions.sql
  24.3+      | array_functions.out
  23         | array_functions_2.out
 
+binary.sql
+----------
+
+ Postgres | File
+----------|-------------
+ 13-19    | binary.out
+
+ ClickHouse | File
+------------|--------------
+ 26+        | binary.out
+ < 26       | binary_1.out
+
 binary_inserts.sql
 ------------------
 
@@ -109,7 +121,8 @@ functions.sql
 ----------|---------------
  19       | functions.out
  18       | functions_1.out
- 14-17    | functions_2.out
+ 15-17    | functions_2.out
+ 14       | functions_0.out
  13       | functions_3.out
 
  ClickHouse | File

--- a/test/sql/engine_args.sql
+++ b/test/sql/engine_args.sql
@@ -140,6 +140,22 @@ OPTIONS (
 );
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_var5;
 
+-- Should fail with no parameter delimiters.
+CREATE FOREIGN TABLE engine_args_test.name_bare (id INT) SERVER engine_args_svr
+OPTIONS (
+  table_name 'innocuous',
+  engine 'CollapsingMergeTree'
+);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_bare;
+
+-- Should fail with no closing delimiter.
+CREATE FOREIGN TABLE engine_args_test.name_open (id INT) SERVER engine_args_svr
+OPTIONS (
+  table_name 'innocuous',
+  engine 'CollapsingMergeTree(id'
+);
+EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_open;
+
 -- Should fail with parameter length > 63.
 CREATE FOREIGN TABLE engine_args_test.name_var6 (id INT) SERVER engine_args_svr
 OPTIONS (

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -234,6 +234,13 @@ SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDE
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 SELECT date_part('ePoch'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 
+-- Dynamic unit argument cannot push down, stays local.
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part(t4.val, t5.ts) FROM t4, t5 LIMIT 1;
+
+-- Unsupported non-ASCII unit raises a clean error.
+SELECT date_trunc('É'::text, ts) FROM t5 LIMIT 1;
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
 SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
 

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -94,6 +94,12 @@ SELECT name, value
   FROM bin_remote_settings
  WHERE name = ANY(:'set_list');
 
+-- Single setting exercises the iterator stopping at the final pair.
+SET pg_clickhouse.session_settings TO 'join_use_nulls 1';
+
+SELECT name, value FROM bin_remote_settings WHERE name = 'join_use_nulls';
+SELECT name, value FROM http_remote_settings WHERE name = 'join_use_nulls';
+
 -- Customize all of the above settings.
 SET pg_clickhouse.session_settings TO $$
     connect_timeout 2,

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -363,6 +363,41 @@ CREATE FOREIGN TABLE ft_nullmark (id text, s text)
 SELECT id, s, length(s), s IS NULL AS is_null
 FROM ft_nullmark ORDER BY id;
 
+/*
+ * bytea columns take raw bytes without the input function. NULL maps to SQL
+ * NULL, empty string stays empty, embedded zero bytes survive.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+    (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+    (''1'', NULL),
+    (''2'', ''''),
+    (''3'', char(97, 0, 98)),
+    (''4'', ''plain'')');
+
+CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
+    SERVER http_loopback OPTIONS (table_name 't_bytea');
+
+SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
+
+/*
+ * time columns strip the exact ISO epoch date prefix. Shorter values or ones
+ * with another prefix route through the input function unchanged.
+ */
+SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+    (id String, v String) ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+    (''1'', ''Z''),
+    (''2'', ''xZ''),
+    (''3'', ''1970-01-01T00:00:00Z'')');
+
+CREATE FOREIGN TABLE ft_timestr (id text, v time)
+    SERVER http_loopback OPTIONS (table_name 't_timestr');
+
+SELECT v FROM ft_timestr WHERE id = '3';
+SELECT v FROM ft_timestr WHERE id = '1';
+SELECT v FROM ft_timestr WHERE id = '2';
+
 /* nested arrays via http (TabSeparated): rectangular maps to multi-dim,
  * jagged shapes route through array_in and surface its malformed-literal
  * error -- matching the binary path. */


### PR DESCRIPTION
1. kv_iter_next would access out of bounds with strlen when iter->togo == 1
2. CollapsingMergeTree was didn't validate well with bad parenthesis
3. CF_DATE_TRUNC/CF_DATE_PART didn't reject non-Const or null units
4. binary_simple_query was accessing state->coltypes[j] potentially out of bounds if column counts mismatched
5. volatile MemoryContext tempcxt needed for longjmp/setjmp semantics, added -Wclobbered to warn about this on gcc
6. char_to_datum would skip out of bounds on inputs without prefix
7. avoid calling convert_record / ch_binary_init_convert_state with NULL
8. `busy` should also be initialized in get_connection_entry
9. use typed curl_xferinfo_callback
10. curl_easy_escape returns NULL on failure, handle failure
11. DateTime64 scale bounded against lengthof(pow10i) for more hardening against malicious CH server
12. Wsign-compare