### PR TITLE
Preserve NULL semantics in IN-family pushdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ All notable changes to this project will be documented in this file. It uses the
 *   Added the `clickhouse_server_version(server)` function, which reports the
     ClickHouse server version ("major.minor.patch") for a foreign server
     ([#293]).
+*   Added pushdown for subqueries the planner cannot flatten into joins
+    (SubPlans): correlated and uncorrelated scalar aggregate subqueries,
+    `EXISTS`, and single-column equality `IN`/`NOT IN`, in `WHERE` and `HAVING`.
+    Covers TPC-H Q2, Q11, Q15, Q17, Q20, and Q22 shapes. `NOT IN` preserves
+    PostgreSQL's NULL semantics under ClickHouse's two-valued `IN`, deparsing
+    with compensating guards when the columns involved are nullable ([#315]).
+    Requires ClickHouse 25.8 or later; older servers keep evaluating the
+    subquery locally ([#289]).
+*   Added `transform_null_in 0` to the default value of the
+    `pg_clickhouse.session_settings` parameter, so that a ClickHouse server
+    profile cannot silently change the `IN` semantics the pushdown rules rely
+    on ([#315]).
 *   Added pushdown for more aggregate functions ([#290]):
     *   [corr]
     *   [covarpop]
@@ -74,6 +86,16 @@ All notable changes to this project will be documented in this file. It uses the
     rejection of non-`Const`/null units in `date_trunc`/`date_part` pushdown;
     NULL handling in record conversion; unchecked `curl_easy_escape` failures;
     and unbounded `DateTime64` scale lookups ([#313]).
+*   Fixed wrong results from pushed-down `= ANY`/`<> ALL` expressions and `IN`
+    expressions over constant lists and when a `NULL` could reach the
+    comparison, because ClickHouse evaluates `IN` under two-valued logic while
+    PostgreSQL evaluates three-value `NULL` logic. These cases now ship only
+    where PostgreSQL's three-valued answer can be provably preserved ([#315]).
+*   Fixed `<> ANY(array)` deparsing to ClickHouse SQL that computes `<> ALL`,
+    which is wrong even with no `NULL`s involved: In Postgres,
+    `1 <> ANY('{1,5}')` is `TRUE`. For now, do not push down ([#315]).
+*   Fixed the pushdown of a `CASE arg WHEN ..` expression without checking its
+    branches when the tested expression was itself unshippable ([#315]).
 
 ### 📚 Documentation
 
@@ -114,8 +136,12 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#309 add binary support to clickhouse_raw_query, add clickhouse_query"
   [#310]: https://github.com/ClickHouse/pg_clickhouse/pull/310
     "ClickHouse/pg_clickhouse#310 Disable MinMaxAgg without impacting overall query planner costs"
+  [#289]: https://github.com/ClickHouse/pg_clickhouse/pull/289
+    "ClickHouse/pg_clickhouse#289 Push down subquery (SubPlan) residue to ClickHouse"
   [#313]: https://github.com/ClickHouse/pg_clickhouse/pull/313
     "ClickHouse/pg_clickhouse#313 Fix misc undefined behavior"
+  [#315]: https://github.com/ClickHouse/pg_clickhouse/pull/315
+    "ClickHouse/pg_clickhouse#315 Preserve NULL semantics in IN-family pushdown"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -795,8 +795,12 @@ settings] to be set on subsequent queries. Example:
 SET pg_clickhouse.session_settings = 'join_use_nulls 1, final 1';
 ```
 
-The default is `join_use_nulls 1, group_by_use_nulls 1, final 1`. Set it to an
-empty string to fall back on the ClickHouse server's settings.
+The default is `join_use_nulls 1, group_by_use_nulls 1, final 1,
+transform_null_in 0`. Set it to an empty string to fall back on the
+ClickHouse server's settings — but note that pushdown correctness depends on
+some of these defaults: `join_use_nulls` for outer joins and
+`transform_null_in` for the `IN` family (see [IN and NULL
+Semantics](#in-and-null-semantics)).
 
 ```sql
 SET pg_clickhouse.session_settings = '';
@@ -1309,6 +1313,30 @@ equivalents as follows:
 *   `!~*` (case insensitive regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `->>` (JSON/JSONB extract element as text): [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `->` (JSON/JSONB extract): [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+
+### IN and NULL Semantics
+
+ClickHouse evaluates `IN` under two-valued logic: when the probe finds no
+match it returns `0` even if a NULL is involved, where PostgreSQL computes
+NULL. To preserve PostgreSQL semantics, pg_clickhouse pushes down the `IN`
+family (`IN`, `NOT IN`, `= ANY`, `<> ALL`, and `IN (SELECT ...)`) only where
+the two systems provably agree: in a plain filter condition, where a NULL
+disqualifies a row exactly like `FALSE`, or when none of the probe, the list,
+nor the subquery output can produce a NULL. A `NOT IN (SELECT ...)` filter
+over nullable columns still pushes down, deparsed with compensating guards
+that keep PostgreSQL's answer: a set containing a NULL disqualifies every
+row, and a NULL probe passes only against an empty set. Each guard is
+omitted when a `NOT NULL` declaration proves it unnecessary. The remaining
+shapes (NULL-capable `IN` expressions in select lists, `GROUP BY`, or
+`ORDER BY`, and `NOT IN` over arrays or grouped subqueries) are evaluated
+locally. Declaring columns `NOT NULL` maximizes pushdown; [IMPORT FOREIGN
+SCHEMA] does so automatically for non-`Nullable` ClickHouse columns.
+
+These rules assume ClickHouse's default `transform_null_in = 0`, which
+pg_clickhouse sets on every query through the default value of the
+[`pg_clickhouse.session_settings`](#pg_clickhousesession_settings) parameter
+so that a ClickHouse server profile cannot silently change it. Setting
+`transform_null_in = 1` breaks the semantics of every pushed `IN`.
 
 ### Custom Functions
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -173,13 +173,33 @@ typedef struct deparse_expr_cxt {
     } while (0)
 
 /*
+ * How an expression's result is consumed, for the IN-family NULL-semantics
+ * rules (see the block comment for saop_null_semantics_ok).
+ *
+ * EXPR_CTX_TRUTH    only qualifies rows: NULL and FALSE are interchangeable.
+ * EXPR_CTX_NEGATED  the direct operand of one NOT whose own result is in a
+ *                   truth context. Only a SubPlan consumes this state (it
+ *                   admits the guarded NOT IN deparse); every other node
+ *                   degrades it to EXPR_CTX_EXACT for its children, so the
+ *                   walker and the deparse peek in deparseBoolExpr agree on
+ *                   exactly which SubPlans get the guarded form.
+ * EXPR_CTX_EXACT    the value itself is observable: exact three-valued
+ *                   equivalence required.
+ */
+typedef enum ExprTruthCtx {
+    EXPR_CTX_TRUTH,
+    EXPR_CTX_NEGATED,
+    EXPR_CTX_EXACT,
+} ExprTruthCtx;
+
+/*
  * Functions to determine whether an expression can be evaluated safely on
  * remote server.
  */
 static bool
-foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt);
+foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx);
 static bool
-is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt);
+is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx);
 static char*
 deparse_type_name(Oid type_oid, int32 typemod);
 
@@ -322,10 +342,21 @@ static void
 deparseNullIfExpr(NullIfExpr* node, deparse_expr_cxt* context);
 static void
 appendRegex(List* args, deparse_expr_cxt* context);
+/*
+ * Which rendering of a SubPlan's subquery body deparseSubPlanQuery emits.
+ */
+typedef enum SubPlanBodyForm {
+    SUBPLAN_BODY_QUERY,      /* the subquery as written */
+    SUBPLAN_BODY_NULL_PROBE, /* SELECT 1 .. AND (output IS NULL): the poison
+                              * guard of a guarded NOT IN */
+} SubPlanBodyForm;
+
 static void
 deparseSubPlan(SubPlan* node, deparse_expr_cxt* context);
 static void
-deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context);
+deparseGuardedNotIn(SubPlan* subplan, deparse_expr_cxt* context);
+static void
+deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context, SubPlanBodyForm form);
 static void
 deparseSubPlanQuals(Node* quals, deparse_expr_cxt* context);
 static void
@@ -368,7 +399,7 @@ chfdw_classify_conditions(
     foreach (lc, input_conds) {
         RestrictInfo* ri = lfirst_node(RestrictInfo, lc);
 
-        if (chfdw_is_foreign_expr(root, baserel, ri->clause)) {
+        if (chfdw_is_foreign_expr(root, baserel, ri->clause, false)) {
             *remote_conds = lappend(*remote_conds, ri);
         } else {
             *local_conds = lappend(*local_conds, ri);
@@ -378,9 +409,24 @@ chfdw_classify_conditions(
 
 /*
  * Returns true if given expr is safe to evaluate on the foreign server.
+ *
+ * exact_ctx determines how the expression's result is consumed: false for a
+ * WHERE/JOIN/HAVING condition, where a NULL qualifies a row exactly like
+ * FALSE; true anywhere the computed value itself is observable (target
+ * lists, grouping and ordering expressions). The distinction feeds the
+ * IN-family NULL-semantics rules; see foreign_expr_walker. Internally the
+ * walker refines this into ExprTruthCtx's three states; the third
+ * (EXPR_CTX_NEGATED) is derivable only from a NOT encountered during the
+ * walk, never assertable by a caller, so the entry point speaks the
+ * two-valued form.
  */
 bool
-chfdw_is_foreign_expr(PlannerInfo* root, RelOptInfo* baserel, Expr* expr) {
+chfdw_is_foreign_expr(
+    PlannerInfo* root,
+    RelOptInfo* baserel,
+    Expr* expr,
+    bool exact_ctx
+) {
     foreign_glob_cxt glob_cxt;
     CHFdwRelationInfo* fpinfo = (CHFdwRelationInfo*)(baserel->fdw_private);
 
@@ -403,7 +449,9 @@ chfdw_is_foreign_expr(PlannerInfo* root, RelOptInfo* baserel, Expr* expr) {
         glob_cxt.relids = baserel->relids;
     }
 
-    if (!foreign_expr_walker((Node*)expr, &glob_cxt)) {
+    if (!foreign_expr_walker(
+            (Node*)expr, &glob_cxt, exact_ctx ? EXPR_CTX_EXACT : EXPR_CTX_TRUTH
+        )) {
         return false;
     }
 
@@ -504,6 +552,345 @@ agg_partial_kind(Aggref* agg) {
     return kind;
 }
 
+static bool
+is_ok_in_expr(Expr* expr);
+
+/*
+ * True if `expr` provably cannot evaluate to NULL: a non-NULL constant, or a
+ * column of a scanned relation that is declared NOT NULL and cannot have been
+ * null-extended by an outer join. Anything else is assumed nullable.
+ *
+ * PG 17+ precomputes the catalog half of this as
+ * RelOptInfo->notnullattnums; the syscache lookup below keeps one code path
+ * across PG 13-19, so switch when PG 16 support drops. Postgres exports no
+ * expression-level equivalent on any version.
+ */
+static bool
+expr_never_null(Expr* expr, foreign_glob_cxt* glob_cxt) {
+    while (IsA(expr, RelabelType)) {
+        expr = ((RelabelType*)expr)->arg;
+    }
+
+    if (IsA(expr, Const)) {
+        return !((Const*)expr)->constisnull;
+    }
+
+    if (IsA(expr, Var)) {
+        Var* var = (Var*)expr;
+        RangeTblEntry* rte;
+        HeapTuple tp;
+        bool notnull;
+
+        /* Only a plain user column that this scan reads is provable */
+        if (var->varlevelsup != 0 || var->varattno <= 0 ||
+            !bms_is_member(var->varno, glob_cxt->relids)) {
+            return false;
+        }
+
+#if PG_VERSION_NUM >= 160000
+        /* A Var nulled by an outer join is nullable whatever the catalog says */
+        if (!bms_is_empty(var->varnullingrels)) {
+            return false;
+        }
+#else
+        /* Pre-16 Vars carry no nulling info; give up if any outer join exists */
+        {
+            ListCell* jlc;
+
+            foreach (jlc, glob_cxt->root->parse->rtable) {
+                RangeTblEntry* jrte = (RangeTblEntry*)lfirst(jlc);
+
+                if (jrte->rtekind == RTE_JOIN && jrte->jointype != JOIN_INNER) {
+                    return false;
+                }
+            }
+        }
+#endif
+
+        rte = planner_rt_fetch(var->varno, glob_cxt->root);
+        if (rte == NULL || rte->rtekind != RTE_RELATION) {
+            return false;
+        }
+
+        tp = SearchSysCache2(
+            ATTNUM, ObjectIdGetDatum(rte->relid), Int16GetDatum(var->varattno)
+        );
+        if (!HeapTupleIsValid(tp)) {
+            return false;
+        }
+        notnull = ((Form_pg_attribute)GETSTRUCT(tp))->attnotnull;
+        ReleaseSysCache(tp);
+
+        return notnull;
+    }
+
+    return false;
+}
+
+/*
+ * What is known at plan time about NULL elements in a ScalarArrayOpExpr's
+ * right-hand array.
+ */
+typedef enum SaopArrayNulls {
+    SAOP_ARR_EMPTY,     /* provably zero elements */
+    SAOP_ARR_NULL_FREE, /* provably contains no NULL element */
+    SAOP_ARR_UNKNOWN,   /* may contain a NULL element */
+} SaopArrayNulls;
+
+static SaopArrayNulls
+saop_array_nulls(Expr* arr, foreign_glob_cxt* glob_cxt) {
+    if (IsA(arr, Const)) {
+        Const* c = (Const*)arr;
+        ArrayType* a;
+
+        if (c->constisnull) {
+            return SAOP_ARR_UNKNOWN;
+        }
+        a = DatumGetArrayTypeP(c->constvalue);
+        if (ArrayGetNItems(ARR_NDIM(a), ARR_DIMS(a)) == 0) {
+            return SAOP_ARR_EMPTY;
+        }
+        /* No null bitmap means no NULL element; with one, assume the worst */
+        return ARR_HASNULL(a) ? SAOP_ARR_UNKNOWN : SAOP_ARR_NULL_FREE;
+    }
+
+    if (IsA(arr, ArrayExpr) && !((ArrayExpr*)arr)->multidims) {
+        ArrayExpr* ae = (ArrayExpr*)arr;
+        ListCell* lc;
+
+        if (ae->elements == NIL) {
+            return SAOP_ARR_EMPTY;
+        }
+        foreach (lc, ae->elements) {
+            if (!expr_never_null((Expr*)lfirst(lc), glob_cxt)) {
+                return SAOP_ARR_UNKNOWN;
+            }
+        }
+        return SAOP_ARR_NULL_FREE;
+    }
+
+    return SAOP_ARR_UNKNOWN;
+}
+
+/*
+ * Decide whether a ScalarArrayOpExpr keeps Postgres semantics on ClickHouse.
+ * This comment is the reference for the divergence rules used here and in
+ * the SubPlan gate (is_shippable_subplan) and deparse (deparseGuardedNotIn).
+ *
+ * ClickHouse evaluates IN under two-valued logic (given transform_null_in =
+ * 0, the ClickHouse default, which pg_clickhouse.session_settings sets
+ * per-query so a server profile cannot change it; overriding the GUC is at
+ * the user's own risk, like the join_use_nulls default the pushed outer
+ * joins rely on): a probe that finds no match yields 0 even when the searched set
+ * contains a NULL, and NOT IN is the exact complement, where Postgres
+ * yields NULL in both cases. The two systems agree whenever no NULL can
+ * reach the comparison; when one can, ClickHouse substitutes FALSE where
+ * Postgres computes NULL, and for the complemented forms (NOT IN, <> ALL)
+ * TRUE where Postgres computes NULL. The has()/countEqual() deparse forms
+ * additionally match a NULL probe against NULL elements as if they were
+ * ordinary values.
+ *
+ * A FALSE-for-NULL substitution is invisible exactly where a NULL qualifies
+ * a row the same way FALSE does: WHERE/JOIN/HAVING conditions, CASE WHEN
+ * branches, and aggregate FILTERs, composed through any number of AND/OR
+ * (EXPR_CTX_TRUTH). Under NOT, in a function/operator/aggregate argument,
+ * in a grouping or ordering expression — anywhere the boolean's value is
+ * consumed — the substitution is observable, so exact three-valued
+ * equivalence is demanded. A TRUE-for-NULL substitution is wrong in every
+ * context, so the complemented forms require a provably NULL-free
+ * right-hand side.
+ *
+ * The decision follows the same form deparseScalarArrayOpExpr will choose:
+ * the IN-list form for a non-empty constant array (is_ok_in_expr),
+ * has()/countEqual() otherwise. `optype` is chfdw_is_equal_op's
+ * classification: 1 for = ANY, 2 for <> ALL.
+ */
+static bool
+saop_null_semantics_ok(
+    ScalarArrayOpExpr* saop,
+    int optype,
+    ExprTruthCtx ctx,
+    foreign_glob_cxt* glob_cxt
+) {
+    /* Arrays have no guarded deparse form: negated means exact */
+    bool exact_ctx       = ctx != EXPR_CTX_TRUTH;
+    Expr* probe          = linitial(saop->args);
+    Expr* arr            = lsecond(saop->args);
+    SaopArrayNulls nulls = saop_array_nulls(arr, glob_cxt);
+
+    /*
+     * A NULL array constant survives const-folding when the probe is not
+     * constant, and the operator's strictness makes the result NULL for
+     * every row. Keep it local: no deparse form models that, and
+     * is_ok_in_expr cannot inspect a NULL array datum.
+     */
+    if (IsA(arr, Const) && ((Const*)arr)->constisnull) {
+        return false;
+    }
+
+    /*
+     * <> ANY has no correct deparse form yet: the not has() ClickHouse SQL it
+     * would produce computes <> ALL (Postgres: 1 <> ANY of {1,5} is TRUE, one
+     * element differs; not has({1,5}, 1) is FALSE). Always evaluate locally.
+     * A truth-context spelling exists for a future follow-up — TRUE exactly
+     * when a non-NULL element differs from a non-NULL probe:
+     *   x IS NOT NULL AND
+     *   length(arr) - countEqual(arr, x) - countEqual(arr, NULL) > 0
+     */
+    if (saop->useOr && optype == 2) {
+        return false;
+    }
+
+    /*
+     * = ALL deparses as countEqual() = length(), which counts a NULL element
+     * as equal to a NULL probe where Postgres never compares two NULLs equal.
+     * An empty array is exact by arithmetic (0 = 0 is TRUE on both systems,
+     * NULL probe included); otherwise ship only when no NULL can be involved.
+     */
+    if (!saop->useOr && optype == 1) {
+        if (nulls == SAOP_ARR_EMPTY) {
+            return true;
+        }
+        return nulls == SAOP_ARR_NULL_FREE && expr_never_null(probe, glob_cxt);
+    }
+
+    /*
+     * Both systems compare against nothing: = ANY is FALSE and <> ALL is TRUE
+     * for every probe, NULL included, in both deparse forms.
+     */
+    if (nulls == SAOP_ARR_EMPTY) {
+        return true;
+    }
+
+    if (is_ok_in_expr(arr)) {
+        /*
+         * IN-list form. ClickHouse's native IN yields NULL for a NULL probe,
+         * so a NULL-free list is exact for both = ANY and <> ALL. A list that
+         * may carry a NULL diverges only toward FALSE for = ANY (tolerable in
+         * truth context) and toward TRUE for <> ALL (never tolerable).
+         */
+        if (nulls == SAOP_ARR_NULL_FREE) {
+            return true;
+        }
+        return optype == 1 && !exact_ctx;
+    }
+
+    /*
+     * has()/countEqual() form: a NULL probe is matched like a value, so
+     * exactness additionally requires the probe to be provably non-NULL.
+     */
+    if (optype == 1) {
+        if (nulls == SAOP_ARR_NULL_FREE) {
+            return !exact_ctx || expr_never_null(probe, glob_cxt);
+        }
+        return !exact_ctx && expr_never_null(probe, glob_cxt);
+    }
+    return nulls == SAOP_ARR_NULL_FREE && expr_never_null(probe, glob_cxt);
+}
+
+/*
+ * How to ship a Postgres `NOT (x IN (SELECT ..))`.
+ */
+typedef enum NotInShipForm {
+    NOTIN_SHIP_PLAIN,   /* both sides provably non-NULL: native NOT IN is exact */
+    NOTIN_SHIP_GUARDED, /* deparseGuardedNotIn's CASE/guard form (truth context) */
+    NOTIN_SHIP_NONE,    /* no correct remote form; evaluate locally */
+} NotInShipForm;
+
+/*
+ * Which sides of an ANY SubPlan's comparison may produce a NULL: the probe
+ * (testexpr's LHS, an outer-scope expression) and the subquery's output
+ * column. A bit is set for each side that cannot be proven non-NULL, so the
+ * guarded NOT IN deparse emits a guard exactly for each bit.
+ */
+typedef enum NotInNullability {
+    NOTIN_NEITHER_NULLABLE = 0,
+    NOTIN_PROBE_NULLABLE   = 1 << 0,
+    NOTIN_OUTPUT_NULLABLE  = 1 << 1,
+} NotInNullability;
+
+/*
+ * Prove non-nullness for an ANY SubPlan's two comparison inputs, reporting
+ * the sides that cannot be proven. root/relids describe the OUTER scope
+ * (the probe's); the subquery scope is derived here. A missing output
+ * column reports both sides nullable.
+ */
+static NotInNullability
+notin_prove_nullability(SubPlan* subplan, PlannerInfo* root, Relids relids) {
+    OpExpr* op = castNode(OpExpr, subplan->testexpr);
+    PlannerInfo* subroot;
+    Query* query;
+    TargetEntry* out       = NULL;
+    NotInNullability nulls = NOTIN_NEITHER_NULLABLE;
+    foreign_glob_cxt outer_cxt;
+    foreign_glob_cxt sub_cxt;
+    ListCell* lc;
+
+    subroot = (PlannerInfo*)list_nth(root->glob->subroots, subplan->plan_id - 1);
+    query   = subroot->parse;
+
+    foreach (lc, query->targetList) {
+        TargetEntry* tle = lfirst_node(TargetEntry, lc);
+
+        if (!tle->resjunk) {
+            out = tle;
+            break;
+        }
+    }
+    if (out == NULL) {
+        return NOTIN_PROBE_NULLABLE | NOTIN_OUTPUT_NULLABLE;
+    }
+
+    memset(&outer_cxt, 0, sizeof(outer_cxt));
+    outer_cxt.root   = root;
+    outer_cxt.relids = relids;
+
+    memset(&sub_cxt, 0, sizeof(sub_cxt));
+    sub_cxt.root = subroot;
+    foreach (lc, query->jointree->fromlist) {
+        RangeTblRef* rtr = (RangeTblRef*)lfirst(lc);
+
+        sub_cxt.relids = bms_add_member(sub_cxt.relids, rtr->rtindex);
+    }
+
+    if (!expr_never_null((Expr*)linitial(op->args), &outer_cxt)) {
+        nulls |= NOTIN_PROBE_NULLABLE;
+    }
+    if (!expr_never_null(out->expr, &sub_cxt)) {
+        nulls |= NOTIN_OUTPUT_NULLABLE;
+    }
+    return nulls;
+}
+
+/*
+ * Classify a NOT-negated ANY SubPlan. Called with identical inputs by the
+ * shippability gate in is_shippable_subplan and by deparseBoolExpr's SubPlan
+ * peek, so the walker's decision and the emitted form always agree.
+ */
+static NotInShipForm
+classify_notin_subplan(SubPlan* subplan, PlannerInfo* root, Relids relids) {
+    PlannerInfo* subroot;
+    Query* query;
+
+    if (notin_prove_nullability(subplan, root, relids) == NOTIN_NEITHER_NULLABLE) {
+        return NOTIN_SHIP_PLAIN;
+    }
+
+    /*
+     * The guarded form's null probe re-runs the subquery body with an extra
+     * "output IS NULL" qual, which asks the same question only when the
+     * output is a per-row expression. A grouped or aggregated body would
+     * need the guard applied above the grouping; not implemented, so those
+     * shapes fall back to local evaluation.
+     */
+    subroot = (PlannerInfo*)list_nth(root->glob->subroots, subplan->plan_id - 1);
+    query   = subroot->parse;
+    if (query->groupClause == NIL && query->havingQual == NULL && !query->hasAggs) {
+        return NOTIN_SHIP_GUARDED;
+    }
+    return NOTIN_SHIP_NONE;
+}
+
 /*
  * Check if expression is safe to execute remotely, and return true if so.
  *
@@ -514,9 +901,14 @@ agg_partial_kind(Aggref* agg) {
  * assign_collations_walker() in parse_collate.c, though we can assume here
  * that the given expression is valid. Note function mutability is not
  * currently considered here.
+ *
+ * ctx tracks whether the expression's value is observable beyond qualifying
+ * rows (see ExprTruthCtx and saop_null_semantics_ok's block comment):
+ * EXPR_CTX_TRUTH only while every enclosing node treats NULL and FALSE
+ * identically.
  */
 static bool
-foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
+foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
     bool check_type = true;
     CHFdwRelationInfo* fpinfo;
 
@@ -594,15 +986,19 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         }
 
         /* Recurse to remaining subexpressions. */
-        if (!foreign_expr_walker((Node*)ar->refupperindexpr, glob_cxt)) {
+        if (!foreign_expr_walker(
+                (Node*)ar->refupperindexpr, glob_cxt, EXPR_CTX_EXACT
+            )) {
             return false;
         }
 
-        if (!foreign_expr_walker((Node*)ar->reflowerindexpr, glob_cxt)) {
+        if (!foreign_expr_walker(
+                (Node*)ar->reflowerindexpr, glob_cxt, EXPR_CTX_EXACT
+            )) {
             return false;
         }
 
-        if (!foreign_expr_walker((Node*)ar->refexpr, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)ar->refexpr, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -633,7 +1029,9 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
             }
 
             /* Only recurse on the column expression. */
-            if (!foreign_expr_walker((Node*)linitial(fe->args), glob_cxt)) {
+            if (!foreign_expr_walker(
+                    (Node*)linitial(fe->args), glob_cxt, EXPR_CTX_EXACT
+                )) {
                 return false;
             }
             break;
@@ -642,7 +1040,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         /*
          * Recurse to input subexpressions.
          */
-        if (!foreign_expr_walker((Node*)fe->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)fe->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -667,21 +1065,27 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         /*
          * Recurse to input subexpressions.
          */
-        if (!foreign_expr_walker((Node*)oe->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)oe->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
     case T_ScalarArrayOpExpr: {
         ScalarArrayOpExpr* oe = (ScalarArrayOpExpr*)node;
+        int optype            = chfdw_is_equal_op(oe->opno);
 
-        if (!chfdw_is_equal_op(oe->opno)) {
+        if (!optype) {
+            return false;
+        }
+
+        /* IN under two-valued ClickHouse logic; see saop_null_semantics_ok */
+        if (!saop_null_semantics_ok(oe, optype, ctx, glob_cxt)) {
             return false;
         }
 
         /*
          * Recurse to input subexpressions.
          */
-        if (!foreign_expr_walker((Node*)oe->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)oe->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -689,19 +1093,36 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         RelabelType* r = (RelabelType*)node;
 
         /*
-         * Recurse to input subexpression.
+         * Recurse to input subexpression. A relabel between a NOT and its
+         * operand would defeat deparseBoolExpr's SubPlan peek, so degrade
+         * NEGATED rather than pass it through.
          */
-        if (!foreign_expr_walker((Node*)r->arg, glob_cxt)) {
+        if (!foreign_expr_walker(
+                (Node*)r->arg, glob_cxt, ctx == EXPR_CTX_NEGATED ? EXPR_CTX_EXACT : ctx
+            )) {
             return false;
         }
     } break;
     case T_BoolExpr: {
         BoolExpr* b = (BoolExpr*)node;
+        ExprTruthCtx child_ctx;
 
         /*
-         * Recurse to input subexpressions.
+         * AND/OR preserve the NULL/FALSE equivalence of a truth context but
+         * consume a NEGATED state (their children are not the NOT's direct
+         * operand). Under NOT the roles swap — a FALSE-for-NULL substitution
+         * below would surface as TRUE-for-NULL above — so the operand must be
+         * exact, except that one NOT directly over a truth context grants the
+         * operand EXPR_CTX_NEGATED, which a SubPlan consumes via the guarded
+         * NOT IN deparse. A second NOT above that degrades to exact (the
+         * planner collapses double negation anyway).
          */
-        if (!foreign_expr_walker((Node*)b->args, glob_cxt)) {
+        if (b->boolop == NOT_EXPR) {
+            child_ctx = ctx == EXPR_CTX_TRUTH ? EXPR_CTX_NEGATED : EXPR_CTX_EXACT;
+        } else {
+            child_ctx = ctx == EXPR_CTX_NEGATED ? EXPR_CTX_EXACT : ctx;
+        }
+        if (!foreign_expr_walker((Node*)b->args, glob_cxt, child_ctx)) {
             return false;
         }
     } break;
@@ -711,7 +1132,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         /*
          * Recurse to input subexpressions.
          */
-        if (!foreign_expr_walker((Node*)nt->arg, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)nt->arg, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -721,7 +1142,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         /*
          * Recurse to input subexpressions.
          */
-        if (!foreign_expr_walker((Node*)a->elements, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)a->elements, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -733,7 +1154,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
          * Recurse to component subexpressions.
          */
         foreach (lc, l) {
-            if (!foreign_expr_walker((Node*)lfirst(lc), glob_cxt)) {
+            if (!foreign_expr_walker((Node*)lfirst(lc), glob_cxt, ctx)) {
                 return false;
             }
         }
@@ -816,13 +1237,13 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
                 n = (Node*)tle->expr;
             }
 
-            if (!foreign_expr_walker(n, glob_cxt)) {
+            if (!foreign_expr_walker(n, glob_cxt, EXPR_CTX_EXACT)) {
                 return false;
             }
         }
 
-        /* Check aggregate filter */
-        if (!foreign_expr_walker((Node*)agg->aggfilter, glob_cxt)) {
+        /* FILTER only qualifies rows, so it keeps NULL/FALSE equivalence */
+        if (!foreign_expr_walker((Node*)agg->aggfilter, glob_cxt, EXPR_CTX_TRUTH)) {
             return false;
         }
     } break;
@@ -847,7 +1268,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         }
 
         /* Recurse to input arguments */
-        if (!foreign_expr_walker((Node*)wfunc->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)wfunc->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -855,49 +1276,58 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
         CaseExpr* caseexpr = (CaseExpr*)node;
         ListCell* lc;
 
-        if (!foreign_expr_walker((Node*)caseexpr->arg, glob_cxt)) {
-            return true;
+        if (!foreign_expr_walker((Node*)caseexpr->arg, glob_cxt, EXPR_CTX_EXACT)) {
+            return false;
         }
 
         foreach (lc, caseexpr->args) {
             CaseWhen* when = lfirst_node(CaseWhen, lc);
 
-            if (!foreign_expr_walker((Node*)when->expr, glob_cxt)) {
+            /* A WHEN condition takes the same branch for NULL and FALSE */
+            if (!foreign_expr_walker((Node*)when->expr, glob_cxt, EXPR_CTX_TRUTH)) {
                 return false;
             }
-            if (!foreign_expr_walker((Node*)when->result, glob_cxt)) {
+            if (!foreign_expr_walker(
+                    (Node*)when->result,
+                    glob_cxt,
+                    ctx == EXPR_CTX_TRUTH ? EXPR_CTX_TRUTH : EXPR_CTX_EXACT
+                )) {
                 return false;
             }
         }
-        if (!foreign_expr_walker((Node*)caseexpr->defresult, glob_cxt)) {
+        if (!foreign_expr_walker(
+                (Node*)caseexpr->defresult,
+                glob_cxt,
+                ctx == EXPR_CTX_TRUTH ? EXPR_CTX_TRUTH : EXPR_CTX_EXACT
+            )) {
             return false;
         }
     } break;
     case T_CoalesceExpr: {
         CoalesceExpr* ce = (CoalesceExpr*)node;
 
-        if (!foreign_expr_walker((Node*)ce->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)ce->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
     case T_MinMaxExpr: {
         MinMaxExpr* me = (MinMaxExpr*)node;
 
-        if (!foreign_expr_walker((Node*)me->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)me->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
     case T_CoerceViaIO: {
         CoerceViaIO* me = (CoerceViaIO*)node;
 
-        if (!foreign_expr_walker((Node*)me->arg, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)me->arg, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
     case T_RowExpr: {
         RowExpr* me = (RowExpr*)node;
 
-        if (!foreign_expr_walker((Node*)me->args, glob_cxt)) {
+        if (!foreign_expr_walker((Node*)me->args, glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     } break;
@@ -917,7 +1347,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt) {
             return false;
         }
 
-        if (!is_shippable_subplan((SubPlan*)node, glob_cxt)) {
+        if (!is_shippable_subplan((SubPlan*)node, glob_cxt, ctx)) {
             return false;
         }
     } break;
@@ -1058,7 +1488,7 @@ subplan_gate_user_mapping(PlannerInfo* root, RelOptInfo* foreignrel, Oid serveri
 }
 
 static bool
-is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt) {
+is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
     PlannerInfo* subroot;
     Query* query;
     foreign_glob_cxt sub_cxt;
@@ -1168,7 +1598,7 @@ is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt) {
         }
 
         /* The LHS lives in the outer scope: walk it there. */
-        if (!foreign_expr_walker((Node*)linitial(op->args), glob_cxt)) {
+        if (!foreign_expr_walker((Node*)linitial(op->args), glob_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     }
@@ -1193,7 +1623,7 @@ is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt) {
      * Correlation args are OUTER-scope expressions; deparseParam will inline
      * them with outer aliases, so they must be shippable out here.
      */
-    if (!foreign_expr_walker((Node*)subplan->args, glob_cxt)) {
+    if (!foreign_expr_walker((Node*)subplan->args, glob_cxt, EXPR_CTX_EXACT)) {
         return false;
     }
 
@@ -1215,15 +1645,40 @@ is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt) {
     foreach (lc, query->targetList) {
         TargetEntry* tle = lfirst_node(TargetEntry, lc);
 
-        if (!foreign_expr_walker((Node*)tle->expr, &sub_cxt)) {
+        if (!foreign_expr_walker((Node*)tle->expr, &sub_cxt, EXPR_CTX_EXACT)) {
             return false;
         }
     }
-    if (!foreign_expr_walker((Node*)query->jointree->quals, &sub_cxt)) {
+    /* Interior quals only qualify the subquery's own rows: truth context */
+    if (!foreign_expr_walker((Node*)query->jointree->quals, &sub_cxt, EXPR_CTX_TRUTH)) {
         return false;
     }
-    if (query->havingQual && !foreign_expr_walker(query->havingQual, &sub_cxt)) {
+    if (query->havingQual &&
+        !foreign_expr_walker(query->havingQual, &sub_cxt, EXPR_CTX_TRUTH)) {
         return false;
+    }
+
+    /*
+     * ClickHouse evaluates IN under two-valued logic, so x IN (SELECT ..)
+     * diverges from Postgres by yielding FALSE where Postgres computes
+     * NULL (a NULL probe stays NULL on both systems). This behavior is invisible in a
+     * truth context but observable under NOT --- which is how x NOT IN
+     * (SELECT ..) arrives here --- and in value positions. Under one NOT in a
+     * truth context (EXPR_CTX_NEGATED) the guarded deparse form keeps the
+     * Postgres answer even when a NULL can reach the comparison, so only
+     * grouped/aggregated bodies fall back; a genuine value position demands
+     * exactness, which requires that no NULL can arrive from either side.
+     * See saop_null_semantics_ok's block comment for the divergence rules
+     * and deparseGuardedNotIn for the guarded form.
+     */
+    if (subplan->subLinkType == ANY_SUBLINK && ctx != EXPR_CTX_TRUTH) {
+        NotInShipForm form =
+            classify_notin_subplan(subplan, glob_cxt->root, glob_cxt->relids);
+
+        if (ctx == EXPR_CTX_NEGATED ? form == NOTIN_SHIP_NONE
+                                    : form != NOTIN_SHIP_PLAIN) {
+            return false;
+        }
     }
 
     /*
@@ -3132,12 +3587,12 @@ deparseSubPlan(SubPlan* node, deparse_expr_cxt* context) {
     switch (node->subLinkType) {
     case EXISTS_SUBLINK:
         appendStringInfoString(buf, "EXISTS (");
-        deparseSubPlanQuery(node, context);
+        deparseSubPlanQuery(node, context, SUBPLAN_BODY_QUERY);
         appendStringInfoChar(buf, ')');
         break;
     case EXPR_SUBLINK:
         appendStringInfoChar(buf, '(');
-        deparseSubPlanQuery(node, context);
+        deparseSubPlanQuery(node, context, SUBPLAN_BODY_QUERY);
         appendStringInfoChar(buf, ')');
         break;
     case ANY_SUBLINK: {
@@ -3151,7 +3606,7 @@ deparseSubPlan(SubPlan* node, deparse_expr_cxt* context) {
         appendStringInfoChar(buf, '(');
         deparseExpr((Expr*)linitial(op->args), context);
         appendStringInfoString(buf, " IN (");
-        deparseSubPlanQuery(node, context);
+        deparseSubPlanQuery(node, context, SUBPLAN_BODY_QUERY);
         appendStringInfoString(buf, "))");
     } break;
     default:
@@ -3270,7 +3725,7 @@ deparseSubPlanFrom(deparse_expr_cxt* context) {
  * s{N} namespaces and with sibling SubPlans.
  */
 static void
-deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context) {
+deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context, SubPlanBodyForm form) {
     PlannerInfo* subroot;
     Query* query;
     StringInfo buf = context->buf;
@@ -3299,7 +3754,11 @@ deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context) {
      * (appendConditions / appendGroupByClause) where it does not.
      */
     appendStringInfoString(buf, "SELECT ");
-    deparseSubPlanTargetList(&subctx);
+    if (form == SUBPLAN_BODY_NULL_PROBE) {
+        appendStringInfoChar(buf, '1');
+    } else {
+        deparseSubPlanTargetList(&subctx);
+    }
 
     appendStringInfoString(buf, " FROM ");
     deparseSubPlanFrom(&subctx);
@@ -3309,12 +3768,93 @@ deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context) {
         deparseSubPlanQuals(query->jointree->quals, &subctx);
     }
 
+    /*
+     * The null-probe form asks whether any row the subquery would emit has a
+     * NULL output. classify_notin_subplan only admits ungrouped bodies here,
+     * so appending the qual to the row-level WHERE asks exactly that.
+     */
+    if (form == SUBPLAN_BODY_NULL_PROBE) {
+        TargetEntry* out = NULL;
+        ListCell* lc;
+
+        foreach (lc, query->targetList) {
+            TargetEntry* tle = lfirst_node(TargetEntry, lc);
+
+            if (!tle->resjunk) {
+                out = tle;
+                break;
+            }
+        }
+        Assert(out != NULL); /* classify_notin_subplan guarantees it */
+
+        appendStringInfoString(
+            buf, query->jointree->quals != NULL ? " AND (" : " WHERE ("
+        );
+        deparseExpr(out->expr, &subctx);
+        appendStringInfoString(buf, " IS NULL)");
+    }
+
     /* Keys off context->root->parse, which is the subquery here. */
     appendGroupByClause(query->targetList, &subctx);
 
     if (query->havingQual != NULL) {
         appendStringInfoString(buf, " HAVING ");
         deparseSubPlanQuals(query->havingQual, &subctx);
+    }
+}
+
+/*
+ * Deparse Postgres's `x NOT IN (SELECT ..)` — arriving as NOT over an ANY
+ * SubPlan — when a NULL could reach the comparison. ClickHouse's native
+ * `NOT IN` computes the plain set complement, where Postgres's three-valued
+ * answer can only be TRUE if the probe is non-NULL, the subquery output
+ * holds no NULL, and the probe matches nothing — except that an empty
+ * result is TRUE regardless of the probe. In a truth context (the only
+ * place the walker admits this form, via EXPR_CTX_NEGATED) that TRUE-set
+ * is all that matters, so emit it directly:
+ *
+ *   CASE WHEN probe IS NULL
+ *        THEN NOT EXISTS (SELECT ..)                            -- empty?
+ *        ELSE probe NOT IN (SELECT ..)
+ *             AND NOT EXISTS (SELECT 1 .. AND (output IS NULL)) -- poison?
+ *   END
+ *
+ * Each piece a plan-time proof makes unnecessary is left out: a non-NULL
+ * probe drops the `CASE` (`x NOT IN (SELECT .. WHERE false)` is already
+ * TRUE on both systems for a non-NULL probe), and a non-NULL output column
+ * drops the poison guard. All subqueries are uncorrelated with each other
+ * and evaluated once.
+ */
+static void
+deparseGuardedNotIn(SubPlan* subplan, deparse_expr_cxt* context) {
+    StringInfo buf = context->buf;
+    OpExpr* op     = castNode(OpExpr, subplan->testexpr);
+    Expr* probe    = (Expr*)linitial(op->args);
+    NotInNullability nulls =
+        notin_prove_nullability(subplan, context->root, context->scanrel->relids);
+
+    if (nulls & NOTIN_PROBE_NULLABLE) {
+        appendStringInfoString(buf, "(CASE WHEN (");
+        deparseExpr(probe, context);
+        appendStringInfoString(buf, ") IS NULL THEN NOT EXISTS (");
+        deparseSubPlanQuery(subplan, context, SUBPLAN_BODY_QUERY);
+        appendStringInfoString(buf, ") ELSE ");
+    }
+
+    appendStringInfoChar(buf, '(');
+    deparseExpr(probe, context);
+    appendStringInfoString(buf, " NOT IN (");
+    deparseSubPlanQuery(subplan, context, SUBPLAN_BODY_QUERY);
+    appendStringInfoChar(buf, ')');
+    if (nulls & NOTIN_OUTPUT_NULLABLE) {
+        appendStringInfoString(buf, " AND NOT EXISTS (");
+        deparseSubPlanQuery(subplan, context, SUBPLAN_BODY_NULL_PROBE);
+        appendStringInfoChar(buf, ')');
+    }
+    appendStringInfoChar(buf, ')');
+
+    if (nulls & NOTIN_PROBE_NULLABLE) {
+        appendStringInfoString(buf, " END)");
     }
 }
 
@@ -4761,11 +5301,29 @@ deparseBoolExpr(BoolExpr* node, deparse_expr_cxt* context) {
     case OR_EXPR:
         op = "OR";
         break;
-    case NOT_EXPR:
+    case NOT_EXPR: {
+        Node* arg = (Node*)linitial(node->args);
+
+        /*
+         * NOT over an ANY SubPlan is Postgres's x NOT IN (SELECT ..). When a
+         * NULL could reach the comparison the native complement is wrong;
+         * emit the guarded form instead. The classifier answers exactly as
+         * the walker's EXPR_CTX_NEGATED gate did, so every shape arriving
+         * here has a remote form.
+         */
+        if (IsA(arg, SubPlan) && ((SubPlan*)arg)->subLinkType == ANY_SUBLINK &&
+            classify_notin_subplan(
+                (SubPlan*)arg, context->root, context->scanrel->relids
+            ) == NOTIN_SHIP_GUARDED) {
+            deparseGuardedNotIn((SubPlan*)arg, context);
+            return;
+        }
+
         appendStringInfoString(buf, "(NOT ");
-        deparseExpr(linitial(node->args), context);
+        deparseExpr((Expr*)arg, context);
         appendStringInfoChar(buf, ')');
         return;
+    }
     }
 
     appendStringInfoChar(buf, '(');

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -768,7 +768,7 @@ get_useful_pathkeys_for_relation(PlannerInfo* root, RelOptInfo* rel) {
              */
             if (pathkey_ec->ec_has_volatile ||
                 !(em_expr = chfdw_find_em_expr_for_rel(pathkey_ec, rel)) ||
-                !chfdw_is_foreign_expr(root, rel, em_expr)) {
+                !chfdw_is_foreign_expr(root, rel, em_expr, true)) {
                 query_pathkeys_ok = false;
                 break;
             }
@@ -967,7 +967,7 @@ clickhouseGetForeignPlan(
                 remote_exprs = lappend(remote_exprs, rinfo->clause);
             } else if (list_member_ptr(fpinfo->local_conds, rinfo)) {
                 local_exprs = lappend(local_exprs, rinfo->clause);
-            } else if (chfdw_is_foreign_expr(root, foreignrel, rinfo->clause)) {
+            } else if (chfdw_is_foreign_expr(root, foreignrel, rinfo->clause, false)) {
                 remote_exprs = lappend(remote_exprs, rinfo->clause);
             } else {
                 local_exprs = lappend(local_exprs, rinfo->clause);
@@ -2165,8 +2165,9 @@ foreign_join_ok(
      */
     joinclauses = NIL;
     foreach (lc, extra->restrictlist) {
-        RestrictInfo* rinfo   = lfirst_node(RestrictInfo, lc);
-        bool is_remote_clause = chfdw_is_foreign_expr(root, joinrel, rinfo->clause);
+        RestrictInfo* rinfo = lfirst_node(RestrictInfo, lc);
+        bool is_remote_clause =
+            chfdw_is_foreign_expr(root, joinrel, rinfo->clause, false);
 
         if (IS_OUTER_JOIN(jointype) && !RINFO_IS_PUSHED_DOWN(rinfo, joinrel->relids)) {
             if (!is_remote_clause) {
@@ -2716,7 +2717,7 @@ foreign_grouping_ok(PlannerInfo* root, RelOptInfo* grouped_rel, Node* havingQual
              * If any GROUP BY expression is not shippable, then we cannot
              * push down aggregation to the foreign server.
              */
-            if (!chfdw_is_foreign_expr(root, grouped_rel, expr)) {
+            if (!chfdw_is_foreign_expr(root, grouped_rel, expr, true)) {
                 return false;
             }
 
@@ -2743,7 +2744,7 @@ foreign_grouping_ok(PlannerInfo* root, RelOptInfo* grouped_rel, Node* havingQual
             /*
              * Non-grouping expression we need to compute. Is it shippable?
              */
-            if (chfdw_is_foreign_expr(root, grouped_rel, expr)) {
+            if (chfdw_is_foreign_expr(root, grouped_rel, expr, true)) {
                 /* Yes, so add to tlist as-is; OK to suppress duplicates */
                 tlist = add_to_flat_tlist(tlist, list_make1(expr));
             } else {
@@ -2754,7 +2755,7 @@ foreign_grouping_ok(PlannerInfo* root, RelOptInfo* grouped_rel, Node* havingQual
                  * If any aggregate expression is not shippable, then we
                  * cannot push down aggregation to the foreign server.
                  */
-                if (!chfdw_is_foreign_expr(root, grouped_rel, (Expr*)aggvars)) {
+                if (!chfdw_is_foreign_expr(root, grouped_rel, (Expr*)aggvars, true)) {
                     return false;
                 }
 
@@ -2813,7 +2814,7 @@ foreign_grouping_ok(PlannerInfo* root, RelOptInfo* grouped_rel, Node* havingQual
                 NULL,
                 NULL
             );
-            if (chfdw_is_foreign_expr(root, grouped_rel, expr)) {
+            if (chfdw_is_foreign_expr(root, grouped_rel, expr, false)) {
                 fpinfo->remote_conds = lappend(fpinfo->remote_conds, rinfo);
             } else {
                 fpinfo->local_conds = lappend(fpinfo->local_conds, rinfo);
@@ -2848,7 +2849,7 @@ foreign_grouping_ok(PlannerInfo* root, RelOptInfo* grouped_rel, Node* havingQual
              * access them again here.
              */
             if (IsA(expr, Aggref)) {
-                if (!chfdw_is_foreign_expr(root, grouped_rel, expr)) {
+                if (!chfdw_is_foreign_expr(root, grouped_rel, expr, true)) {
                     return false;
                 }
 
@@ -3120,7 +3121,7 @@ foreign_window_ok(PlannerInfo* root, RelOptInfo* window_rel) {
          * the expression against the window_rel so that WindowFunc nodes are
          * recognized as being in an upper relation context.
          */
-        if (!chfdw_is_foreign_expr(root, window_rel, expr)) {
+        if (!chfdw_is_foreign_expr(root, window_rel, expr, true)) {
             return false;
         }
 
@@ -3343,7 +3344,8 @@ add_foreign_ordered_paths(
                                                : root->upper_targets[ifpinfo->stage]
         );
 
-        if (sort_expr == NULL || !chfdw_is_foreign_expr(root, input_rel, sort_expr)) {
+        if (sort_expr == NULL ||
+            !chfdw_is_foreign_expr(root, input_rel, sort_expr, true)) {
             return;
         }
     }
@@ -3510,8 +3512,8 @@ add_foreign_final_paths(
      * Also, the LIMIT/OFFSET cannot be pushed down, if their expressions are
      * not safe to remote.
      */
-    if (!chfdw_is_foreign_expr(root, input_rel, (Expr*)parse->limitOffset) ||
-        !chfdw_is_foreign_expr(root, input_rel, (Expr*)parse->limitCount)) {
+    if (!chfdw_is_foreign_expr(root, input_rel, (Expr*)parse->limitOffset, true) ||
+        !chfdw_is_foreign_expr(root, input_rel, (Expr*)parse->limitCount, true)) {
         return;
     }
 

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -321,7 +321,12 @@ chfdw_classify_conditions(
     List** local_conds
 );
 extern bool
-chfdw_is_foreign_expr(PlannerInfo* root, RelOptInfo* baserel, Expr* expr);
+chfdw_is_foreign_expr(
+    PlannerInfo* root,
+    RelOptInfo* baserel,
+    Expr* expr,
+    bool exact_ctx
+);
 extern bool
 is_foreign_param(PlannerInfo* root, RelOptInfo* baserel, Expr* expr);
 extern char*

--- a/src/option.c
+++ b/src/option.c
@@ -686,7 +686,7 @@ _PG_init(void) {
         "Sets the default ClickHouse session settings.",
         NULL,
         &ch_session_settings,
-        "join_use_nulls 1, group_by_use_nulls 1, final 1",
+        "join_use_nulls 1, group_by_use_nulls 1, final 1, transform_null_in 0",
         PGC_USERSET,
         0,
         chfdw_check_settings_guc,

--- a/test/expected/gucs.out
+++ b/test/expected/gucs.out
@@ -14,14 +14,16 @@ NOTICE:  ERR 42601 - pg_clickhouse: missing comma after "join_use_nulls" value i
  final              | 1
  group_by_use_nulls | 1
  join_use_nulls     | 1
-(3 rows)
+ transform_null_in  | 0
+(4 rows)
 
         name        | value 
 --------------------+-------
  final              | 1
  group_by_use_nulls | 1
  join_use_nulls     | 1
-(3 rows)
+ transform_null_in  | 0
+(4 rows)
 
       name      | value 
 ----------------+-------

--- a/test/expected/in_null_semantics.out
+++ b/test/expected/in_null_semantics.out
@@ -1,0 +1,407 @@
+-- NULL semantics of the IN family (ScalarArrayOpExpr pushdown).
+--
+-- ClickHouse evaluates IN under two-valued logic: a probe that finds no
+-- match yields 0 even when the searched set contains a NULL, where Postgres
+-- computes NULL; The ClickHouse has()/countEqual() functions also match a NULL probe as
+-- if it were an ordinary value. A FALSE-for-NULL substitution is invisible
+-- while the result only qualifies rows (WHERE/JOIN/HAVING through AND/OR),
+-- but observable under NOT and anywhere the boolean's value is consumed.
+-- These tests ensure the shapes deparse.c ships and that the rows returned
+-- match local (Postgres) semantics either way.
+CREATE SERVER in_null_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'in_null_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS in_null_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('CREATE DATABASE in_null_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+-- xn imports as a plain (nullable) int column, xp as int NOT NULL
+SELECT clickhouse_raw_query('CREATE TABLE in_null_test.tnull
+    (id Int32, xn Nullable(Int32), xp Int32)
+    ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO in_null_test.tnull VALUES (1, 1, 1), (2, 2, 2), (3, NULL, 3)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE SCHEMA in_null_test;
+IMPORT FOREIGN SCHEMA in_null_test FROM SERVER in_null_svr INTO in_null_test;
+SET SESSION search_path = in_null_test,public;
+-- The import must carry ClickHouse nullability into the declarations the
+-- never-null proofs rely on
+\d tnull
+               Foreign table "in_null_test.tnull"
+ Column |  Type   | Collation | Nullable | Default | FDW options 
+--------+---------+-----------+----------+---------+-------------
+ id     | integer |           | not null |         | 
+ xn     | integer |           |          |         | 
+ xp     | integer |           | not null |         | 
+Server: in_null_svr
+FDW options: (database 'in_null_test', table_name 'tnull', engine 'MergeTree')
+
+-- ============================================================
+-- 1. IN over a constant list: pushable in a WHERE condition
+-- ============================================================
+-- NULL-free list is exactly equivalent
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn IN (1, 500) ORDER BY id;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((xn IN (1,500))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xn IN (1, 500) ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- A NULL in the list only pulls results toward FALSE, which a WHERE treats
+-- like the NULL Postgres computes: still pushable
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn IN (1, NULL) ORDER BY id;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((xn IN (1,NULL))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xn IN (1, NULL) ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- ============================================================
+-- 2. NOT IN over a constant list: pushable only when NULL-free
+-- ============================================================
+-- ClickHouse's native NOT IN yields NULL for a NULL probe, so a NULL-free
+-- list is exact: id 3 (xn IS NULL) is dropped on both systems
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn NOT IN (1, 500) ORDER BY id;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((xn NOT IN (1,500))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xn NOT IN (1, 500) ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+-- With a NULL in the list Postgres returns no rows (every result is NULL
+-- or FALSE) where ClickHouse would return id 2: must stay local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn NOT IN (1, NULL) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xn <> ALL ('{1,NULL}'::integer[]))
+   Remote SQL: SELECT id, xn FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xn NOT IN (1, NULL) ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- NOT over IN is the same thing arriving unrewritten
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE NOT (xn IN (1, NULL)) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xn <> ALL ('{1,NULL}'::integer[]))
+   Remote SQL: SELECT id, xn FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE NOT (xn IN (1, NULL)) ORDER BY id;
+ id 
+----
+(0 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE NOT (xn IN (1, 500)) ORDER BY id;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((xn NOT IN (1,500))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE NOT (xn IN (1, 500)) ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+-- ============================================================
+-- 3. Non-constant arrays: the has()/countEqual() deparse forms
+-- ============================================================
+-- has() matches a NULL probe against a NULL element where Postgres computes
+-- NULL, so = ANY needs a provably non-NULL probe; xp is declared NOT NULL
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp = ANY(ARRAY[xn, 5]) ORDER BY id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((has([xn, 5],xp))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xp = ANY(ARRAY[xn, 5]) ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- A nullable probe against an array that may hold a NULL would turn
+-- Postgres's NULL (id 3: NULL = ANY({NULL,5})) into TRUE: must stay local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ANY(ARRAY[xn, 5]) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xn = ANY (ARRAY[tnull.xn, 5]))
+   Remote SQL: SELECT id, xn FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xn = ANY(ARRAY[xn, 5]) ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- countEqual() = 0 turns any NULL involved into TRUE (id 3: 3 <> ALL of
+-- {NULL,5} is NULL on Postgres): <> ALL needs both sides provably non-NULL
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xn, 5]) ORDER BY id;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xp <> ALL (ARRAY[tnull.xn, 5]))
+   Remote SQL: SELECT id, xn, xp FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xn, 5]) ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- ...and with both sides proven, it ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xp, 500]) ORDER BY id;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((countEqual([xp, 500],xp) = 0)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xp, 500]) ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- <> ANY has no correct deparse (not has() computes <> ALL: it would return
+-- no rows here, where one differing element makes every row qualify): local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ANY(ARRAY[xp, 500]) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xp <> ANY (ARRAY[tnull.xp, 500]))
+   Remote SQL: SELECT id, xp FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xp <> ANY(ARRAY[xp, 500]) ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- = ALL ships with both sides proven non-NULL...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp = ALL(ARRAY[xp]) ORDER BY id;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Remote SQL: SELECT id FROM in_null_test.tnull WHERE ((countEqual([xp],xp) = length([xp]))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM tnull WHERE xp = ALL(ARRAY[xp]) ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- ...but countEqual() counts NULL as equal to NULL (id 3 would come back
+-- where Postgres computes NULL = ALL({NULL}) as NULL): local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ALL(ARRAY[xn]) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xn = ALL (ARRAY[tnull.xn]))
+   Remote SQL: SELECT id, xn FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xn = ALL(ARRAY[xn]) ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- ============================================================
+-- 4. Value contexts observe the difference even without NOT
+-- ============================================================
+-- Grouping on the IN result exposes FALSE-vs-NULL directly: Postgres groups
+-- id 2 and id 3 together under NULL; ClickHouse would put id 2 under FALSE.
+-- A NULL-free list is exact and ships; a NULL in the list keeps it local.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT xn IN (1, 500) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ((xn = ANY ('{1,500}'::integer[]))), (count(*))
+   Relations: Aggregate on (tnull)
+   Remote SQL: SELECT (xn IN (1,500)), count(*) FROM in_null_test.tnull GROUP BY ((xn IN (1,500))) ORDER BY (xn IN (1,500)) ASC NULLS LAST
+(4 rows)
+
+SELECT xn IN (1, 500) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+ flag | count 
+------+-------
+ f    |     1
+ t    |     1
+      |     1
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT xn IN (1, NULL) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Sort
+   Output: ((xn = ANY ('{1,NULL}'::integer[]))), (count(*))
+   Sort Key: ((tnull.xn = ANY ('{1,NULL}'::integer[])))
+   ->  HashAggregate
+         Output: ((xn = ANY ('{1,NULL}'::integer[]))), count(*)
+         Group Key: (tnull.xn = ANY ('{1,NULL}'::integer[]))
+         ->  Foreign Scan on in_null_test.tnull
+               Output: (xn = ANY ('{1,NULL}'::integer[]))
+               Remote SQL: SELECT xn FROM in_null_test.tnull
+(9 rows)
+
+SELECT xn IN (1, NULL) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+ flag | count 
+------+-------
+ t    |     1
+      |     2
+(2 rows)
+
+-- An aggregate FILTER only qualifies rows, so it keeps truth-context rules
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(*) FILTER (WHERE xn IN (1, NULL)) FROM tnull;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (count(*) FILTER (WHERE (xn = ANY ('{1,NULL}'::integer[]))))
+   Relations: Aggregate on (tnull)
+   Remote SQL: SELECT countIf((((xn IN (1,NULL))) > 0)) FROM in_null_test.tnull
+(4 rows)
+
+SELECT count(*) FILTER (WHERE xn IN (1, NULL)) FROM tnull;
+ count 
+-------
+     1
+(1 row)
+
+-- ============================================================
+-- 5. Shippability-walker regressions fixed alongside the rules
+-- ============================================================
+-- A NULL array constant survives const-folding when the probe is a column;
+-- inspecting it for the IN-list deparse would detoast a null datum. Local.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ANY(NULL::int[]) ORDER BY id;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: (tnull.xn = ANY (NULL::integer[]))
+   Remote SQL: SELECT id, xn FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE xn = ANY(NULL::int[]) ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- A CASE arg WHEN .. with an unshippable tested expression shipped without
+-- its branches ever being checked. Local, with correct rows.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE CASE pg_backend_pid() WHEN 0 THEN xp = 1 ELSE xp > 0 END
+ORDER BY id;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Foreign Scan on in_null_test.tnull
+   Output: id
+   Filter: CASE pg_backend_pid() WHEN 0 THEN (tnull.xp = 1) ELSE (tnull.xp > 0) END
+   Remote SQL: SELECT id, xp FROM in_null_test.tnull ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM tnull WHERE CASE pg_backend_pid() WHEN 0 THEN xp = 1 ELSE xp > 0 END
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Cleanup
+SET SESSION search_path = public;
+DROP SCHEMA in_null_test CASCADE;
+NOTICE:  drop cascades to foreign table in_null_test.tnull
+SELECT clickhouse_raw_query('DROP DATABASE in_null_test');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+DROP USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
+DROP SERVER in_null_svr;

--- a/test/expected/subplan_pushdown.out
+++ b/test/expected/subplan_pushdown.out
@@ -359,6 +359,133 @@ RESET ROLE;
 DROP VIEW sales_v;
 DROP OWNED BY regress_subplan_nomap;
 DROP ROLE regress_subplan_nomap;
+-- ============================================================
+-- 10. NULL semantics: ClickHouse evaluates IN under two-valued
+--     logic, so a native x NOT IN (SELECT ..) diverges whenever a
+--     NULL can reach the comparison: Postgres computes NULL (row
+--     dropped) where ClickHouse returns TRUE. Shape 5 above ships
+--     plain because both item_id columns import as NOT NULL; with a
+--     nullable column on either side the deparse compensates with
+--     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set — each
+--     emitted only when the corresponding proof fails.
+-- ============================================================
+SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+    (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
+    SERVER subplan_svr OPTIONS (table_name 'maybe_null');
+-- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
+-- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
+-- an unguarded pushdown would return items 4..6
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                                                                           QUERY PLAN                                                                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.items
+   Output: items.item_id
+   Remote SQL: SELECT item_id FROM subplan_test.items r1 WHERE ((r1.item_id NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL)))) ORDER BY r1.item_id ASC NULLS LAST
+   SubPlan any_1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+(0 rows)
+
+-- Nullable probe, NOT NULL inner column: ships as the probe-NULL CASE with
+-- no poison guard (east sales are items {1,2,3,5}, so only val = 7
+-- qualifies; val IS NULL must not)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+                                                                                                                                                               QUERY PLAN                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null
+   Output: maybe_null.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east'))) ELSE (r1.val NOT IN (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east')))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan any_1
+     ->  Foreign Scan on subplan_test.sales
+           Output: sales.item_id
+           Remote SQL: SELECT item_id FROM subplan_test.sales WHERE ((region = 'east'))
+(7 rows)
+
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Both sides nullable: the full form, CASE and poison guard together.
+-- The set holds a NULL, so no probe — NULL included — can qualify
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null m
+   Output: m.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) ELSE (r1.val NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan any_1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Positive IN over the same nullable column diverges only toward FALSE,
+-- which a WHERE treats like the NULL Postgres computes: still ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: items.item_id
+   Relations: (items) LEFT SEMI JOIN (maybe_null)
+   Remote SQL: SELECT r1.item_id FROM  subplan_test.items r1 LEFT SEMI JOIN subplan_test.maybe_null r3 ON (((r1.item_id = r3.val))) ORDER BY r1.item_id ASC NULLS LAST
+(4 rows)
+
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+       1
+       2
+(2 rows)
+
+DROP FOREIGN TABLE maybe_null;
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;

--- a/test/expected/subplan_pushdown_1.out
+++ b/test/expected/subplan_pushdown_1.out
@@ -362,6 +362,133 @@ RESET ROLE;
 DROP VIEW sales_v;
 DROP OWNED BY regress_subplan_nomap;
 DROP ROLE regress_subplan_nomap;
+-- ============================================================
+-- 10. NULL semantics: ClickHouse evaluates IN under two-valued
+--     logic, so a native x NOT IN (SELECT ..) diverges whenever a
+--     NULL can reach the comparison: Postgres computes NULL (row
+--     dropped) where ClickHouse returns TRUE. Shape 5 above ships
+--     plain because both item_id columns import as NOT NULL; with a
+--     nullable column on either side the deparse compensates with
+--     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set — each
+--     emitted only when the corresponding proof fails.
+-- ============================================================
+SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+    (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
+    SERVER subplan_svr OPTIONS (table_name 'maybe_null');
+-- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
+-- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
+-- an unguarded pushdown would return items 4..6
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                                                                           QUERY PLAN                                                                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.items
+   Output: items.item_id
+   Remote SQL: SELECT item_id FROM subplan_test.items r1 WHERE ((r1.item_id NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL)))) ORDER BY r1.item_id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+(0 rows)
+
+-- Nullable probe, NOT NULL inner column: ships as the probe-NULL CASE with
+-- no poison guard (east sales are items {1,2,3,5}, so only val = 7
+-- qualifies; val IS NULL must not)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+                                                                                                                                                               QUERY PLAN                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null
+   Output: maybe_null.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east'))) ELSE (r1.val NOT IN (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east')))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.sales
+           Output: sales.item_id
+           Remote SQL: SELECT item_id FROM subplan_test.sales WHERE ((region = 'east'))
+(7 rows)
+
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Both sides nullable: the full form, CASE and poison guard together.
+-- The set holds a NULL, so no probe — NULL included — can qualify
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null m
+   Output: m.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) ELSE (r1.val NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Positive IN over the same nullable column diverges only toward FALSE,
+-- which a WHERE treats like the NULL Postgres computes: still ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: items.item_id
+   Relations: (items) LEFT SEMI JOIN (maybe_null)
+   Remote SQL: SELECT r1.item_id FROM  subplan_test.items r1 LEFT SEMI JOIN subplan_test.maybe_null r3 ON (((r1.item_id = r3.val))) ORDER BY r1.item_id ASC NULLS LAST
+(4 rows)
+
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+       1
+       2
+(2 rows)
+
+DROP FOREIGN TABLE maybe_null;
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;

--- a/test/expected/subplan_pushdown_2.out
+++ b/test/expected/subplan_pushdown_2.out
@@ -362,6 +362,133 @@ RESET ROLE;
 DROP VIEW sales_v;
 DROP OWNED BY regress_subplan_nomap;
 DROP ROLE regress_subplan_nomap;
+-- ============================================================
+-- 10. NULL semantics: ClickHouse evaluates IN under two-valued
+--     logic, so a native x NOT IN (SELECT ..) diverges whenever a
+--     NULL can reach the comparison: Postgres computes NULL (row
+--     dropped) where ClickHouse returns TRUE. Shape 5 above ships
+--     plain because both item_id columns import as NOT NULL; with a
+--     nullable column on either side the deparse compensates with
+--     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set — each
+--     emitted only when the corresponding proof fails.
+-- ============================================================
+SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+    (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
+    SERVER subplan_svr OPTIONS (table_name 'maybe_null');
+-- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
+-- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
+-- an unguarded pushdown would return items 4..6
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                                                                           QUERY PLAN                                                                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.items
+   Output: items.item_id
+   Remote SQL: SELECT item_id FROM subplan_test.items r1 WHERE ((r1.item_id NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL)))) ORDER BY r1.item_id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+(0 rows)
+
+-- Nullable probe, NOT NULL inner column: ships as the probe-NULL CASE with
+-- no poison guard (east sales are items {1,2,3,5}, so only val = 7
+-- qualifies; val IS NULL must not)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+                                                                                                                                                               QUERY PLAN                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null
+   Output: maybe_null.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east'))) ELSE (r1.val NOT IN (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east')))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.sales
+           Output: sales.item_id
+           Remote SQL: SELECT item_id FROM subplan_test.sales WHERE ((region = 'east'))
+(7 rows)
+
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Both sides nullable: the full form, CASE and poison guard together.
+-- The set holds a NULL, so no probe — NULL included — can qualify
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null m
+   Output: m.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) ELSE (r1.val NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Positive IN over the same nullable column diverges only toward FALSE,
+-- which a WHERE treats like the NULL Postgres computes: still ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: items.item_id
+   Relations: (items) LEFT SEMI JOIN (maybe_null)
+   Remote SQL: SELECT r1.item_id FROM  subplan_test.items r1 LEFT SEMI JOIN subplan_test.maybe_null r3 ON (((r1.item_id = r3.val))) ORDER BY r1.item_id ASC NULLS LAST
+(4 rows)
+
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+       1
+       2
+(2 rows)
+
+DROP FOREIGN TABLE maybe_null;
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;

--- a/test/expected/subplan_pushdown_3.out
+++ b/test/expected/subplan_pushdown_3.out
@@ -362,6 +362,133 @@ RESET ROLE;
 DROP VIEW sales_v;
 DROP OWNED BY regress_subplan_nomap;
 DROP ROLE regress_subplan_nomap;
+-- ============================================================
+-- 10. NULL semantics: ClickHouse evaluates IN under two-valued
+--     logic, so a native x NOT IN (SELECT ..) diverges whenever a
+--     NULL can reach the comparison: Postgres computes NULL (row
+--     dropped) where ClickHouse returns TRUE. Shape 5 above ships
+--     plain because both item_id columns import as NOT NULL; with a
+--     nullable column on either side the deparse compensates with
+--     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set — each
+--     emitted only when the corresponding proof fails.
+-- ============================================================
+SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+    (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
+    INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
+    SERVER subplan_svr OPTIONS (table_name 'maybe_null');
+-- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
+-- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
+-- an unguarded pushdown would return items 4..6
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                                                                           QUERY PLAN                                                                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.items
+   Output: items.item_id
+   Remote SQL: SELECT item_id FROM subplan_test.items r1 WHERE ((r1.item_id NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL)))) ORDER BY r1.item_id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+(0 rows)
+
+-- Nullable probe, NOT NULL inner column: ships as the probe-NULL CASE with
+-- no poison guard (east sales are items {1,2,3,5}, so only val = 7
+-- qualifies; val IS NULL must not)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+                                                                                                                                                               QUERY PLAN                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null
+   Output: maybe_null.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east'))) ELSE (r1.val NOT IN (SELECT q1_1.item_id FROM subplan_test.sales q1_1 WHERE ((q1_1.region = 'east')))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.sales
+           Output: sales.item_id
+           Remote SQL: SELECT item_id FROM subplan_test.sales WHERE ((region = 'east'))
+(7 rows)
+
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Both sides nullable: the full form, CASE and poison guard together.
+-- The set holds a NULL, so no probe — NULL included — can qualify
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on subplan_test.maybe_null m
+   Output: m.id
+   Remote SQL: SELECT id FROM subplan_test.maybe_null r1 WHERE ((CASE WHEN (r1.val) IS NULL THEN NOT EXISTS (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) ELSE (r1.val NOT IN (SELECT q1_1.val FROM subplan_test.maybe_null q1_1) AND NOT EXISTS (SELECT 1 FROM subplan_test.maybe_null q1_1 WHERE (q1_1.val IS NULL))) END)) ORDER BY r1.id ASC NULLS LAST
+   SubPlan 1
+     ->  Foreign Scan on subplan_test.maybe_null
+           Output: maybe_null.val
+           Remote SQL: SELECT val FROM subplan_test.maybe_null
+(7 rows)
+
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Positive IN over the same nullable column diverges only toward FALSE,
+-- which a WHERE treats like the NULL Postgres computes: still ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: items.item_id
+   Relations: (items) LEFT SEMI JOIN (maybe_null)
+   Remote SQL: SELECT r1.item_id FROM  subplan_test.items r1 LEFT SEMI JOIN subplan_test.maybe_null r3 ON (((r1.item_id = r3.val))) ORDER BY r1.item_id ASC NULLS LAST
+(4 rows)
+
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+ item_id 
+---------
+       1
+       2
+(2 rows)
+
+DROP FOREIGN TABLE maybe_null;
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;

--- a/test/sql/gucs.sql
+++ b/test/sql/gucs.sql
@@ -60,11 +60,11 @@ CREATE FOREIGN TABLE http_remote_settings (
 -- Reset to defaults.
 RESET pg_clickhouse.session_settings;
 SELECT name, value FROM bin_remote_settings
- WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final')
+ WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final', 'transform_null_in')
  ORDER BY name;
 
 SELECT name, value FROM http_remote_settings
- WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final')
+ WHERE name IN ('join_use_nulls', 'group_by_use_nulls', 'final', 'transform_null_in')
  ORDER BY name;
 
 -- List of settings changed below.

--- a/test/sql/in_null_semantics.sql
+++ b/test/sql/in_null_semantics.sql
@@ -1,0 +1,156 @@
+-- NULL semantics of the IN family (ScalarArrayOpExpr pushdown).
+--
+-- ClickHouse evaluates IN under two-valued logic: a probe that finds no
+-- match yields 0 even when the searched set contains a NULL, where Postgres
+-- computes NULL; The ClickHouse has()/countEqual() functions also match a NULL probe as
+-- if it were an ordinary value. A FALSE-for-NULL substitution is invisible
+-- while the result only qualifies rows (WHERE/JOIN/HAVING through AND/OR),
+-- but observable under NOT and anywhere the boolean's value is consumed.
+-- These tests ensure the shapes deparse.c ships and that the rows returned
+-- match local (Postgres) semantics either way.
+CREATE SERVER in_null_svr FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(dbname 'in_null_test', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
+
+SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS in_null_test');
+SELECT clickhouse_raw_query('CREATE DATABASE in_null_test');
+
+-- xn imports as a plain (nullable) int column, xp as int NOT NULL
+SELECT clickhouse_raw_query('CREATE TABLE in_null_test.tnull
+    (id Int32, xn Nullable(Int32), xp Int32)
+    ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query($$
+    INSERT INTO in_null_test.tnull VALUES (1, 1, 1), (2, 2, 2), (3, NULL, 3)
+$$);
+
+CREATE SCHEMA in_null_test;
+IMPORT FOREIGN SCHEMA in_null_test FROM SERVER in_null_svr INTO in_null_test;
+SET SESSION search_path = in_null_test,public;
+
+-- The import must carry ClickHouse nullability into the declarations the
+-- never-null proofs rely on
+\d tnull
+
+-- ============================================================
+-- 1. IN over a constant list: pushable in a WHERE condition
+-- ============================================================
+-- NULL-free list is exactly equivalent
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn IN (1, 500) ORDER BY id;
+SELECT id FROM tnull WHERE xn IN (1, 500) ORDER BY id;
+
+-- A NULL in the list only pulls results toward FALSE, which a WHERE treats
+-- like the NULL Postgres computes: still pushable
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn IN (1, NULL) ORDER BY id;
+SELECT id FROM tnull WHERE xn IN (1, NULL) ORDER BY id;
+
+-- ============================================================
+-- 2. NOT IN over a constant list: pushable only when NULL-free
+-- ============================================================
+-- ClickHouse's native NOT IN yields NULL for a NULL probe, so a NULL-free
+-- list is exact: id 3 (xn IS NULL) is dropped on both systems
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn NOT IN (1, 500) ORDER BY id;
+SELECT id FROM tnull WHERE xn NOT IN (1, 500) ORDER BY id;
+
+-- With a NULL in the list Postgres returns no rows (every result is NULL
+-- or FALSE) where ClickHouse would return id 2: must stay local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn NOT IN (1, NULL) ORDER BY id;
+SELECT id FROM tnull WHERE xn NOT IN (1, NULL) ORDER BY id;
+
+-- NOT over IN is the same thing arriving unrewritten
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE NOT (xn IN (1, NULL)) ORDER BY id;
+SELECT id FROM tnull WHERE NOT (xn IN (1, NULL)) ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE NOT (xn IN (1, 500)) ORDER BY id;
+SELECT id FROM tnull WHERE NOT (xn IN (1, 500)) ORDER BY id;
+
+-- ============================================================
+-- 3. Non-constant arrays: the has()/countEqual() deparse forms
+-- ============================================================
+-- has() matches a NULL probe against a NULL element where Postgres computes
+-- NULL, so = ANY needs a provably non-NULL probe; xp is declared NOT NULL
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp = ANY(ARRAY[xn, 5]) ORDER BY id;
+SELECT id FROM tnull WHERE xp = ANY(ARRAY[xn, 5]) ORDER BY id;
+
+-- A nullable probe against an array that may hold a NULL would turn
+-- Postgres's NULL (id 3: NULL = ANY({NULL,5})) into TRUE: must stay local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ANY(ARRAY[xn, 5]) ORDER BY id;
+SELECT id FROM tnull WHERE xn = ANY(ARRAY[xn, 5]) ORDER BY id;
+
+-- countEqual() = 0 turns any NULL involved into TRUE (id 3: 3 <> ALL of
+-- {NULL,5} is NULL on Postgres): <> ALL needs both sides provably non-NULL
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xn, 5]) ORDER BY id;
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xn, 5]) ORDER BY id;
+
+-- ...and with both sides proven, it ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xp, 500]) ORDER BY id;
+SELECT id FROM tnull WHERE xp <> ALL(ARRAY[xp, 500]) ORDER BY id;
+
+-- <> ANY has no correct deparse (not has() computes <> ALL: it would return
+-- no rows here, where one differing element makes every row qualify): local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp <> ANY(ARRAY[xp, 500]) ORDER BY id;
+SELECT id FROM tnull WHERE xp <> ANY(ARRAY[xp, 500]) ORDER BY id;
+
+-- = ALL ships with both sides proven non-NULL...
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xp = ALL(ARRAY[xp]) ORDER BY id;
+SELECT id FROM tnull WHERE xp = ALL(ARRAY[xp]) ORDER BY id;
+
+-- ...but countEqual() counts NULL as equal to NULL (id 3 would come back
+-- where Postgres computes NULL = ALL({NULL}) as NULL): local
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ALL(ARRAY[xn]) ORDER BY id;
+SELECT id FROM tnull WHERE xn = ALL(ARRAY[xn]) ORDER BY id;
+
+-- ============================================================
+-- 4. Value contexts observe the difference even without NOT
+-- ============================================================
+-- Grouping on the IN result exposes FALSE-vs-NULL directly: Postgres groups
+-- id 2 and id 3 together under NULL; ClickHouse would put id 2 under FALSE.
+-- A NULL-free list is exact and ships; a NULL in the list keeps it local.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT xn IN (1, 500) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+SELECT xn IN (1, 500) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT xn IN (1, NULL) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+SELECT xn IN (1, NULL) AS flag, count(*) FROM tnull GROUP BY flag ORDER BY flag;
+
+-- An aggregate FILTER only qualifies rows, so it keeps truth-context rules
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT count(*) FILTER (WHERE xn IN (1, NULL)) FROM tnull;
+SELECT count(*) FILTER (WHERE xn IN (1, NULL)) FROM tnull;
+
+-- ============================================================
+-- 5. Shippability-walker regressions fixed alongside the rules
+-- ============================================================
+-- A NULL array constant survives const-folding when the probe is a column;
+-- inspecting it for the IN-list deparse would detoast a null datum. Local.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE xn = ANY(NULL::int[]) ORDER BY id;
+SELECT id FROM tnull WHERE xn = ANY(NULL::int[]) ORDER BY id;
+
+-- A CASE arg WHEN .. with an unshippable tested expression shipped without
+-- its branches ever being checked. Local, with correct rows.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM tnull WHERE CASE pg_backend_pid() WHEN 0 THEN xp = 1 ELSE xp > 0 END
+ORDER BY id;
+SELECT id FROM tnull WHERE CASE pg_backend_pid() WHEN 0 THEN xp = 1 ELSE xp > 0 END
+ORDER BY id;
+
+-- Cleanup
+SET SESSION search_path = public;
+DROP SCHEMA in_null_test CASCADE;
+SELECT clickhouse_raw_query('DROP DATABASE in_null_test');
+DROP USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
+DROP SERVER in_null_svr;

--- a/test/sql/subplan_pushdown.sql
+++ b/test/sql/subplan_pushdown.sql
@@ -192,6 +192,73 @@ DROP VIEW sales_v;
 DROP OWNED BY regress_subplan_nomap;
 DROP ROLE regress_subplan_nomap;
 
+-- ============================================================
+-- 10. NULL semantics: ClickHouse evaluates IN under two-valued
+--     logic, so a native x NOT IN (SELECT ..) diverges whenever a
+--     NULL can reach the comparison: Postgres computes NULL (row
+--     dropped) where ClickHouse returns TRUE. Shape 5 above ships
+--     plain because both item_id columns import as NOT NULL; with a
+--     nullable column on either side the deparse compensates with
+--     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set — each
+--     emitted only when the corresponding proof fails.
+-- ============================================================
+SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+    (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
+SELECT clickhouse_raw_query($$
+    INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
+$$);
+CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
+    SERVER subplan_svr OPTIONS (table_name 'maybe_null');
+
+-- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
+-- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
+-- an unguarded pushdown would return items 4..6
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+
+SELECT item_id FROM items
+WHERE item_id NOT IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+
+-- Nullable probe, NOT NULL inner column: ships as the probe-NULL CASE with
+-- no poison guard (east sales are items {1,2,3,5}, so only val = 7
+-- qualifies; val IS NULL must not)
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+
+SELECT id FROM maybe_null
+WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
+ORDER BY id;
+
+-- Both sides nullable: the full form, CASE and poison guard together.
+-- The set holds a NULL, so no probe — NULL included — can qualify
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+
+SELECT id FROM maybe_null m
+WHERE m.val NOT IN (SELECT val FROM maybe_null)
+ORDER BY id;
+
+-- Positive IN over the same nullable column diverges only toward FALSE,
+-- which a WHERE treats like the NULL Postgres computes: still ships
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+
+SELECT item_id FROM items
+WHERE item_id IN (SELECT val FROM maybe_null)
+ORDER BY item_id;
+
+DROP FOREIGN TABLE maybe_null;
+
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;


### PR DESCRIPTION
ClickHouse evaluates IN under binary Boolean logic where the Postgres
expression can result in NULL, so pushed `IN`-family expressions gave
wrong answers whenever a NULL could reach the comparison:
`x NOT IN (1, NULL)` returned rows Postgres would drop, meanwhile
`has()`/`countEqual()` matched a NULL probe against NULL array elements
as values, `x NOT IN (SELECT ...)` over nullable columns returned the
plain set complement, and grouping by an `IN` result merged Postgres's
`NULL` group into `FALSE`. The same audit caught three walker bugs:
1. `<> ANY(array)` deparsed to SQL computing `<> ALL`
   (wrong with no NULLs involved),
2. `CASE arg WHEN ..` shipped unchecked when the tested expression was
   unshippable, and
3. a bare EXPLAIN of `x = ANY(NULL::int[])` crashed the backend when
   detoasting the null array datum.

To see each of these, run the new `in_null_semantics` test and
`subplan_pushdown` section 10 against `main`: the wrong rows appear as
regression diffs and the `EXPLAIN` as the crash.

The shippability walker now tracks how each expression's result is
consumed, which I'm generally apprehensive of doing, but it avoids
blowing up this PR adding specialized handlers for different contexts.
Filter conditions treat `NULL` exactly like `FALSE`, so ClickHouse's
`FALSE`-for-`NULL` substitution is invisible there and those shapes
ship unchanged. Value positions and negations demand exact three-valued
equivalence, established by proving the operands can never be `NULL`
(non-NULL constants; NOT NULL columns not nulled by outer joins).
`x NOT IN (SELECT ...)` filters keep their pushdown either way:
a clean query when the columns prove non-nullable, a guarded one
enforcing Postgres's answer when they do not, each guard emitted only
when its proof (of non-nullability) fails. Grouped or aggregated
subquery bodies without proofs stay local, as do `<> ANY` and
`NULL`-array shapes, which will require a different spelling as well
that I think deserves a follow-up PR (modulo the pathological case of
someone attempting to construct a NULL array as part of the query).

`in_null_semantics` carries one expected file across PG 13-19;
subplan_pushdown gains a nullable `NOT IN` section on all four run
variants.

