### PR TITLE
Fix foreign table selection for pushed-down joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ All notable changes to this project will be documented in this file. It uses the
     `1 <> ANY('{1,5}')` is `TRUE`. For now, do not push down ([#315]).
 *   Fixed the pushdown of a `CASE arg WHEN ..` expression without checking its
     branches when the tested expression was itself unshippable ([#315]).
+*   Fixed an error when incorrectly selecting an invalid relation OID when
+    selecting the user to execute the remote query. Thanks to Kostia R for the
+    PR ([#319])!
 
 ### 📚 Documentation
 
@@ -155,6 +158,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#318 Push down the re2 v0.4 `@~` operator"
   [#317]: https://github.com/ClickHouse/pg_clickhouse/pull/317
     "ClickHouse/pg_clickhouse#317 Push down the array IN family unconditionally"
+  [#319]: https://github.com/ClickHouse/pg_clickhouse/pull/319
+    "ClickHouse/pg_clickhouse#319 Fix foreign scan RTE selection"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -1134,11 +1134,12 @@ clickhouseBeginForeignScan(ForeignScanState* node, int eflags) {
     ForeignScan* fsplan = (ForeignScan*)node->ss.ps.plan;
     EState* estate      = node->ss.ps.state;
     ChFdwScanState* fsstate;
+#if PG_VERSION_NUM < 160000
     RangeTblEntry* rte;
-    Oid userid;
-    ForeignTable* table;
-    UserMapping* user;
     int rtindex;
+#endif
+    Oid userid;
+    UserMapping* user;
     int numParams;
 
     /*
@@ -1154,27 +1155,35 @@ clickhouseBeginForeignScan(ForeignScanState* node, int eflags) {
     fsstate         = (ChFdwScanState*)palloc0(sizeof(ChFdwScanState));
     node->fdw_state = (void*)fsstate;
 
+    /* Identify which user to do the remote access as. */
+#if PG_VERSION_NUM >= 160000
+    userid = OidIsValid(fsplan->checkAsUser) ? fsplan->checkAsUser : GetUserId();
+#else
     /*
-     * Identify which user to do the remote access as. This should match what
-     * ExecCheckRTEPerms() does. In case of a join or aggregate, use the
-     * lowest-numbered member RTE as a representative; we would get the same
-     * result from any.
+     * This should match what ExecCheckRTEPerms() does. In case of a join or
+     * aggregate, use a foreign-table member RTE as a representative.
+     * fs_relids can also contain synthetic join RTEs, which do not have a
+     * relation OID.
      */
     if (fsplan->scan.scanrelid > 0) {
         rtindex = fsplan->scan.scanrelid;
     } else {
-        rtindex = bms_next_member(fsplan->fs_relids, -1);
+        rtindex = -1;
+        while ((rtindex = bms_next_member(fsplan->fs_relids, rtindex)) >= 0) {
+            rte = rt_fetch(rtindex, estate->es_range_table);
+            if (rte->rtekind == RTE_RELATION && rte->relkind == RELKIND_FOREIGN_TABLE) {
+                break;
+            }
+        }
+        if (rtindex < 0) {
+            elog(ERROR, "could not find foreign table for pg_clickhouse scan");
+        }
     }
-    rte = rt_fetch(rtindex, estate->es_range_table);
-#if PG_VERSION_NUM >= 160000
-    userid = OidIsValid(fsplan->checkAsUser) ? fsplan->checkAsUser : GetUserId();
-#else
+    rte    = rt_fetch(rtindex, estate->es_range_table);
     userid = rte->checkAsUser ? rte->checkAsUser : GetUserId();
 #endif
 
-    /* Get info about foreign table. */
-    table = GetForeignTable(rte->relid);
-    user  = GetUserMapping(userid, table->serverid);
+    user = GetUserMapping(userid, fsplan->fs_server);
 
     /*
      * Get connection to the foreign server. Connection manager will establish

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -754,6 +754,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r12.c1, count(DISTINCT r12.c2) FROM    binary_queries_test.t1 r9 ALL INNER JOIN binary_queries_test.t2 r10 ON (((r9.c1 = r10.c1))) ALL LEFT JOIN binary_queries_test.t4 r11 ON (((r9.c2 = r11.c2))) ALL INNER JOIN binary_queries_test.t4 r12 ON (((r9.c1 = r12.c1))) WHERE ((r9.c1 < 4)) GROUP BY r12.c1 ORDER BY r12.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -752,6 +752,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r12.c1, count(DISTINCT r12.c2) FROM    binary_queries_test.t1 r9 ALL INNER JOIN binary_queries_test.t2 r10 ON (((r9.c1 = r10.c1))) ALL LEFT JOIN binary_queries_test.t4 r11 ON (((r9.c2 = r11.c2))) ALL INNER JOIN binary_queries_test.t4 r12 ON (((r9.c1 = r12.c1))) WHERE ((r9.c1 < 4)) GROUP BY r12.c1 ORDER BY r12.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -752,6 +752,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r11.c1, count(DISTINCT r11.c2) FROM    binary_queries_test.t1 r8 ALL INNER JOIN binary_queries_test.t2 r9 ON (((r8.c1 = r9.c1))) ALL LEFT JOIN binary_queries_test.t4 r10 ON (((r8.c2 = r10.c2))) ALL INNER JOIN binary_queries_test.t4 r11 ON (((r8.c1 = r11.c1))) WHERE ((r8.c1 < 4)) GROUP BY r11.c1 ORDER BY r11.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -752,6 +752,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r11.c1, count(DISTINCT r11.c2) FROM    binary_queries_test.t1 r8 ALL INNER JOIN binary_queries_test.t2 r9 ON (((r8.c1 = r9.c1))) ALL LEFT JOIN binary_queries_test.t4 r10 ON (((r8.c2 = r10.c2))) ALL INNER JOIN binary_queries_test.t4 r11 ON (((r8.c1 = r11.c1))) WHERE ((r8.c1 < 4)) GROUP BY r11.c1 ORDER BY r11.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -752,6 +752,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                         QUERY PLAN                                                                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r11.c1, count(DISTINCT r11.c2) FROM    binary_queries_test.t1 r8 ALL INNER JOIN binary_queries_test.t2 r9 ON (((r8.c1 = r9.c1))) ALL LEFT JOIN binary_queries_test.t4 r10 ON (((r8.c2 = r10.c2))) ALL INNER JOIN binary_queries_test.t4 r11 ON (((r8.c1 = r11.c1))) WHERE ((r8.c1 < 4)) GROUP BY r11.c1 ORDER BY r11.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -754,6 +754,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r12.c1, count(DISTINCT r12.c2) FROM    binary_queries_test.t1 r9 ALL INNER JOIN binary_queries_test.t2 r10 ON (((r9.c1 = r10.c1))) ALL LEFT JOIN binary_queries_test.t4 r11 ON (((r9.c2 = r11.c2))) ALL INNER JOIN binary_queries_test.t4 r12 ON (((r9.c1 = r12.c1))) WHERE ((r9.c1 < 4)) GROUP BY r12.c1 ORDER BY r12.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -754,6 +754,40 @@ SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
      9
 (1 row)
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: ft5.c1, (count(DISTINCT ft5.c2))
+   Relations: Aggregate on ((((ft1) INNER JOIN (ft2)) LEFT JOIN (ft4)) INNER JOIN (ft5))
+   Remote SQL: SELECT r12.c1, count(DISTINCT r12.c2) FROM    binary_queries_test.t1 r9 ALL INNER JOIN binary_queries_test.t2 r10 ON (((r9.c1 = r10.c1))) ALL LEFT JOIN binary_queries_test.t4 r11 ON (((r9.c2 = r11.c2))) ALL INNER JOIN binary_queries_test.t4 r12 ON (((r9.c1 = r12.c1))) WHERE ((r9.c1 < 4)) GROUP BY r12.c1 ORDER BY r12.c1 ASC NULLS LAST
+(4 rows)
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+ c1 | count 
+----+-------
+  1 |     1
+  2 |     1
+  3 |     1
+(3 rows)
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
  clickhouse_raw_query 
 ----------------------

--- a/test/sql/binary_queries.sql
+++ b/test/sql/binary_queries.sql
@@ -197,6 +197,27 @@ SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(*) FILTER (WHERE c1 < 20) FROM ft2;
 SELECT COUNT(*) FILTER (WHERE c1 < 10) FROM ft2;
 
+-- Pulled-up subqueries can place an outer-join RTE before the base foreign
+-- tables represented by a pushed-down scan.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+
+SELECT t4.c1, COUNT(DISTINCT t4.c2)
+FROM (SELECT * FROM ft1) t1
+JOIN (SELECT * FROM ft2) t2 ON t1.c1 = t2.c1
+LEFT JOIN (SELECT * FROM ft4) t3 ON t1.c2 = t3.c2
+JOIN (SELECT * FROM ft5) t4 ON t2.c1 = t4.c1
+WHERE t1.c1 < 4
+GROUP BY t4.c1
+ORDER BY t4.c1;
+
 SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;


### PR DESCRIPTION
## Problem

For pushed-down join or upper-relation scans, `scanrelid` is zero.
`clickhouseBeginForeignScan()` selected the lowest member of `fs_relids` and
assumed it represented a base foreign table.

With pulled-up subqueries and an outer join, that member can instead be a
synthetic join RTE whose relation OID is invalid. Execution then calls
`GetForeignTable(InvalidOid)` and fails with:

`cache lookup failed for foreign table 0`

Plain `EXPLAIN` does not expose the problem because foreign-scan initialization
is skipped for explain-only execution.

## Fix

- On PostgreSQL 16+, use the core-populated `ForeignScan.checkAsUser` and
  `ForeignScan.fs_server` fields directly, without looking up a representative
  range-table entry.
- On PostgreSQL 13–15, scan `fs_relids` until a foreign-table RTE is found so
  its `checkAsUser` value can be used.
- Use the core-populated `fs_server` field for the user mapping on every
  supported PostgreSQL version.
- Report an explicit error if no representative foreign table exists on
  PostgreSQL 13–15.

## Test

Adds a regression covering execution of a pushed-down aggregate over pulled-up
subqueries with mixed inner and left joins.

Validated with the project pre-commit checks, full PostgreSQL 14 and 18 builds,
and an end-to-end PostgreSQL 18/ClickHouse execution test.
