### PR TITLE
Test importing bare Decimal

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1874,7 +1874,12 @@ ch_format_type_extended(Oid type_oid, int32 typemod, uint16 flags) {
 
     case NUMERICOID:
         if (with_typemod) {
-            buf = printTypmod("Decimal", typemod, typeform->typmodout);
+            /*
+             * Unconstrained numeric potentially much larger than ClickHouse can
+               do; max it out when no precision specified.
+            */
+            buf = typemod < 0 ? "Decimal(76, 38)"
+                              : printTypmod("Decimal", typemod, typeform->typmodout);
         } else {
             buf = pstrdup("Decimal");
         }

--- a/test/expected/decimal.out
+++ b/test/expected/decimal.out
@@ -15,15 +15,17 @@ SELECT clickhouse_raw_query('CREATE DATABASE decimal_test');
  
 (1 row)
 
-SELECT clickhouse_raw_query($$
+\set ECHO errors
+SELECT clickhouse_raw_query(format($$
     CREATE TABLE decimal_test.decimals (
         id     Int32          NOT NULL,
         dec    Decimal(8, 0)  NOT NULL,
         dec32  Decimal32(4)   NOT NULL,
         dec64  Decimal64(6)   NOT NULL,
-        dec128 Decimal128(8)  NOT NULL
+        dec128 Decimal128(8)  NOT NULL,
+        dec0   Decimal%s      NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
-$$);
+$$, :'bare_dec'));
  clickhouse_raw_query 
 ----------------------
  
@@ -41,6 +43,7 @@ IMPORT FOREIGN SCHEMA "decimal_test" FROM SERVER binary_decimal_loopback INTO de
  dec32  | numeric(9,4)  |           | not null |         | 
  dec64  | numeric(18,6) |           | not null |         | 
  dec128 | numeric(38,8) |           | not null |         | 
+ dec0   | numeric(10,0) |           | not null |         | 
 Server: binary_decimal_loopback
 FDW options: (database 'decimal_test', table_name 'decimals', engine 'MergeTree')
 
@@ -54,40 +57,40 @@ IMPORT FOREIGN SCHEMA "decimal_test" FROM SERVER http_decimal_loopback INTO dec_
  dec32  | numeric(9,4)  |           | not null |         | 
  dec64  | numeric(18,6) |           | not null |         | 
  dec128 | numeric(38,8) |           | not null |         | 
+ dec0   | numeric(10,0) |           | not null |         | 
 Server: http_decimal_loopback
 FDW options: (database 'decimal_test', table_name 'decimals', engine 'MergeTree')
 
--- Fails pending https://github.com/ClickHouse/clickhouse-cpp/issues/422
-INSERT INTO dec_bin.decimals (id, dec, dec32, dec64, dec128) VALUES
-    (1, 42::NUMERIC, 98.6::NUMERIC, 102.4::NUMERIC, 1024.003::NUMERIC),
-    (2, 9999, 9999.9999, 9999999.999999, 99999999999.99999999),
-    (3, -9999, -9999.9999, -9999999.999999, -99999999999.99999999)
+INSERT INTO dec_bin.decimals (id, dec, dec32, dec64, dec128, dec0) VALUES
+    (1, 42::NUMERIC, 98.6::NUMERIC, 102.4::NUMERIC, 1024.003::NUMERIC, 66::NUMERIC),
+    (2, 9999, 9999.9999, 9999999.999999, 99999999999.99999999, 9999999999),
+    (3, -9999, -9999.9999, -9999999.999999, -99999999999.99999999, -9999999999)
 ;
 INSERT INTO dec_http.decimals VALUES
-    (4, 1000000::NUMERIC, 10000::NUMERIC, 3000000000::NUMERIC, 400000000000::NUMERIC),
-    (5, -1, -0.0001, -0.000001, -0.00000001),
-    (6, 0, 0, 0, 0)
+    (4, 1000000::NUMERIC, 10000::NUMERIC, 3000000000::NUMERIC, 400000000000::NUMERIC, 67::NUMERIC),
+    (5, -1, -0.0001, -0.000001, -0.00000001, -1111111111),
+    (6, 0, 0, 0, 0, 0)
 ;
 SELECT * FROM dec_bin.decimals ORDER BY id;
- id |   dec   |   dec32    |       dec64       |        dec128         
-----+---------+------------+-------------------+-----------------------
-  1 |      42 |    98.6000 |        102.400000 |         1024.00300000
-  2 |    9999 |  9999.9999 |    9999999.999999 |  99999999999.99999999
-  3 |   -9999 | -9999.9999 |   -9999999.999999 | -99999999999.99999999
-  4 | 1000000 | 10000.0000 | 3000000000.000000 | 400000000000.00000000
-  5 |      -1 |    -0.0001 |         -0.000001 |           -0.00000001
-  6 |       0 |     0.0000 |          0.000000 |            0.00000000
+ id |   dec   |   dec32    |       dec64       |        dec128         |    dec0     
+----+---------+------------+-------------------+-----------------------+-------------
+  1 |      42 |    98.6000 |        102.400000 |         1024.00300000 |          66
+  2 |    9999 |  9999.9999 |    9999999.999999 |  99999999999.99999999 |  9999999999
+  3 |   -9999 | -9999.9999 |   -9999999.999999 | -99999999999.99999999 | -9999999999
+  4 | 1000000 | 10000.0000 | 3000000000.000000 | 400000000000.00000000 |          67
+  5 |      -1 |    -0.0001 |         -0.000001 |           -0.00000001 | -1111111111
+  6 |       0 |     0.0000 |          0.000000 |            0.00000000 |           0
 (6 rows)
 
 SELECT * FROM dec_http.decimals ORDER BY id;
- id |   dec   |   dec32    |       dec64       |        dec128         
-----+---------+------------+-------------------+-----------------------
-  1 |      42 |    98.6000 |        102.400000 |         1024.00300000
-  2 |    9999 |  9999.9999 |    9999999.999999 |  99999999999.99999999
-  3 |   -9999 | -9999.9999 |   -9999999.999999 | -99999999999.99999999
-  4 | 1000000 | 10000.0000 | 3000000000.000000 | 400000000000.00000000
-  5 |      -1 |    -0.0001 |         -0.000001 |           -0.00000001
-  6 |       0 |     0.0000 |          0.000000 |            0.00000000
+ id |   dec   |   dec32    |       dec64       |        dec128         |    dec0     
+----+---------+------------+-------------------+-----------------------+-------------
+  1 |      42 |    98.6000 |        102.400000 |         1024.00300000 |          66
+  2 |    9999 |  9999.9999 |    9999999.999999 |  99999999999.99999999 |  9999999999
+  3 |   -9999 | -9999.9999 |   -9999999.999999 | -99999999999.99999999 | -9999999999
+  4 | 1000000 | 10000.0000 | 3000000000.000000 | 400000000000.00000000 |          67
+  5 |      -1 |    -0.0001 |         -0.000001 |           -0.00000001 | -1111111111
+  6 |       0 |     0.0000 |          0.000000 |            0.00000000 |           0
 (6 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE decimal_test');

--- a/test/expected/import_schema.out
+++ b/test/expected/import_schema.out
@@ -33,7 +33,7 @@ SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
  
 (1 row)
 
--- integer types
+-- numeric types
 SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,

--- a/test/expected/import_schema_1.out
+++ b/test/expected/import_schema_1.out
@@ -33,7 +33,7 @@ SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
  
 (1 row)
 
--- integer types
+-- numeric types
 SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,

--- a/test/sql/decimal.sql
+++ b/test/sql/decimal.sql
@@ -6,15 +6,26 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER http_decimal_loopback;
 
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS decimal_test');
 SELECT clickhouse_raw_query('CREATE DATABASE decimal_test');
-SELECT clickhouse_raw_query($$
+
+\set ECHO errors
+SELECT split_part(clickhouse_server_version('binary_decimal_loopback'), '.', 1)::int <= 23 AS ch23 \gset
+\if :ch23
+\set bare_dec (10, 0)
+\else
+\set bare_dec
+\endif
+\set ECHO all
+
+SELECT clickhouse_raw_query(format($$
     CREATE TABLE decimal_test.decimals (
         id     Int32          NOT NULL,
         dec    Decimal(8, 0)  NOT NULL,
         dec32  Decimal32(4)   NOT NULL,
         dec64  Decimal64(6)   NOT NULL,
-        dec128 Decimal128(8)  NOT NULL
+        dec128 Decimal128(8)  NOT NULL,
+        dec0   Decimal%s      NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
-$$);
+$$, :'bare_dec'));
 
 CREATE SCHEMA dec_bin;
 CREATE SCHEMA dec_http;
@@ -23,17 +34,16 @@ IMPORT FOREIGN SCHEMA "decimal_test" FROM SERVER binary_decimal_loopback INTO de
 IMPORT FOREIGN SCHEMA "decimal_test" FROM SERVER http_decimal_loopback INTO dec_http;
 \d dec_http.decimals
 
--- Fails pending https://github.com/ClickHouse/clickhouse-cpp/issues/422
-INSERT INTO dec_bin.decimals (id, dec, dec32, dec64, dec128) VALUES
-    (1, 42::NUMERIC, 98.6::NUMERIC, 102.4::NUMERIC, 1024.003::NUMERIC),
-    (2, 9999, 9999.9999, 9999999.999999, 99999999999.99999999),
-    (3, -9999, -9999.9999, -9999999.999999, -99999999999.99999999)
+INSERT INTO dec_bin.decimals (id, dec, dec32, dec64, dec128, dec0) VALUES
+    (1, 42::NUMERIC, 98.6::NUMERIC, 102.4::NUMERIC, 1024.003::NUMERIC, 66::NUMERIC),
+    (2, 9999, 9999.9999, 9999999.999999, 99999999999.99999999, 9999999999),
+    (3, -9999, -9999.9999, -9999999.999999, -99999999999.99999999, -9999999999)
 ;
 
 INSERT INTO dec_http.decimals VALUES
-    (4, 1000000::NUMERIC, 10000::NUMERIC, 3000000000::NUMERIC, 400000000000::NUMERIC),
-    (5, -1, -0.0001, -0.000001, -0.00000001),
-    (6, 0, 0, 0, 0)
+    (4, 1000000::NUMERIC, 10000::NUMERIC, 3000000000::NUMERIC, 400000000000::NUMERIC, 67::NUMERIC),
+    (5, -1, -0.0001, -0.000001, -0.00000001, -1111111111),
+    (6, 0, 0, 0, 0, 0)
 ;
 
 SELECT * FROM dec_bin.decimals ORDER BY id;

--- a/test/sql/import_schema.sql
+++ b/test/sql/import_schema.sql
@@ -15,7 +15,7 @@ SELECT clickhouse_raw_query('CREATE DATABASE import_test');
 SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test_2');
 SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
 
--- integer types
+-- numeric types
 SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,


### PR DESCRIPTION
Fortunately ClickHouse resolves it to `Decimal(10, 0)` so we end up with `NUMERIC(10, 0)`.

Ideally would test going the other way, because `NUMERIC` != `NUMERIC(10)` but "values of any length can be stored, up to the implementation limits". The reverse mapping doesn't seem to come up, but max it out in `ch_format_type_extended()`, anyway.