### PR TITLE
Deprecate clickhouse_raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,18 @@ All notable changes to this project will be documented in this file. It uses the
 *   Binary driver now supports inserting into `Array(Nullable(T))` columns ([#316]).
 *   Added pushdown for the three-argument forms of `ltrim`, `rtrim`, and
     `btrim` ([#307]).
-*   Added support for binary driver to `clickhouse_raw_query()` ([#309]).
 *   Added `clickhouse_query(server, sql)`, a set-returning function that runs a
     query against a configured foreign server and returns its rows typed by the
     caller's column definition list ([#309]).
+*   Added `clickhouse_perform(server, sql)`, a procedure that runs a statement
+    against a configured foreign server and discards any result, for statements
+    such as DDL returning no results ([#329]).
+*   Deprecated `clickhouse_raw_query()`, which will be removed in next release.
+    Use `clickhouse_query(server, sql)` or `CALL clickhouse_perform(server, sql)`,
+    which use a foreign server rather than a connection string ([#329]).
+*   Any ClickHouse column now reads into `text` or another string type, rendered
+    by the output function of the PostgreSQL type it maps to, rather than
+    failing with `could not cast value` ([#329]).
 *   Added pushdown support for partial aggregates under partitionwise
     aggregation, so a query over a partitioned table mixing local and foreign
     partitions computes the foreign partition's aggregate on ClickHouse
@@ -199,6 +207,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#326 pg-clickhouse-c"
   [#328]: https://github.com/ClickHouse/pg_clickhouse/pull/328
     "ClickHouse/pg_clickhouse#328use native format for http"
+  [#329]: https://github.com/ClickHouse/pg_clickhouse/pull/329
+    "ClickHouse/pg_clickhouse#329 Deprecate clickhouse_raw_query, add clickhouse_perform"
   [#330]: https://github.com/ClickHouse/pg_clickhouse/pull/330
     "ClickHouse/pg_clickhouse#330 preserve typmod in binary driver"
   [#331]: https://github.com/ClickHouse/pg_clickhouse/pull/331

--- a/doc/offload-partition.sql
+++ b/doc/offload-partition.sql
@@ -245,8 +245,7 @@ BEGIN
 
     ddl := pg_catalog.format('CREATE TABLE %s (%s) ENGINE = %s ORDER BY %s',
                              ch_table, coldefs, engine, order_by);
-    -- DDL yields no rows; column list is a formality clickhouse_query requires
-    PERFORM * FROM clickhouse_query(server, ddl) AS (ddl_result text);
+    CALL clickhouse_perform(server, ddl);
     RETURN ddl;
 END;
 $create$;

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -945,6 +945,11 @@ the PostgreSQL column when importing columns; additional types may be used in
 | UInt8      | smallint         |                               |
 | UUID       | uuid             |                               |
 
+Any column also reads into `text`, `varchar`, or another string type. The value
+takes the PostgreSQL type above, then renders through that type's output
+function. UInt64 values above the bigint maximum still error, so render those
+with the ClickHouse `toString()` function.
+
 Additional notes and details follow.
 
 ### BYTEA
@@ -956,7 +961,7 @@ to [BYTEA]. Example:
 
 ```sql
 -- Create clickHouse table with String columns.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('ch_srv', $$
     CREATE TABLE bytes (
 	      c1 Int8, c2 String, c3 String
     ) ENGINE = MergeTree ORDER BY (c1);
@@ -1073,6 +1078,13 @@ These functions provide the interface to query a ClickHouse database.
 
 #### `clickhouse_raw_query`
 
+> [!WARNING]
+> Deprecated: `clickhouse_raw_query()` emits a deprecation warning and will be
+> removed in the next release. Use [`clickhouse_query`](#clickhouse_query) to
+> read rows and [`clickhouse_perform`](#clickhouse_perform) to run statements
+> that return none. Both reuse a configured server's driver, credentials,
+> database, and connection cache instead of an ad-hoc connection string.
+
 ```sql
 SELECT clickhouse_raw_query(
     'CREATE TABLE t1 (x String) ENGINE = Memory',
@@ -1160,21 +1172,45 @@ SELECT * FROM clickhouse_query(
 
 Execute a query against an already-configured foreign server and return its
 rows as a relation, mapping each ClickHouse result column to the PostgreSQL type
-named in the column definition list. Unlike [`clickhouse_raw_query`](#clickhouse_raw_query)
-it reuses the server's `driver`, credentials, database, and the connection cache
-rather than an ad-hoc connection string.
+named in the column definition list. It reuses the server's `driver`,
+credentials, database, and the connection cache.
 
 The first argument is the name of a server created with [CREATE SERVER]. A
 column definition list (`AS name(col type, ...)`) is required: PostgreSQL needs
 the result shape before fetching rows, and it must match the columns the query
 returns. Values are converted from ClickHouse to the declared types the same way
-a foreign table column would be.
+a foreign table column would be. Statements that return no results, such as DDL,
+have nothing to declare; run them with
+[`clickhouse_perform`](#clickhouse_perform) instead.
 
-As with `clickhouse_raw_query`, no role has `EXECUTE` access by default;
-`GRANT` to a role to allow it to use the function.
+No role has `EXECUTE` access by default; `GRANT` to a role to allow it to use
+the function.
 
 ```sql
 GRANT EXECUTE ON FUNCTION clickhouse_query(text, text) TO ch_admin;
+```
+
+#### `clickhouse_perform`
+
+```sql
+CALL clickhouse_perform(
+    'server',
+    'CREATE TABLE remote_table (id Int32) ENGINE = MergeTree ORDER BY id'
+);
+```
+
+Execute a statement against an already-configured foreign server and discard
+any result. Use it for statements that return no rows, such as DDL, where
+[`clickhouse_query`](#clickhouse_query) has no result shape to declare. It
+resolves the server the same way `clickhouse_query` does, reusing its `driver`,
+credentials, database, and the connection cache.
+
+As a procedure it must be invoked with [CALL], not `SELECT`, and it returns no
+rows. No role has `EXECUTE` access by default; `GRANT` to a role to allow it to
+use the procedure.
+
+```sql
+GRANT EXECUTE ON PROCEDURE clickhouse_perform(text, text) TO ch_admin;
 ```
 
 ### Pushdown Functions
@@ -1667,6 +1703,8 @@ Copyright (c) 2025-2026, ClickHouse.
     "PostgreSQL Docs: DROP EXTENSION"
   [CREATE SERVER]: https://www.postgresql.org/docs/current/sql-createserver.html
     "PostgreSQL Docs: CREATE SERVER"
+  [CALL]: https://www.postgresql.org/docs/current/sql-call.html
+    "PostgreSQL Docs: CALL"
   [ALTER SERVER]: https://www.postgresql.org/docs/current/sql-alterserver.html
     "PostgreSQL Docs: ALTER SERVER"
   [DROP SERVER]: https://www.postgresql.org/docs/current/sql-dropserver.html

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -477,12 +477,12 @@ Here's an excerpt from the CSV file you're using in table format. The
   |          4 | Manhattan     | Alphabet City           | Yellow Zone  |
   |          5 | Staten Island | Arden Heights           | Boro Zone    |
 
-1.  Still in Postgres, use the `clickhouse_raw_query` function to create a
+1.  Still in Postgres, use the `clickhouse_perform` procedure to create a
     ClickHouse [dictionary] named `taxi_zone_dictionary` and populate the
     dictionary from the CSV file in S3:
 
     ```sql
-    SELECT clickhouse_raw_query($$
+    CALL clickhouse_perform('taxi_srv', $$
         CREATE DICTIONARY taxi.taxi_zone_dictionary (
             LocationID Int64 DEFAULT 0,
             Borough String,
@@ -493,7 +493,7 @@ Here's an excerpt from the CSV file you're using in table format. The
         SOURCE(HTTP(URL 'https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/taxi_zone_lookup.csv' FORMAT 'CSVWithNames'))
         LIFETIME(MIN 0 MAX 0)
         LAYOUT(HASHED_ARRAY())
-    $$, 'host=localhost dbname=taxi');
+    $$);
     ```
 
     > [!NOTE]

--- a/sql/pg_clickhouse--0.3--0.4.sql
+++ b/sql/pg_clickhouse--0.3--0.4.sql
@@ -13,5 +13,14 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
--- As with clickhouse_raw_query(), don't let PUBLIC run arbitrary remote queries.
+-- Don't let PUBLIC run arbitrary remote queries.
 REVOKE EXECUTE ON FUNCTION clickhouse_query(text, text) FROM PUBLIC;
+
+-- Execute statement against foreign server, discarding any result, e.g.
+-- CALL clickhouse_perform('srv', 'CREATE TABLE t (a Int32) ENGINE = Memory');
+CREATE PROCEDURE clickhouse_perform(TEXT, TEXT)
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+-- Don't let PUBLIC run arbitrary remote queries.
+REVOKE EXECUTE ON PROCEDURE clickhouse_perform(text, text) FROM PUBLIC;

--- a/sql/pg_clickhouse.sql
+++ b/sql/pg_clickhouse.sql
@@ -12,6 +12,9 @@ RETURNS fdw_handler
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
+-- Deprecated, removed in the next release: use clickhouse_query() or
+-- clickhouse_perform(), which reuse a configured server rather than an ad-hoc
+-- connection string. Emits a deprecation warning when called.
 CREATE FUNCTION clickhouse_raw_query(TEXT, TEXT DEFAULT 'host=localhost port=8123')
 RETURNS TEXT
 AS 'MODULE_PATHNAME'
@@ -36,8 +39,19 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
--- As with clickhouse_raw_query(), don't let PUBLIC run arbitrary remote queries.
+-- Make sure PUBLIC can't run arbitrary remote queries; roles must be granted
+-- explicit access.
 REVOKE EXECUTE ON FUNCTION clickhouse_query(text, text) FROM PUBLIC;
+
+-- Execute statement against foreign server, discarding any result, e.g.
+-- CALL clickhouse_perform('srv', 'CREATE TABLE t (a Int32) ENGINE = Memory');
+CREATE PROCEDURE clickhouse_perform(TEXT, TEXT)
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+-- Make sure PUBLIC can't run arbitrary remote queries; roles must be granted
+-- explicit access.
+REVOKE EXECUTE ON PROCEDURE clickhouse_perform(text, text) FROM PUBLIC;
 
 CREATE FUNCTION clickhouse_fdw_validator(text[], oid)
 RETURNS VOID

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -179,6 +179,7 @@ typedef struct {
 PG_FUNCTION_INFO_V1(clickhouse_fdw_handler);
 PG_FUNCTION_INFO_V1(clickhouse_raw_query);
 PG_FUNCTION_INFO_V1(clickhouse_query);
+PG_FUNCTION_INFO_V1(clickhouse_perform);
 PG_FUNCTION_INFO_V1(clickhouse_op_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_push_fail);
 PG_FUNCTION_INFO_V1(clickhouse_noop);
@@ -364,6 +365,16 @@ clickhouse_raw_query(PG_FUNCTION_ARGS) {
     ch_connection conn;
     text* res;
 
+    ereport(
+        WARNING,
+        errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
+        errmsg("pg_clickhouse: clickhouse_raw_query() is deprecated"),
+        errhint(
+            "Use clickhouse_query() or clickhouse_perform(); "
+            "clickhouse_raw_query() will be removed in the next release."
+        )
+    );
+
     if (strcmp(details->driver, "http") == 0) {
         conn = chfdw_http_connect(details);
     } else if (strcmp(details->driver, "binary") == 0) {
@@ -415,7 +426,7 @@ clickhouse_server_version(PG_FUNCTION_ARGS) {
  * Execute a query against a configured foreign server and return its rows,
  * mapping ClickHouse values to the Postgres types named in the caller's column
  * definition list. Reuses the server's driver, credentials and connection
- * cache, unlike clickhouse_raw_query which takes an ad-hoc connection string.
+ * cache.
  */
 Datum
 clickhouse_query(PG_FUNCTION_ARGS) {
@@ -523,6 +534,45 @@ clickhouse_query(PG_FUNCTION_ARGS) {
     chfdw_release_scan_connection(user, sconn);
 
     return (Datum)0;
+}
+
+/*
+ * Execute a statement against a configured foreign server and discard any
+ * result. Procedure counterpart of clickhouse_query() for statements such as
+ * DDL, which return no results to describe in a column definition list.
+ */
+Datum
+clickhouse_perform(PG_FUNCTION_ARGS) {
+    char* server_name;
+    char* sql;
+    ForeignServer* server;
+    UserMapping* user;
+    ch_scan_connection sconn;
+    ch_cursor* cursor;
+
+    /* procedures cannot be declared STRICT, so reject nulls here */
+    if (PG_ARGISNULL(0) || PG_ARGISNULL(1)) {
+        ereport(
+            ERROR,
+            errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+            errmsg("pg_clickhouse: clickhouse_perform() arguments must not be null")
+        );
+    }
+
+    server_name = text_to_cstring(PG_GETARG_TEXT_P(0));
+    sql         = text_to_cstring(PG_GETARG_TEXT_P(1));
+    server      = GetForeignServerByName(server_name, false);
+    user        = GetUserMapping(GetUserId(), server->serverid);
+    sconn       = chfdw_get_scan_connection(user);
+
+    ch_query query = new_query(sql, 0, NULL, NULL, NULL);
+
+    /* deleting the cursor context drains the connection so it stays reusable */
+    cursor = sconn.gate.methods->simple_query(sconn.gate.conn, &query);
+    MemoryContextDelete(cursor->memcxt);
+    chfdw_release_scan_connection(user, sconn);
+
+    PG_RETURN_VOID();
 }
 
 /* calculate difference */

--- a/test/expected/aggregates.out
+++ b/test/expected/aggregates.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/aggregates_1.out
+++ b/test/expected/aggregates_1.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/aggregates_2.out
+++ b/test/expected/aggregates_2.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/aggregates_3.out
+++ b/test/expected/aggregates_3.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/aggregates_4.out
+++ b/test/expected/aggregates_4.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/aggregates_5.out
+++ b/test/expected/aggregates_5.out
@@ -1,34 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
                Foreign table "agg_bin.agg_numbers"
  Column |   Type   | Collation | Nullable | Default | FDW options 
 --------+----------+-----------+----------+---------+-------------

--- a/test/expected/array_functions.out
+++ b/test/expected/array_functions.out
@@ -1,18 +1,10 @@
 CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER arr_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_admin;
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE IF EXISTS arr_test');
+CALL clickhouse_perform('arr_admin', 'CREATE DATABASE arr_test');
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.t1 (
         id   Int32,
         vals Array(Int32),
@@ -20,39 +12,19 @@ SELECT clickhouse_raw_query($$
         list String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     INSERT INTO arr_test.t1 VALUES
         (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.empty_arrays (
         id   Int32,
         vals Array(Int32)
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'INSERT INTO arr_test.empty_arrays VALUES (4, [])');
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -675,12 +647,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', '
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE arr_test');
 DROP SERVER arr_svr CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table empty_arrays

--- a/test/expected/array_functions_1.out
+++ b/test/expected/array_functions_1.out
@@ -1,18 +1,10 @@
 CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER arr_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_admin;
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE IF EXISTS arr_test');
+CALL clickhouse_perform('arr_admin', 'CREATE DATABASE arr_test');
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.t1 (
         id   Int32,
         vals Array(Int32),
@@ -20,39 +12,19 @@ SELECT clickhouse_raw_query($$
         list String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     INSERT INTO arr_test.t1 VALUES
         (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.empty_arrays (
         id   Int32,
         vals Array(Int32)
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'INSERT INTO arr_test.empty_arrays VALUES (4, [])');
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -647,12 +619,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', '
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE arr_test');
 DROP SERVER arr_svr CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table empty_arrays

--- a/test/expected/array_functions_2.out
+++ b/test/expected/array_functions_2.out
@@ -1,18 +1,10 @@
 CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER arr_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_admin;
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE IF EXISTS arr_test');
+CALL clickhouse_perform('arr_admin', 'CREATE DATABASE arr_test');
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.t1 (
         id   Int32,
         vals Array(Int32),
@@ -20,39 +12,19 @@ SELECT clickhouse_raw_query($$
         list String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     INSERT INTO arr_test.t1 VALUES
         (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.empty_arrays (
         id   Int32,
         vals Array(Int32)
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'INSERT INTO arr_test.empty_arrays VALUES (4, [])');
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -671,12 +643,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', '
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE arr_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE arr_test');
 DROP SERVER arr_svr CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to foreign table empty_arrays

--- a/test/expected/binary.out
+++ b/test/expected/binary.out
@@ -2,52 +2,29 @@ SET datestyle = 'ISO';
 CREATE SERVER binary_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'binary_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER binary_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_admin;
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE IF EXISTS binary_test');
+CALL clickhouse_perform('binary_admin', 'CREATE DATABASE binary_test');
 -- integer types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- date and string types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -56,107 +33,52 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
     ''two'',
     ''three''
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.arrays SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- nested arrays
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.nested_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.nested_arrays VALUES
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ragged nested arrays must error: postgres requires hyper-rectangles
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ragged_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.tuples (
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
     c3 UInt8
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
     number % 2
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.bytes (
     c1 Int8,
     c2 String,
     c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.bytes SELECT
     number,
     SHA1(''val'' || toString(number)),
     MD5(''val'' || toString(number))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE fints (
 	c1 int2,
 	c2 int2,
@@ -391,54 +313,12 @@ ORDER BY c1;
   3
 (2 rows)
 
--- clickhouse_raw_query over the binary protocol
-SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 1       x           +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT number FROM numbers(3) ORDER BY number', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 0                   +
- 1                   +
- 2                   +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT [1,2,3] AS arr, (1, ''a'') AS tup', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- {1,2,3} (1,a)       +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT NULL', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- \N                  +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.raw (c1 Int32) ENGINE = Memory', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
--- explicit http driver still works
-SELECT clickhouse_raw_query('SELECT 1', 'driver=http port=8123');
- clickhouse_raw_query 
-----------------------
- 1                   +
- 
-(1 row)
-
 -- unknown driver is rejected
-SELECT clickhouse_raw_query('SELECT 1', 'driver=bogus');
-ERROR:  pg_clickhouse: invalid ClickHouse connection driver "bogus"
+CREATE SERVER binary_bogus FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'bogus');
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_bogus;
+SELECT * FROM clickhouse_query('binary_bogus', 'SELECT 1') AS t(x int);
+ERROR:  invalid ClickHouse connection driver
 -- clickhouse_query: server-based typed rowset over the binary driver
 SELECT * FROM clickhouse_query(
     'binary_loopback', 'SELECT c1, c3 FROM ints ORDER BY c1 LIMIT 3'
@@ -485,14 +365,11 @@ SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0')
     AS t(x int, y text);
 ERROR:  pg_clickhouse: returned 1 columns, expected 2
 DETAIL:  Remote Query: SELECT 1 WHERE 0
--- DDL returns zero columns, required placeholder column list is ignored
-SELECT * FROM clickhouse_query(
+-- DDL returns zero columns, so it runs through clickhouse_perform
+CALL clickhouse_perform(
     'binary_loopback', 'CREATE TABLE ddl (c1 Int32) ENGINE = Memory'
-) AS t(x int);
- x 
----
-(0 rows)
-
+);
+-- zero columns returned yields no rows; the statement still ran remotely
 SELECT * FROM clickhouse_query('binary_loopback', 'DROP TABLE ddl') AS t(x int);
  x 
 ---
@@ -575,12 +452,7 @@ SELECT * FROM clickhouse_query(
 DROP TYPE nested_tup, nested_tup_inner;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE binary_test');
 DROP SERVER binary_loopback CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to foreign table fints

--- a/test/expected/binary_1.out
+++ b/test/expected/binary_1.out
@@ -2,52 +2,29 @@ SET datestyle = 'ISO';
 CREATE SERVER binary_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'binary_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER binary_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_admin;
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE IF EXISTS binary_test');
+CALL clickhouse_perform('binary_admin', 'CREATE DATABASE binary_test');
 -- integer types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- date and string types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -56,107 +33,52 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
     ''two'',
     ''three''
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.arrays SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- nested arrays
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.nested_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.nested_arrays VALUES
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ragged nested arrays must error: postgres requires hyper-rectangles
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ragged_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.tuples (
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
     c3 UInt8
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
     number % 2
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.bytes (
     c1 Int8,
     c2 String,
     c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.bytes SELECT
     number,
     SHA1(''val'' || toString(number)),
     MD5(''val'' || toString(number))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE fints (
 	c1 int2,
 	c2 int2,
@@ -391,54 +313,12 @@ ORDER BY c1;
   3
 (2 rows)
 
--- clickhouse_raw_query over the binary protocol
-SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 1       x           +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT number FROM numbers(3) ORDER BY number', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 0                   +
- 1                   +
- 2                   +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT [1,2,3] AS arr, (1, ''a'') AS tup', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- {1,2,3} (1,a)       +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('SELECT NULL', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- \N                  +
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.raw (c1 Int32) ENGINE = Memory', 'driver=binary port=9000');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
--- explicit http driver still works
-SELECT clickhouse_raw_query('SELECT 1', 'driver=http port=8123');
- clickhouse_raw_query 
-----------------------
- 1                   +
- 
-(1 row)
-
 -- unknown driver is rejected
-SELECT clickhouse_raw_query('SELECT 1', 'driver=bogus');
-ERROR:  pg_clickhouse: invalid ClickHouse connection driver "bogus"
+CREATE SERVER binary_bogus FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'bogus');
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_bogus;
+SELECT * FROM clickhouse_query('binary_bogus', 'SELECT 1') AS t(x int);
+ERROR:  invalid ClickHouse connection driver
 -- clickhouse_query: server-based typed rowset over the binary driver
 SELECT * FROM clickhouse_query(
     'binary_loopback', 'SELECT c1, c3 FROM ints ORDER BY c1 LIMIT 3'
@@ -485,14 +365,11 @@ SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0')
     AS t(x int, y text);
 ERROR:  pg_clickhouse: returned 1 columns, expected 2
 DETAIL:  Remote Query: SELECT 1 WHERE 0
--- DDL returns zero columns, required placeholder column list is ignored
-SELECT * FROM clickhouse_query(
+-- DDL returns zero columns, so it runs through clickhouse_perform
+CALL clickhouse_perform(
     'binary_loopback', 'CREATE TABLE ddl (c1 Int32) ENGINE = Memory'
-) AS t(x int);
- x 
----
-(0 rows)
-
+);
+-- zero columns returned yields no rows; the statement still ran remotely
 SELECT * FROM clickhouse_query('binary_loopback', 'DROP TABLE ddl') AS t(x int);
  x 
 ---
@@ -557,12 +434,7 @@ SELECT * FROM clickhouse_query(
 DROP TYPE nested_tup, nested_tup_inner;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE binary_test');
 DROP SERVER binary_loopback CASCADE;
 NOTICE:  drop cascades to 8 other objects
 DETAIL:  drop cascades to foreign table fints

--- a/test/expected/binary_compression.out
+++ b/test/expected/binary_compression.out
@@ -1,32 +1,14 @@
 SET datestyle = 'ISO';
--- Seed a small table through the http helper (clickhouse_raw_query is http).
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS compression_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE compression_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE compression_test.t (
+-- Seed a small table through the http admin server.
+CREATE SERVER comp_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER comp_admin;
+CALL clickhouse_perform('comp_admin', 'DROP DATABASE IF EXISTS compression_test');
+CALL clickhouse_perform('comp_admin', 'CREATE DATABASE compression_test');
+CALL clickhouse_perform('comp_admin', 'CREATE TABLE compression_test.t (
     c1 Int32, c2 String
 ) ENGINE = MergeTree ORDER BY c1;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO compression_test.t
+CALL clickhouse_perform('comp_admin', 'INSERT INTO compression_test.t
     SELECT number, format(''row {0}'', toString(number)) FROM numbers(5);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- One server, reconfigured per case: ALTER SERVER invalidates the cached
 -- connection, so each subsequent query reconnects with the new compression.
 CREATE SERVER comp FOREIGN DATA WRAPPER clickhouse_fdw
@@ -97,10 +79,5 @@ ERROR:  pg_clickhouse: invalid compression "bogus"
 HINT:  valid values: none, lz4, zstd
 DROP FOREIGN TABLE ft;
 DROP USER MAPPING FOR CURRENT_USER SERVER comp;
-SELECT clickhouse_raw_query('DROP DATABASE compression_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('comp_admin', 'DROP DATABASE compression_test');
 DROP SERVER comp CASCADE;

--- a/test/expected/binary_inserts.out
+++ b/test/expected/binary_inserts.out
@@ -1,106 +1,48 @@
 SET datestyle = 'ISO';
 CREATE SERVER binary_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_inserts_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
-SELECT clickhouse_raw_query('drop database if exists binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
+CREATE SERVER binary_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_admin;
+CALL clickhouse_perform('binary_inserts_admin', 'drop database if exists binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'create database binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.floats (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.null_ints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.complex (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.nested_arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.not_nullable (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.not_nullable (
 	c1 Int8, c2 Nullable(Enum(''x''=1)), c3 Nullable(Enum16(''x''=1)), c4 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_inserts_test;
 IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 SET search_path = binary_inserts_test, public;
@@ -352,12 +294,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
   4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
 (4 rows)
 
-SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'TRUNCATE binary_inserts_test.bytes');
 -- Should fail.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -365,12 +302,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 ERROR:  value too long for type character varying(16)
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
 -- Should succeed.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -394,7 +326,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
 (4 rows)
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -424,11 +356,6 @@ SELECT clickhouse_raw_query($$
 		c27 Nullable(IPv4), c28 Nullable(IPv6)
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (null_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 INSERT INTO null_vals VALUES(
@@ -444,7 +371,7 @@ SELECT * FROM null_vals;
 (1 row)
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -474,11 +401,6 @@ SELECT clickhouse_raw_query($$
 		c27 IPv4, c28 IPv6
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (default_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 -- Fails on c2, the first column set to NULL: pg-clickhouse-c's writer rejects
@@ -524,12 +446,7 @@ SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'DROP DATABASE binary_inserts_test');
 DROP SERVER binary_inserts_loopback CASCADE;
 NOTICE:  drop cascades to 13 other objects
 DETAIL:  drop cascades to foreign table addr

--- a/test/expected/binary_inserts_1.out
+++ b/test/expected/binary_inserts_1.out
@@ -1,106 +1,48 @@
 SET datestyle = 'ISO';
 CREATE SERVER binary_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_inserts_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
-SELECT clickhouse_raw_query('drop database if exists binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
+CREATE SERVER binary_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_admin;
+CALL clickhouse_perform('binary_inserts_admin', 'drop database if exists binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'create database binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.floats (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.null_ints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.complex (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.nested_arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.not_nullable (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.not_nullable (
 	c1 Int8, c2 Nullable(Enum(''x''=1)), c3 Nullable(Enum16(''x''=1)), c4 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_inserts_test;
 IMPORT FOREIGN SCHEMA binary_inserts_test FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 SET search_path = binary_inserts_test, public;
@@ -343,12 +285,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
   4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
 (4 rows)
 
-SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'TRUNCATE binary_inserts_test.bytes');
 -- Should fail.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -356,12 +293,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 ERROR:  value too long for type character varying(16)
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
 -- Should succeed.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -385,7 +317,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
 (4 rows)
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -415,11 +347,6 @@ SELECT clickhouse_raw_query($$
 		c27 Nullable(IPv4), c28 Nullable(IPv6)
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (null_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 INSERT INTO null_vals VALUES(
@@ -435,7 +362,7 @@ SELECT * FROM null_vals;
 (1 row)
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -465,11 +392,6 @@ SELECT clickhouse_raw_query($$
 		c27 IPv4, c28 IPv6
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA binary_inserts_test LIMIT TO (default_vals)
 FROM SERVER binary_inserts_loopback INTO binary_inserts_test;
 -- Fails on c2, the first column set to NULL: pg-clickhouse-c's writer rejects
@@ -515,12 +437,7 @@ SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_inserts_admin', 'DROP DATABASE binary_inserts_test');
 DROP SERVER binary_inserts_loopback CASCADE;
 NOTICE:  drop cascades to 13 other objects
 DETAIL:  drop cascades to foreign table addr

--- a/test/expected/binary_nullable_json.out
+++ b/test/expected/binary_nullable_json.out
@@ -1,26 +1,13 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_vals (c1 int, c2 jsonb)
 	SERVER binary_nullable_json_loopback OPTIONS (table_name 'json_vals');
 INSERT INTO json_vals VALUES (1, '{"a": 1}'), (2, NULL), (3, '{"b": 2}');
@@ -34,10 +21,5 @@ SELECT * FROM json_vals ORDER BY c1;
 
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_nullable_json_1.out
+++ b/test/expected/binary_nullable_json_1.out
@@ -1,26 +1,13 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_vals (c1 int, c2 jsonb)
 	SERVER binary_nullable_json_loopback OPTIONS (table_name 'json_vals');
 INSERT INTO json_vals VALUES (1, '{"a": 1}'), (2, NULL), (3, '{"b": 2}');
@@ -34,10 +21,5 @@ SELECT * FROM json_vals ORDER BY c1;
 
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_nullable_json_2.out
+++ b/test/expected/binary_nullable_json_2.out
@@ -1,19 +1,11 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
 ERROR:  pg_clickhouse: Code: 43. DB::Exception: Nested type JSON cannot be inside Nullable type. (ILLEGAL_TYPE_OF_ARGUMENT)
@@ -30,10 +22,5 @@ ERROR:  pg_clickhouse: DB::Exception: Unknown table expression identifier 'binar
 DETAIL:  Remote Query: SELECT c1, c2 FROM binary_nullable_json_test.json_vals ORDER BY c1 ASC NULLS LAST
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_nullable_json_3.out
+++ b/test/expected/binary_nullable_json_3.out
@@ -1,19 +1,11 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
 ERROR:  pg_clickhouse: Code: 43. DB::Exception: Nested type Object('json') cannot be inside Nullable type. (ILLEGAL_TYPE_OF_ARGUMENT)
@@ -30,10 +22,5 @@ ERROR:  pg_clickhouse: DB::Exception: Unknown table expression identifier 'binar
 DETAIL:  Remote Query: SELECT c1, c2 FROM binary_nullable_json_test.json_vals ORDER BY c1 ASC NULLS LAST
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_nullable_json_4.out
+++ b/test/expected/binary_nullable_json_4.out
@@ -1,19 +1,11 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
 ERROR:  pg_clickhouse: Code: 43. DB::Exception: Nested type Object('json') cannot be inside Nullable type. (ILLEGAL_TYPE_OF_ARGUMENT)
@@ -30,10 +22,5 @@ ERROR:  pg_clickhouse: DB::Exception: Table binary_nullable_json_test.json_vals 
 DETAIL:  Remote Query: SELECT c1, c2 FROM binary_nullable_json_test.json_vals ORDER BY c1 ASC NULLS LAST
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_nullable_json_5.out
+++ b/test/expected/binary_nullable_json_5.out
@@ -1,19 +1,11 @@
 CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
 ERROR:  pg_clickhouse: Code: 43. DB::Exception: Nested type Object('json') cannot be inside Nullable type. (ILLEGAL_TYPE_OF_ARGUMENT)
@@ -30,10 +22,5 @@ ERROR:  pg_clickhouse: DB::Exception: Table binary_nullable_json_test.json_vals 
 DETAIL:  Remote Query: SELECT c1, c2 FROM binary_nullable_json_test.json_vals ORDER BY c1 ASC NULLS LAST
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/expected/binary_queries.out
+++ b/test/expected/binary_queries.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -788,12 +745,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_1.out
+++ b/test/expected/binary_queries_1.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -786,12 +743,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_2.out
+++ b/test/expected/binary_queries_2.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -786,12 +743,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_3.out
+++ b/test/expected/binary_queries_3.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -786,12 +743,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_4.out
+++ b/test/expected/binary_queries_4.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -786,12 +743,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_5.out
+++ b/test/expected/binary_queries_5.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -788,12 +745,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/binary_queries_6.out
+++ b/test/expected/binary_queries_6.out
@@ -3,48 +3,20 @@ CREATE SERVER binary_queries_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_queries_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA binary_queries_test;
 SET search_path = binary_queries_test, public;
 CREATE FOREIGN TABLE ft1 (
@@ -78,7 +50,7 @@ CREATE FOREIGN TABLE ft6 (
 	c2 int NOT NULL,
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -89,32 +61,17 @@ select clickhouse_raw_query($$
                number % 10,
                'foo'
         FROM numbers(1, 110);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 \set VERBOSITY terse
 SELECT c3, c4 FROM ft1 ORDER BY c3, c1 LIMIT 1;  -- should work
  c3 |     c4     
@@ -788,12 +745,7 @@ ORDER BY t4.c1;
   3 |     1
 (3 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 DROP SERVER binary_queries_loopback2 CASCADE;

--- a/test/expected/column_name.out
+++ b/test/expected/column_name.out
@@ -9,34 +9,16 @@ CREATE SERVER cn_bin_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'cn_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER cn_http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER cn_bin_loopback;
-SELECT clickhouse_raw_query('drop database if exists cn_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database cn_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.t_http (
+CREATE SERVER cn_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER cn_admin;
+CALL clickhouse_perform('cn_admin', 'drop database if exists cn_test');
+CALL clickhouse_perform('cn_admin', 'create database cn_test');
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.t_http (
     ch_id Int32, ch_val String, plain Nullable(Int32)
 ) ENGINE = MergeTree ORDER BY (ch_id);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.t_bin (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.t_bin (
     ch_id Int32, ch_val String, plain Nullable(Int32)
 ) ENGINE = MergeTree ORDER BY (ch_id);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE cn_http (
     pg_id int OPTIONS (column_name 'ch_id'),
     pg_val text OPTIONS (column_name 'ch_val'),
@@ -76,14 +58,9 @@ SELECT * FROM cn_bin  ORDER BY pg_id;
 
 -- Dropped attnum: forces lazy populator to skip an attisdropped slot when
 -- materializing the cache entry on first INSERT.
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.td (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.td (
     ch_id Int32, ch_val String
 ) ENGINE = MergeTree ORDER BY (ch_id);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE cn_drop (
     discarded int,
     pg_id int OPTIONS (column_name 'ch_id'),
@@ -99,14 +76,9 @@ SELECT * FROM cn_drop ORDER BY pg_id;
 
 -- Drop column after the cache is primed by an INSERT and SELECT, to confirm
 -- the ATTNUM syscache invalidation purges stale CustomColumnInfo entries.
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.tlate (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.tlate (
     discarded Nullable(Int32), ch_id Int32, ch_val String
 ) ENGINE = MergeTree ORDER BY (ch_id);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE cn_drop_late (
     discarded int,
     pg_id int OPTIONS (column_name 'ch_id'),
@@ -130,12 +102,7 @@ SELECT * FROM cn_drop_late ORDER BY pg_id;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER cn_http_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER cn_bin_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE cn_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('cn_admin', 'DROP DATABASE cn_test');
 DROP SERVER cn_http_loopback CASCADE;
 NOTICE:  drop cascades to foreign table cn_http
 DROP SERVER cn_bin_loopback CASCADE;

--- a/test/expected/concurrent_scans.out
+++ b/test/expected/concurrent_scans.out
@@ -5,33 +5,15 @@
 CREATE SERVER concur_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS (dbname 'concur_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS concur_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE concur_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE concur_test.sales (
+CREATE SERVER concur_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER concur_admin;
+CALL clickhouse_perform('concur_admin', 'DROP DATABASE IF EXISTS concur_test');
+CALL clickhouse_perform('concur_admin', 'CREATE DATABASE concur_test');
+CALL clickhouse_perform('concur_admin', 'CREATE TABLE concur_test.sales (
     sale_id Int32, item_id Int32, amount Decimal(15, 2)
 ) ENGINE = MergeTree ORDER BY sale_id;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$INSERT INTO concur_test.sales VALUES
+CALL clickhouse_perform('concur_admin', $$INSERT INTO concur_test.sales VALUES
     (1, 1, 100), (2, 1, 150), (3, 2, 200), (8, 1, 250)$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA concur;
 IMPORT FOREIGN SCHEMA concur_test FROM SERVER concur_loopback INTO concur;
 -- Correlated subquery: the inner foreign scan runs while the outer cursor is
@@ -82,9 +64,4 @@ DROP FOREIGN TABLE concur.sales;
 DROP USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
 DROP SERVER concur_loopback;
 DROP SCHEMA concur;
-SELECT clickhouse_raw_query('DROP DATABASE concur_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('concur_admin', 'DROP DATABASE concur_test');

--- a/test/expected/custom_casts.out
+++ b/test/expected/custom_casts.out
@@ -1,39 +1,21 @@
 CREATE SERVER casts_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'casts_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER casts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS casts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE casts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER casts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER casts_admin;
+CALL clickhouse_perform('casts_admin', 'DROP DATABASE IF EXISTS casts_test');
+CALL clickhouse_perform('casts_admin', 'CREATE DATABASE casts_test');
+CALL clickhouse_perform('casts_admin', $$
 	CREATE TABLE casts_test.things (
         num  integer,
         name text
     ) ENGINE = MergeTree ORDER BY (num);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('casts_admin', $$
 	INSERT INTO casts_test.things
 	SELECT number, toString(number)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA casts_test;
 IMPORT FOREIGN SCHEMA casts_test FROM SERVER casts_loopback INTO casts_test;
 SET search_path = casts_test, public;
@@ -198,11 +180,6 @@ SELECT num FROM things WHERE toUint128(name) IN (1, 2, 3);
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER casts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE casts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('casts_admin', 'DROP DATABASE casts_test');
 DROP SERVER casts_loopback CASCADE;
 NOTICE:  drop cascades to foreign table things

--- a/test/expected/decimal.out
+++ b/test/expected/decimal.out
@@ -3,20 +3,12 @@ CREATE SERVER binary_decimal_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTION
 CREATE SERVER http_decimal_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'decimal_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_decimal_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_decimal_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS decimal_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE decimal_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER decimal_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER decimal_admin;
+CALL clickhouse_perform('decimal_admin', 'DROP DATABASE IF EXISTS decimal_test');
+CALL clickhouse_perform('decimal_admin', 'CREATE DATABASE decimal_test');
 \set ECHO errors
-SELECT clickhouse_raw_query(format($$
+CALL clickhouse_perform('decimal_admin', format($$
     CREATE TABLE decimal_test.decimals (
         id     Int32          NOT NULL,
         dec    Decimal(8, 0)  NOT NULL,
@@ -26,11 +18,6 @@ SELECT clickhouse_raw_query(format($$
         dec0   Decimal%s      NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$, :'bare_dec'));
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA dec_bin;
 CREATE SCHEMA dec_http;
 IMPORT FOREIGN SCHEMA "decimal_test" FROM SERVER binary_decimal_loopback INTO dec_bin;
@@ -93,12 +80,7 @@ SELECT * FROM dec_http.decimals ORDER BY id;
   6 |       0 |     0.0000 |          0.000000 |            0.00000000 |           0
 (6 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE decimal_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('decimal_admin', 'DROP DATABASE decimal_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_decimal_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_decimal_loopback;
 DROP SERVER binary_decimal_loopback CASCADE;

--- a/test/expected/deparse_checks.out
+++ b/test/expected/deparse_checks.out
@@ -1,33 +1,15 @@
 CREATE SERVER deparse_lookback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'deparse_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
-SELECT clickhouse_raw_query('drop database if exists deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CREATE SERVER deparse_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_admin;
+CALL clickhouse_perform('deparse_admin', 'drop database if exists deparse_test');
+CALL clickhouse_perform('deparse_admin', 'create database deparse_test');
+CALL clickhouse_perform('deparse_admin', '
 	create table deparse_test.t1 (a int, b Int8)
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('deparse_admin', '
 	insert into deparse_test.t1 select number % 10, number % 10 > 5 from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA deparse_test;
 IMPORT FOREIGN SCHEMA deparse_test FROM SERVER deparse_lookback INTO deparse_test;
 SET search_path = deparse_test, public;
@@ -79,11 +61,6 @@ SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
-SELECT clickhouse_raw_query('DROP DATABASE deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('deparse_admin', 'DROP DATABASE deparse_test');
 DROP SERVER deparse_lookback CASCADE;
 NOTICE:  drop cascades to foreign table t1

--- a/test/expected/deparse_checks_1.out
+++ b/test/expected/deparse_checks_1.out
@@ -1,33 +1,15 @@
 CREATE SERVER deparse_lookback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'deparse_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
-SELECT clickhouse_raw_query('drop database if exists deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CREATE SERVER deparse_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_admin;
+CALL clickhouse_perform('deparse_admin', 'drop database if exists deparse_test');
+CALL clickhouse_perform('deparse_admin', 'create database deparse_test');
+CALL clickhouse_perform('deparse_admin', '
 	create table deparse_test.t1 (a int, b Int8)
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('deparse_admin', '
 	insert into deparse_test.t1 select number % 10, number % 10 > 5 from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA deparse_test;
 IMPORT FOREIGN SCHEMA deparse_test FROM SERVER deparse_lookback INTO deparse_test;
 SET search_path = deparse_test, public;
@@ -76,11 +58,6 @@ SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
-SELECT clickhouse_raw_query('DROP DATABASE deparse_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('deparse_admin', 'DROP DATABASE deparse_test');
 DROP SERVER deparse_lookback CASCADE;
 NOTICE:  drop cascades to foreign table t1

--- a/test/expected/docs_offload_partition.out
+++ b/test/expected/docs_offload_partition.out
@@ -8,18 +8,10 @@ SET max_parallel_workers_per_gather = 0;
 CREATE SERVER offload_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'offload_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER offload_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER offload_admin;
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE IF EXISTS offload_test');
+CALL clickhouse_perform('offload_admin', 'CREATE DATABASE offload_test');
 -- Load documented helpers without echoing their bodies; round-trips below guard
 -- against drift, a parse error still surfaces
 \set ECHO none
@@ -172,10 +164,5 @@ DROP TABLE offload_events, offload_plain, offload_badcol, offload_bylist,
 DROP FUNCTION clickhouse_offload_range(regclass, regclass[], name, text, text, name);
 DROP FUNCTION clickhouse_offload_create_table(regclass, name, text, text, text);
 DROP USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE offload_test');
 DROP SERVER offload_svr CASCADE;

--- a/test/expected/docs_offload_partition_1.out
+++ b/test/expected/docs_offload_partition_1.out
@@ -8,18 +8,10 @@ SET max_parallel_workers_per_gather = 0;
 CREATE SERVER offload_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'offload_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER offload_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER offload_admin;
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE IF EXISTS offload_test');
+CALL clickhouse_perform('offload_admin', 'CREATE DATABASE offload_test');
 -- Load documented helpers without echoing their bodies; round-trips below guard
 -- against drift, a parse error still surfaces
 \set ECHO none
@@ -170,10 +162,5 @@ DROP TABLE offload_events, offload_plain, offload_badcol, offload_bylist,
 DROP FUNCTION clickhouse_offload_range(regclass, regclass[], name, text, text, name);
 DROP FUNCTION clickhouse_offload_create_table(regclass, name, text, text, text);
 DROP USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE offload_test');
 DROP SERVER offload_svr CASCADE;

--- a/test/expected/docs_offload_partition_2.out
+++ b/test/expected/docs_offload_partition_2.out
@@ -8,18 +8,10 @@ SET max_parallel_workers_per_gather = 0;
 CREATE SERVER offload_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'offload_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER offload_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER offload_admin;
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE IF EXISTS offload_test');
+CALL clickhouse_perform('offload_admin', 'CREATE DATABASE offload_test');
 -- Load documented helpers without echoing their bodies; round-trips below guard
 -- against drift, a parse error still surfaces
 \set ECHO none
@@ -169,10 +161,5 @@ DROP TABLE offload_events, offload_plain, offload_badcol, offload_bylist,
 DROP FUNCTION clickhouse_offload_range(regclass, regclass[], name, text, text, name);
 DROP FUNCTION clickhouse_offload_create_table(regclass, name, text, text, text);
 DROP USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE offload_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE offload_test');
 DROP SERVER offload_svr CASCADE;

--- a/test/expected/engine_args.out
+++ b/test/expected/engine_args.out
@@ -1,19 +1,11 @@
 CREATE SERVER engine_args_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'engine_args_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER engine_args_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS engine_args_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE engine_args_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER engine_args_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER engine_args_admin;
+CALL clickhouse_perform('engine_args_admin', 'DROP DATABASE IF EXISTS engine_args_test');
+CALL clickhouse_perform('engine_args_admin', 'CREATE DATABASE engine_args_test');
+CALL clickhouse_perform('engine_args_admin', $$
 	CREATE TABLE engine_args_test.innocuous (
         id UInt32,
         value String
@@ -21,40 +13,20 @@ SELECT clickhouse_raw_query($$
 	ENGINE = MergeTree()
 	ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     INSERT INTO engine_args_test.innocuous
     VALUES (1, 'public'), (2, 'data'), (3, 'here')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     CREATE TABLE IF NOT EXISTS engine_args_test.sensitive (
         id UInt32,
         password String
     ) ENGINE=MergeTree() ORDER BY id;
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     INSERT INTO engine_args_test.sensitive
     VALUES (1, 'admin123'), (2, 'password!')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA engine_args_test;
 -- Should fail on invalid column name (also attempted SQL injection).
 CREATE FOREIGN TABLE engine_args_test.dr_evil (id INT) SERVER engine_args_svr
@@ -297,12 +269,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_var9;
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engine_args_svr;
-SELECT clickhouse_raw_query('DROP DATABASE engine_args_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('engine_args_admin', 'DROP DATABASE engine_args_test');
 DROP SERVER engine_args_svr CASCADE;
 NOTICE:  drop cascades to 17 other objects
 DETAIL:  drop cascades to foreign table engine_args_test.dr_evil

--- a/test/expected/engines.out
+++ b/test/expected/engines.out
@@ -1,85 +1,37 @@
 CREATE SERVER engines_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'engines_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
-SELECT clickhouse_raw_query('drop database if exists engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CREATE SERVER engines_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER engines_admin;
+CALL clickhouse_perform('engines_admin', 'drop database if exists engines_test');
+CALL clickhouse_perform('engines_admin', 'create database engines_test');
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t1 (a int, b int)
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t2 (a int, b AggregateFunction(sum, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t3 (a int, b Array(Int32), c Array(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t1 select number % 10, number from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t2 select number % 10 as a, sumState(toInt32(number)) as b from numbers(1, 100) group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t3 select number % 10,
 		[1, number % 10 + 1], [1, 1] from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t1_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumState(b) as b from engines_test.t1 group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t3_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumMapState(b, c) as b from engines_test.t3 group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
@@ -88,11 +40,6 @@ SELECT clickhouse_raw_query('
 		f AggregateFunction(quantile, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA engines_test;
 IMPORT FOREIGN SCHEMA engines_test FROM SERVER engines_loopback INTO engines_test;
 SET search_path = engines_test, public;
@@ -297,12 +244,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('engines_admin', 'DROP DATABASE engines_test');
 DROP SERVER engines_loopback CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/engines_1.out
+++ b/test/expected/engines_1.out
@@ -1,85 +1,37 @@
 CREATE SERVER engines_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'engines_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
-SELECT clickhouse_raw_query('drop database if exists engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CREATE SERVER engines_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER engines_admin;
+CALL clickhouse_perform('engines_admin', 'drop database if exists engines_test');
+CALL clickhouse_perform('engines_admin', 'create database engines_test');
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t1 (a int, b int)
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t2 (a int, b AggregateFunction(sum, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t3 (a int, b Array(Int32), c Array(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t1 select number % 10, number from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t2 select number % 10 as a, sumState(toInt32(number)) as b from numbers(1, 100) group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t3 select number % 10,
 		[1, number % 10 + 1], [1, 1] from numbers(1, 100);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t1_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumState(b) as b from engines_test.t1 group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t3_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumMapState(b, c) as b from engines_test.t3 group by a;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
@@ -88,11 +40,6 @@ SELECT clickhouse_raw_query('
 		f AggregateFunction(quantile, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA engines_test;
 IMPORT FOREIGN SCHEMA engines_test FROM SERVER engines_loopback INTO engines_test;
 SET search_path = engines_test, public;
@@ -274,12 +221,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER
 (4 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE engines_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('engines_admin', 'DROP DATABASE engines_test');
 DROP SERVER engines_loopback CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2158,14 +2060,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2583,14 +2480,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2899,14 +2791,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2961,12 +2848,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_0.out
+++ b/test/expected/functions_0.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2158,14 +2060,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2583,14 +2480,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2887,14 +2779,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2923,12 +2810,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 ) ORDER BY n;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2158,14 +2060,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2583,14 +2480,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2899,14 +2791,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2935,12 +2822,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 ) ORDER BY n;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2158,14 +2060,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2583,14 +2480,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2887,14 +2779,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2923,12 +2810,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 ) ORDER BY n;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2158,14 +2060,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2571,14 +2468,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2875,14 +2767,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2911,12 +2798,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 ) ORDER BY n;
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2154,14 +2056,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2579,14 +2476,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2895,14 +2787,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2957,12 +2844,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2142,14 +2044,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2567,14 +2464,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2883,14 +2775,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2945,12 +2832,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2142,14 +2044,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2567,14 +2464,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2883,14 +2775,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2945,12 +2832,7 @@ WHERE encode(val::bytea, 'base64url') IN (
 
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2138,14 +2040,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2557,14 +2454,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2873,14 +2765,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2921,12 +2808,7 @@ ERROR:  pg_clickhouse: DB::Exception: Function with name 'base64URLEncode' does 
 DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((base64URLEncode(CAST(val AS bytea(0))) IN ('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh','YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh'))) ORDER BY length(val) ASC NULLS LAST
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_8.out
+++ b/test/expected/functions_8.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2135,14 +2037,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2541,14 +2438,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2857,14 +2749,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2905,12 +2792,7 @@ ERROR:  pg_clickhouse: DB::Exception: Unknown function base64URLEncode. Maybe yo
 DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((base64URLEncode(CAST(val AS bytea(0))) IN ('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh','YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh'))) ORDER BY length(val) ASC NULLS LAST
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/functions_9.out
+++ b/test/expected/functions_9.out
@@ -8,93 +8,35 @@ SELECT pgch_version() ~ '^\d+\.\d+\.\d+$';
 CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
 		(2, 2, '2019-01-02 11:00:00'),
 		(2, 3, '2019-01-02 10:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -103,12 +45,7 @@ SELECT clickhouse_raw_query($$
 		('2029-02-19T01:16:29'),
 		('2030-03-20T02:16:30')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -117,12 +54,7 @@ SELECT clickhouse_raw_query($$
 		('2021-02-19'),
 		('2020-03-20')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -132,23 +64,13 @@ SELECT clickhouse_raw_query($$
 		('2026-08-07T12:00:00'),
 		('2026-08-08T12:00:00')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
 		(0, 0),
 		(1774996811, 1774996811.8384),
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE t1 (a int, b int, c timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t2 (a int, b int, c timestamp with time zone) SERVER functions_loopback OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE t3 (a int, b int) SERVER functions_loopback;
@@ -158,37 +80,22 @@ CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -196,11 +103,6 @@ SELECT clickhouse_raw_query($$
     layout(complex_key_hashed())
     lifetime(10);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- check coalesce((cast as Nullable...
 EXPLAIN (VERBOSE, COSTS OFF)
 	SELECT coalesce(a::text, b::text, c::text) FROM t1 GROUP BY a, b, c;
@@ -2131,14 +2033,9 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE reverse(val) = 'βαΩ';
                                      QUERY PLAN                                     
@@ -2534,14 +2431,9 @@ SELECT i64 FROM t6 WHERE f64 < pi();
 (3 rows)
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT val FROM t4 WHERE lower(val) = 'val3';
                                     QUERY PLAN                                     
@@ -2850,14 +2742,9 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 SELECT octet_length(val) AS n FROM t4
 WHERE encode(val::bytea, 'base64') IN (
     encode(repeat('a', 57)::bytea, 'base64'),
@@ -2898,12 +2785,7 @@ ERROR:  pg_clickhouse: DB::Exception: Unknown function base64URLEncode. Maybe yo
 DETAIL:  Remote Query: SELECT val FROM functions_test.t4 WHERE ((base64URLEncode(CAST(val AS bytea(0))) IN ('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh','YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh'))) ORDER BY length(val) ASC NULLS LAST
 \endif
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;
 NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1

--- a/test/expected/http.out
+++ b/test/expected/http.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -812,11 +779,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -842,13 +804,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -873,13 +830,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -897,24 +849,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -931,23 +873,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -964,22 +896,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -993,39 +915,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1134,12 +1036,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_1.out
+++ b/test/expected/http_1.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -810,11 +777,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -840,13 +802,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -871,13 +828,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -895,24 +847,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -929,23 +871,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -962,22 +894,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -991,39 +913,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1132,12 +1034,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_2.out
+++ b/test/expected/http_2.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -810,11 +777,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -840,13 +802,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -871,13 +828,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -895,24 +847,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -929,23 +871,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -962,22 +894,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -991,39 +913,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1132,12 +1034,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_3.out
+++ b/test/expected/http_3.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -810,11 +777,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -840,13 +802,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -871,13 +828,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -895,24 +847,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -929,23 +871,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -962,22 +894,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -991,39 +913,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1132,12 +1034,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_4.out
+++ b/test/expected/http_4.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -810,11 +777,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -840,13 +802,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -871,13 +828,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -895,24 +847,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -929,23 +871,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -962,22 +894,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -991,39 +913,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1132,12 +1034,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_5.out
+++ b/test/expected/http_5.out
@@ -3,60 +3,27 @@ CREATE SERVER http_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname '
 CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+');
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
 	c1 int NOT NULL,
@@ -812,11 +779,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FR
 (5 rows)
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
-ERROR:  pg_clickhouse: unsupported line ending character in database name
-DETAIL:  Invalid database name: 'http_test
-X-My-Header: 123'
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 CREATE FOREIGN TABLE bad_name (
@@ -842,13 +804,8 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk (id text, term text)
     SERVER http_loopback OPTIONS (table_name 't_brk');
 INSERT INTO ft_brk VALUES
@@ -873,13 +830,8 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
     SERVER http_loopback OPTIONS (table_name 't_brk_mix');
 INSERT INTO ft_brk_mix VALUES
@@ -897,24 +849,14 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
     || ' (''3'', ''leading text \\N''),'/* contains \N at end */
     || ' (''4'', ''ordinary'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_nullmark (id text, s text)
     SERVER http_loopback OPTIONS (table_name 't_nullmark');
 SELECT id, s, length(s), s IS NULL AS is_null
@@ -931,23 +873,13 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
     (''4'', ''plain'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_bytea (id text, v bytea)
     SERVER http_loopback OPTIONS (table_name 't_bytea');
 SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
@@ -964,22 +896,12 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE ft_timestr (id text, v time)
     SERVER http_loopback OPTIONS (table_name 't_timestr');
 SELECT v FROM ft_timestr WHERE id = '3';
@@ -993,39 +915,19 @@ ERROR:  invalid input syntax for type time: "xZ"
 DETAIL:  Remote Query: SELECT v FROM http_test.t_timestr WHERE ((id = '2'))
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
     c2 int[],
@@ -1134,12 +1036,7 @@ HINT:  Valid values are: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3.
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 NOTICE:  drop cascades to foreign table bad_name
 DROP SERVER http_loopback2 CASCADE;

--- a/test/expected/http_inserts.out
+++ b/test/expected/http_inserts.out
@@ -1,98 +1,45 @@
 SET datestyle = 'ISO';
 CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+CREATE SERVER http_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_admin;
+CALL clickhouse_perform('http_inserts_admin', 'drop database if exists http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'create database http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.nested_arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -340,12 +287,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
   4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
 (4 rows)
 
-SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'TRUNCATE http_inserts_test.bytes');
 -- Should fail.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -353,12 +295,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 ERROR:  value too long for type character varying(16)
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
 -- Should succeed.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -382,7 +319,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
 (4 rows)
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -412,11 +349,6 @@ SELECT clickhouse_raw_query($$
 		c27 Nullable(IPv4), c28 Nullable(IPv6)
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (null_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO null_vals VALUES(
@@ -432,7 +364,7 @@ SELECT * FROM null_vals;
 (1 row)
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -462,11 +394,6 @@ SELECT clickhouse_raw_query($$
 		c27 IPv4, c28 IPv6
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (default_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO default_vals VALUES(
@@ -501,12 +428,7 @@ SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'DROP DATABASE http_inserts_test');
 DROP SERVER http_inserts_loopback CASCADE;
 NOTICE:  drop cascades to 12 other objects
 DETAIL:  drop cascades to foreign table addr

--- a/test/expected/http_inserts_1.out
+++ b/test/expected/http_inserts_1.out
@@ -1,98 +1,45 @@
 SET datestyle = 'ISO';
 CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+CREATE SERVER http_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_admin;
+CALL clickhouse_perform('http_inserts_admin', 'drop database if exists http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'create database http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.nested_arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -331,12 +278,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
   4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
 (4 rows)
 
-SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'TRUNCATE http_inserts_test.bytes');
 -- Should fail.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -344,12 +286,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 ERROR:  value too long for type character varying(16)
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
 -- Should succeed.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -373,7 +310,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
 (4 rows)
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -403,11 +340,6 @@ SELECT clickhouse_raw_query($$
 		c27 Nullable(IPv4), c28 Nullable(IPv6)
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (null_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO null_vals VALUES(
@@ -423,7 +355,7 @@ SELECT * FROM null_vals;
 (1 row)
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -453,11 +385,6 @@ SELECT clickhouse_raw_query($$
 		c27 IPv4, c28 IPv6
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (default_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO default_vals VALUES(
@@ -492,12 +419,7 @@ SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'DROP DATABASE http_inserts_test');
 DROP SERVER http_inserts_loopback CASCADE;
 NOTICE:  drop cascades to 12 other objects
 DETAIL:  drop cascades to foreign table addr

--- a/test/expected/http_inserts_2.out
+++ b/test/expected/http_inserts_2.out
@@ -1,98 +1,45 @@
 SET datestyle = 'ISO';
 CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('create database http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+CREATE SERVER http_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_admin;
+CALL clickhouse_perform('http_inserts_admin', 'drop database if exists http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'create database http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.nested_arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA http_inserts_test;
 IMPORT FOREIGN SCHEMA http_inserts_test FROM SERVER http_inserts_loopback INTO http_inserts_test;
 SET search_path = http_inserts_test, public;
@@ -340,12 +287,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
   4 | 4e3c2e4cb7542a45173a8dac939ddc4bc75202e342ebc769b0f5da2f | 8ef30f44c65480d12b650ab6b2b04245
 (4 rows)
 
-SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'TRUNCATE http_inserts_test.bytes');
 -- Should fail.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -353,12 +295,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 ERROR:  value too long for type character varying(16)
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
 -- Should succeed.
 INSERT INTO bytes
 SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
@@ -382,7 +319,7 @@ SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER B
 (4 rows)
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -412,11 +349,6 @@ SELECT clickhouse_raw_query($$
 		c27 Nullable(IPv4), c28 Nullable(IPv6)
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (null_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO null_vals VALUES(
@@ -432,7 +364,7 @@ SELECT * FROM null_vals;
 (1 row)
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -462,11 +394,6 @@ SELECT clickhouse_raw_query($$
 		c27 IPv4, c28 IPv6
 	) ENGINE = MergeTree ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 IMPORT FOREIGN SCHEMA http_inserts_test LIMIT TO (default_vals)
 FROM SERVER http_inserts_loopback INTO http_inserts_test;
 INSERT INTO default_vals VALUES(
@@ -530,12 +457,7 @@ SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 (3 rows)
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('http_inserts_admin', 'DROP DATABASE http_inserts_test');
 DROP SERVER http_inserts_loopback CASCADE;
 NOTICE:  drop cascades to 12 other objects
 DETAIL:  drop cascades to foreign table addr

--- a/test/expected/ilike_regex.out
+++ b/test/expected/ilike_regex.out
@@ -6,31 +6,18 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;
 CREATE SERVER ilike_regex_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'ilike_regex_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER ilike_regex_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_admin;
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE IF EXISTS ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', 'CREATE DATABASE ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', $$
     CREATE TABLE ilike_regex_test.events (
         id     Int32,
         name   String,
         path   String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('ilike_regex_admin', $$
     INSERT INTO ilike_regex_test.events VALUES
         (1, 'page_view',   '/users/profile'),
         (2, 'Page_View',   '/users/settings'),
@@ -43,11 +30,6 @@ SELECT clickhouse_raw_query($$
         (9, 'logout',      '/auth/logout'),
         (10, 'signup',     '/auth/signup')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA ilike_regex_bin;
 CREATE SCHEMA ilike_regex_http;
 IMPORT FOREIGN SCHEMA "ilike_regex_test" FROM SERVER ilike_regex_bin_svr INTO ilike_regex_bin;
@@ -457,12 +439,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~*
 (4 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE ilike_regex_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
 DROP SERVER ilike_regex_bin_svr CASCADE;

--- a/test/expected/ilike_regex_1.out
+++ b/test/expected/ilike_regex_1.out
@@ -6,31 +6,18 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;
 CREATE SERVER ilike_regex_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'ilike_regex_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER ilike_regex_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_admin;
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE IF EXISTS ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', 'CREATE DATABASE ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', $$
     CREATE TABLE ilike_regex_test.events (
         id     Int32,
         name   String,
         path   String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('ilike_regex_admin', $$
     INSERT INTO ilike_regex_test.events VALUES
         (1, 'page_view',   '/users/profile'),
         (2, 'Page_View',   '/users/settings'),
@@ -43,11 +30,6 @@ SELECT clickhouse_raw_query($$
         (9, 'logout',      '/auth/logout'),
         (10, 'signup',     '/auth/signup')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA ilike_regex_bin;
 CREATE SCHEMA ilike_regex_http;
 IMPORT FOREIGN SCHEMA "ilike_regex_test" FROM SERVER ilike_regex_bin_svr INTO ilike_regex_bin;
@@ -457,12 +439,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~*
 (4 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE ilike_regex_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
 DROP SERVER ilike_regex_bin_svr CASCADE;

--- a/test/expected/import_schema.out
+++ b/test/expected/import_schema.out
@@ -9,59 +9,26 @@ CREATE SCHEMA clickhouse_limit;
 CREATE SCHEMA clickhouse_except;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER import_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER import_admin;
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test_2');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test_2');
 -- numeric types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Nullable(Float64)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, NULL FROM numbers(10, 2);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3),
@@ -69,12 +36,7 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
     c8 LowCardinality(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -85,125 +47,65 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
     toString(number),
     format(''cardinal {0}'', toString(number))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types2 (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types2 (
     c1 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_nullable_key = 1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types2 SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types2 SELECT
     format(''cardinal {0}'', toString(number + 1))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ip (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ip (
     c1 IPv4,
     c2 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ip VALUES
     ('116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
     ('116.106.34.243', '2a02:e980:1e::1'),
     ('116.106.34.244', '::1');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.arrays (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.arrays SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- tuple
-SELECT clickhouse_raw_query('CREATE TABLE import_test.tuples (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
 	c3 Nested(a Int, b Int),
 	c4 Int16
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.tuples SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
 	[toInt32(number),1,1],
 	[toInt32(number),2,2],
 	toInt16(number)
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- datetime with timezones
-SELECT clickhouse_raw_query('CREATE TABLE import_test.timezones (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.timezones (
 	t1 DateTime64(6,''UTC''),
 	t2 DateTime64(6,''Europe/Berlin''),
 	t4 DateTime(''Europe/Berlin''),
 	t5 DateTime64(6))
 	ENGINE = MergeTree ORDER BY (t1) SETTINGS index_granularity=8192;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Injection attempt should import nothing.
 IMPORT FOREIGN SCHEMA "import_test' OR database = 'public" FROM SERVER import_loopback INTO clickhouse;
 \det clickhouse.*
@@ -647,12 +549,7 @@ Server: import_loopback
 FDW options: (database 'import_test', table_name 'tuples', engine 'MergeTree')
 
 -- check custom database
-SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
                                    QUERY PLAN                                    
@@ -672,7 +569,7 @@ EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
 (3 rows)
 
 -- check overflows.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ints (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) VALUES
     (
         -- Min values
@@ -687,22 +584,18 @@ SELECT clickhouse_raw_query($$
         3.402823466e+38, 1.7976931348623158e+308
     )
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    SELECT * FROM import_test.ints
+SELECT * FROM clickhouse_query('import_admin', $$
+    SELECT c1, c2, c3, c4, c5, c6, c7, c9, c10
+    FROM import_test.ints
     WHERE c1 IN (127, -128)
     ORDER BY c1;
-$$);
-                                                                  clickhouse_raw_query                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------
- -128    -32768  -2147483648     -9223372036854775808    0       0       0       0       1.1754944e-38   2.2250738585072014e-308                       +
- 127     32767   2147483647      9223372036854775807     255     65535   4294967295      18446744073709551615    3.4028235e38    1.7976931348623157e308+
- 
-(1 row)
+$$) AS t(c1 text, c2 text, c3 text, c4 text, c5 text,
+         c6 text, c7 text, c9 text, c10 text);
+  c1  |   c2   |     c3      |          c4          | c5  |  c6   |     c7     |      c9       |           c10           
+------+--------+-------------+----------------------+-----+-------+------------+---------------+-------------------------
+ -128 | -32768 | -2147483648 | -9223372036854775808 | 0   | 0     | 0          | 1.1754944e-38 | 2.2250738585072014e-308
+ 127  | 32767  | 2147483647  | 9223372036854775807  | 255 | 65535 | 4294967295 | 3.4028235e+38 | 1.7976931348623157e+308
+(2 rows)
 
 -- Error on 18446744073709551615.
 SELECT * FROM clickhouse_bin.ints
@@ -742,18 +635,8 @@ ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test_2');
 DROP SERVER import_loopback_bin CASCADE;
 NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to foreign table clickhouse_bin.arrays

--- a/test/expected/import_schema_1.out
+++ b/test/expected/import_schema_1.out
@@ -9,59 +9,26 @@ CREATE SCHEMA clickhouse_limit;
 CREATE SCHEMA clickhouse_except;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER import_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER import_admin;
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test_2');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test_2');
 -- numeric types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Nullable(Float64)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, NULL FROM numbers(10, 2);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3),
@@ -69,12 +36,7 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
     c8 LowCardinality(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -85,125 +47,65 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
     toString(number),
     format(''cardinal {0}'', toString(number))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types2 (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types2 (
     c1 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_nullable_key = 1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types2 SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types2 SELECT
     format(''cardinal {0}'', toString(number + 1))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ip (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ip (
     c1 IPv4,
     c2 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ip VALUES
     ('116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
     ('116.106.34.243', '2a02:e980:1e::1'),
     ('116.106.34.244', '::1');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.arrays (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.arrays SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- tuple
-SELECT clickhouse_raw_query('CREATE TABLE import_test.tuples (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
 	c3 Nested(a Int, b Int),
 	c4 Int16
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.tuples SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
 	[toInt32(number),1,1],
 	[toInt32(number),2,2],
 	toInt16(number)
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- datetime with timezones
-SELECT clickhouse_raw_query('CREATE TABLE import_test.timezones (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.timezones (
 	t1 DateTime64(6,''UTC''),
 	t2 DateTime64(6,''Europe/Berlin''),
 	t4 DateTime(''Europe/Berlin''),
 	t5 DateTime64(6))
 	ENGINE = MergeTree ORDER BY (t1) SETTINGS index_granularity=8192;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Injection attempt should import nothing.
 IMPORT FOREIGN SCHEMA "import_test' OR database = 'public" FROM SERVER import_loopback INTO clickhouse;
 \det clickhouse.*
@@ -547,12 +449,7 @@ Server: import_loopback
 FDW options: (database 'import_test', table_name 'tuples', engine 'MergeTree')
 
 -- check custom database
-SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
                                    QUERY PLAN                                    
@@ -572,7 +469,7 @@ EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
 (3 rows)
 
 -- check overflows.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ints (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) VALUES
     (
         -- Min values
@@ -587,22 +484,18 @@ SELECT clickhouse_raw_query($$
         3.402823466e+38, 1.7976931348623158e+308
     )
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    SELECT * FROM import_test.ints
+SELECT * FROM clickhouse_query('import_admin', $$
+    SELECT c1, c2, c3, c4, c5, c6, c7, c9, c10
+    FROM import_test.ints
     WHERE c1 IN (127, -128)
     ORDER BY c1;
-$$);
-                                                                  clickhouse_raw_query                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------
- -128    -32768  -2147483648     -9223372036854775808    0       0       0       0       1.1754944e-38   2.2250738585072014e-308                       +
- 127     32767   2147483647      9223372036854775807     255     65535   4294967295      18446744073709551615    3.4028235e38    1.7976931348623157e308+
- 
-(1 row)
+$$) AS t(c1 text, c2 text, c3 text, c4 text, c5 text,
+         c6 text, c7 text, c9 text, c10 text);
+  c1  |   c2   |     c3      |          c4          | c5  |  c6   |     c7     |      c9       |           c10           
+------+--------+-------------+----------------------+-----+-------+------------+---------------+-------------------------
+ -128 | -32768 | -2147483648 | -9223372036854775808 | 0   | 0     | 0          | 1.1754944e-38 | 2.2250738585072014e-308
+ 127  | 32767  | 2147483647  | 9223372036854775807  | 255 | 65535 | 4294967295 | 3.4028235e+38 | 1.7976931348623157e+308
+(2 rows)
 
 -- Error on 18446744073709551615.
 SELECT * FROM clickhouse_bin.ints
@@ -642,18 +535,8 @@ ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test_2');
 DROP SERVER import_loopback_bin CASCADE;
 NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to foreign table clickhouse_bin.arrays

--- a/test/expected/import_schema_2.out
+++ b/test/expected/import_schema_2.out
@@ -9,59 +9,26 @@ CREATE SCHEMA clickhouse_limit;
 CREATE SCHEMA clickhouse_except;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER import_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER import_admin;
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test_2');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test_2');
 -- numeric types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Nullable(Float64)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, NULL FROM numbers(10, 2);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3),
@@ -69,12 +36,7 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
     c8 LowCardinality(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -85,125 +47,65 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
     toString(number),
     format(''cardinal {0}'', toString(number))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types2 (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types2 (
     c1 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_nullable_key = 1;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.types2 SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types2 SELECT
     format(''cardinal {0}'', toString(number + 1))
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ip (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ip (
     c1 IPv4,
     c2 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ip VALUES
     ('116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
     ('116.106.34.243', '2a02:e980:1e::1'),
     ('116.106.34.244', '::1');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.arrays (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.arrays SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- tuple
-SELECT clickhouse_raw_query('CREATE TABLE import_test.tuples (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
 	c3 Nested(a Int, b Int),
 	c4 Int16
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.tuples SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
 	[toInt32(number),1,1],
 	[toInt32(number),2,2],
 	toInt16(number)
     FROM numbers(10);');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- datetime with timezones
-SELECT clickhouse_raw_query('CREATE TABLE import_test.timezones (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.timezones (
 	t1 DateTime64(6,''UTC''),
 	t2 DateTime64(6,''Europe/Berlin''),
 	t4 DateTime(''Europe/Berlin''),
 	t5 DateTime64(6))
 	ENGINE = MergeTree ORDER BY (t1) SETTINGS index_granularity=8192;');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'')');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Injection attempt should import nothing.
 IMPORT FOREIGN SCHEMA "import_test' OR database = 'public" FROM SERVER import_loopback INTO clickhouse;
 \det clickhouse.*
@@ -647,12 +549,7 @@ Server: import_loopback
 FDW options: (database 'import_test', table_name 'tuples', engine 'MergeTree')
 
 -- check custom database
-SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
                                    QUERY PLAN                                    
@@ -672,7 +569,7 @@ EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
 (3 rows)
 
 -- check overflows.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ints (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) VALUES
     (
         -- Min values
@@ -687,22 +584,18 @@ SELECT clickhouse_raw_query($$
         3.402823466e+38, 1.7976931348623158e+308
     )
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    SELECT * FROM import_test.ints
+SELECT * FROM clickhouse_query('import_admin', $$
+    SELECT c1, c2, c3, c4, c5, c6, c7, c9, c10
+    FROM import_test.ints
     WHERE c1 IN (127, -128)
     ORDER BY c1;
-$$);
-                                                                  clickhouse_raw_query                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------
- -128    -32768  -2147483648     -9223372036854775808    0       0       0       0       1.1754942e-38   2.2250738585072014e-308                       +
- 127     32767   2147483647      9223372036854775807     255     65535   4294967295      18446744073709551615    3.4028233e38    1.7976931348623157e308+
- 
-(1 row)
+$$) AS t(c1 text, c2 text, c3 text, c4 text, c5 text,
+         c6 text, c7 text, c9 text, c10 text);
+  c1  |   c2   |     c3      |          c4          | c5  |  c6   |     c7     |      c9       |           c10           
+------+--------+-------------+----------------------+-----+-------+------------+---------------+-------------------------
+ -128 | -32768 | -2147483648 | -9223372036854775808 | 0   | 0     | 0          | 1.1754942e-38 | 2.2250738585072014e-308
+ 127  | 32767  | 2147483647  | 9223372036854775807  | 255 | 65535 | 4294967295 | 3.4028233e+38 | 1.7976931348623157e+308
+(2 rows)
 
 -- Error on 18446744073709551615.
 SELECT * FROM clickhouse_bin.ints
@@ -742,18 +635,8 @@ ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
-SELECT clickhouse_raw_query('DROP DATABASE import_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('DROP DATABASE import_test_2');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test_2');
 DROP SERVER import_loopback_bin CASCADE;
 NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to foreign table clickhouse_bin.arrays

--- a/test/expected/in_null_semantics.out
+++ b/test/expected/in_null_semantics.out
@@ -13,37 +13,19 @@
 CREATE SERVER in_null_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'in_null_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS in_null_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE in_null_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER in_null_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_admin;
+CALL clickhouse_perform('in_null_admin', 'DROP DATABASE IF EXISTS in_null_test');
+CALL clickhouse_perform('in_null_admin', 'CREATE DATABASE in_null_test');
 -- xn imports as a plain (nullable) int column, xp as int NOT NULL, and arr
 -- as int[]; its elements' nullability is never provable at plan time
-SELECT clickhouse_raw_query('CREATE TABLE in_null_test.tnull
+CALL clickhouse_perform('in_null_admin', 'CREATE TABLE in_null_test.tnull
     (id Int32, xn Nullable(Int32), xp Int32, arr Array(Int32))
     ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('in_null_admin', $$
     INSERT INTO in_null_test.tnull
     VALUES (1, 1, 1, [1, 500]), (2, 2, 2, [500]), (3, NULL, 3, [])
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA in_null_test;
 IMPORT FOREIGN SCHEMA in_null_test FROM SERVER in_null_svr INTO in_null_test;
 SET SESSION search_path = in_null_test,public;
@@ -553,11 +535,6 @@ ORDER BY id;
 SET SESSION search_path = public;
 DROP SCHEMA in_null_test CASCADE;
 NOTICE:  drop cascades to foreign table in_null_test.tnull
-SELECT clickhouse_raw_query('DROP DATABASE in_null_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('in_null_admin', 'DROP DATABASE in_null_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
 DROP SERVER in_null_svr;

--- a/test/expected/json.out
+++ b/test/expected/json.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -952,17 +939,12 @@ SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 (1 row)
 
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1528,28 +1510,18 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1982,12 +1954,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_1.out
+++ b/test/expected/json_1.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -862,17 +849,12 @@ SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 (1 row)
 
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1438,28 +1420,18 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1892,12 +1864,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_2.out
+++ b/test/expected/json_2.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -952,17 +939,12 @@ SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 (1 row)
 
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1528,28 +1510,18 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1982,12 +1954,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -738,17 +725,12 @@ SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 (0 rows)
 
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1255,28 +1237,18 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1661,12 +1633,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_4.out
+++ b/test/expected/json_4.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -629,17 +616,12 @@ ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE (data -> 'name')::text =...
                       ^
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1110,28 +1092,18 @@ DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data.
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1516,12 +1488,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_5.out
+++ b/test/expected/json_5.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -629,17 +616,12 @@ ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE (data -> 'name')::text =...
                       ^
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1110,28 +1092,18 @@ DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data.
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1516,12 +1488,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/json_6.out
+++ b/test/expected/json_6.out
@@ -3,29 +3,16 @@ CREATE SERVER binary_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(d
 CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'json_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree PARTITION BY id ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA json_bin;
 CREATE SCHEMA json_http;
 IMPORT FOREIGN SCHEMA "json_test" FROM SERVER binary_json_loopback INTO json_bin;
@@ -629,17 +616,12 @@ ERROR:  relation "json_bin.things" does not exist
 LINE 1: SELECT * FROM json_bin.things WHERE (data -> 'name')::text =...
                       ^
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.special_keys (id integer NOT NULL, data jsonb NOT NULL)
   SERVER http_json_loopback OPTIONS (database 'json_test', table_name 'special_keys');
 CREATE FOREIGN TABLE json_bin.special_keys (id integer NOT NULL, data jsonb NOT NULL)
@@ -1110,28 +1092,18 @@ DETAIL:  Remote Query: SELECT id, data FROM json_test.special_keys WHERE ((data.
 -- jsonb_extract_path_text / jsonb_extract_path pushdown
 -- =======================================================================
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE json_http.events (
     id         integer,
     event_name text,
@@ -1516,12 +1488,7 @@ WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
    Remote SQL: SELECT id, props FROM json_test.events
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/expected/param.out
+++ b/test/expected/param.out
@@ -7,19 +7,11 @@ CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
 -- Create the schema in ClickHouse.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER param_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_admin;
+CALL clickhouse_perform('param_admin', 'DROP DATABASE IF EXISTS param_test');
+CALL clickhouse_perform('param_admin', 'CREATE DATABASE param_test');
+CALL clickhouse_perform('param_admin', $$
     CREATE TABLE param_test.ft1 (
         c1 Int,
         c2 Int,
@@ -31,13 +23,8 @@ SELECT clickhouse_raw_query($$
         c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('param_admin', $$
     INSERT INTO param_test.ft1
     SELECT number,
            number % 10,
@@ -49,11 +36,6 @@ SELECT clickhouse_raw_query($$
            ['foo']
     FROM numbers(1, 110)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ===================================================================
 -- binary foreign tables
 -- ===================================================================
@@ -284,12 +266,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -321,12 +298,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
@@ -584,12 +556,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -621,12 +588,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);

--- a/test/expected/param_1.out
+++ b/test/expected/param_1.out
@@ -7,19 +7,11 @@ CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
 -- Create the schema in ClickHouse.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER param_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_admin;
+CALL clickhouse_perform('param_admin', 'DROP DATABASE IF EXISTS param_test');
+CALL clickhouse_perform('param_admin', 'CREATE DATABASE param_test');
+CALL clickhouse_perform('param_admin', $$
     CREATE TABLE param_test.ft1 (
         c1 Int,
         c2 Int,
@@ -31,13 +23,8 @@ SELECT clickhouse_raw_query($$
         c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('param_admin', $$
     INSERT INTO param_test.ft1
     SELECT number,
            number % 10,
@@ -49,11 +36,6 @@ SELECT clickhouse_raw_query($$
            ['foo']
     FROM numbers(1, 110)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ===================================================================
 -- binary foreign tables
 -- ===================================================================
@@ -284,12 +266,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -321,12 +298,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
@@ -584,12 +556,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -621,12 +588,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);

--- a/test/expected/param_2.out
+++ b/test/expected/param_2.out
@@ -7,19 +7,11 @@ CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
 -- Create the schema in ClickHouse.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER param_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_admin;
+CALL clickhouse_perform('param_admin', 'DROP DATABASE IF EXISTS param_test');
+CALL clickhouse_perform('param_admin', 'CREATE DATABASE param_test');
+CALL clickhouse_perform('param_admin', $$
     CREATE TABLE param_test.ft1 (
         c1 Int,
         c2 Int,
@@ -31,13 +23,8 @@ SELECT clickhouse_raw_query($$
         c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('param_admin', $$
     INSERT INTO param_test.ft1
     SELECT number,
            number % 10,
@@ -49,11 +36,6 @@ SELECT clickhouse_raw_query($$
            ['foo']
     FROM numbers(1, 110)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ===================================================================
 -- binary foreign tables
 -- ===================================================================
@@ -284,12 +266,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -321,12 +298,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
@@ -584,12 +556,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -621,12 +588,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying(10), 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);

--- a/test/expected/param_3.out
+++ b/test/expected/param_3.out
@@ -7,19 +7,11 @@ CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
 -- Create the schema in ClickHouse.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE param_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER param_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_admin;
+CALL clickhouse_perform('param_admin', 'DROP DATABASE IF EXISTS param_test');
+CALL clickhouse_perform('param_admin', 'CREATE DATABASE param_test');
+CALL clickhouse_perform('param_admin', $$
     CREATE TABLE param_test.ft1 (
         c1 Int,
         c2 Int,
@@ -31,13 +23,8 @@ SELECT clickhouse_raw_query($$
         c8 Array(String)
     ) ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('param_admin', $$
     INSERT INTO param_test.ft1
     SELECT number,
            number % 10,
@@ -49,11 +36,6 @@ SELECT clickhouse_raw_query($$
            ['foo']
     FROM numbers(1, 110)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ===================================================================
 -- binary foreign tables
 -- ===================================================================
@@ -284,12 +266,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -321,12 +298,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM bin_test.ft1 WHERE c1 = (SELECT 4);
@@ -584,12 +556,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
                                                      QUERY PLAN                                                      
@@ -621,12 +588,7 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
          Output: 1001, 101, 'foo'::text, NULL::timestamp with time zone, NULL::timestamp without time zone, NULL::character varying, 'ft1       '::character(10), NULL::text[]
 (3 rows)
 
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
 -- implicit parameter
 EXPLAIN (VERBOSE, COSTS OFF) SELECT c1, c2 FROM http_test.ft1 WHERE c1 = (SELECT 4);

--- a/test/expected/partitioning_binary.out
+++ b/test/expected/partitioning_binary.out
@@ -7,30 +7,12 @@ CREATE SERVER pwagg_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'pwagg_bin_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_svr;
 -- ClickHouse holds cold data
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS pwagg_bin_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE pwagg_bin_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE pwagg_bin_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$INSERT INTO pwagg_bin_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER pwagg_bin_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_admin;
+CALL clickhouse_perform('pwagg_bin_admin', 'DROP DATABASE IF EXISTS pwagg_bin_test');
+CALL clickhouse_perform('pwagg_bin_admin', 'CREATE DATABASE pwagg_bin_test');
+CALL clickhouse_perform('pwagg_bin_admin', 'CREATE TABLE pwagg_bin_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
+CALL clickhouse_perform('pwagg_bin_admin', $$INSERT INTO pwagg_bin_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
 -- Partitioned table whose cold 2023 range lives on ClickHouse as a foreign
 -- partition while the hot 2024 range stays local: the layout a consumer builds
 -- when offloading old partitions (offload itself is left to the consumer)
@@ -164,10 +146,5 @@ SELECT avg(val) FILTER (WHERE val > 15),
 RESET enable_partitionwise_aggregate;
 DROP TABLE events_bin;
 DROP USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_svr;
-SELECT clickhouse_raw_query('DROP DATABASE pwagg_bin_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('pwagg_bin_admin', 'DROP DATABASE pwagg_bin_test');
 DROP SERVER pwagg_bin_svr CASCADE;

--- a/test/expected/partitioning_http.out
+++ b/test/expected/partitioning_http.out
@@ -4,30 +4,12 @@ CREATE SERVER pwagg_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'pwagg_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_svr;
 -- ClickHouse holds cold data
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS pwagg_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE pwagg_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE pwagg_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$INSERT INTO pwagg_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER pwagg_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_admin;
+CALL clickhouse_perform('pwagg_admin', 'DROP DATABASE IF EXISTS pwagg_test');
+CALL clickhouse_perform('pwagg_admin', 'CREATE DATABASE pwagg_test');
+CALL clickhouse_perform('pwagg_admin', 'CREATE TABLE pwagg_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
+CALL clickhouse_perform('pwagg_admin', $$INSERT INTO pwagg_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
 -- Partitioned table whose cold 2023 range lives on ClickHouse as a foreign
 -- partition while the hot 2024 range stays local: the layout a consumer builds
 -- when offloading old partitions (offload itself is left to the consumer)
@@ -161,10 +143,5 @@ SELECT avg(val) FILTER (WHERE val > 15),
 RESET enable_partitionwise_aggregate;
 DROP TABLE events;
 DROP USER MAPPING FOR CURRENT_USER SERVER pwagg_svr;
-SELECT clickhouse_raw_query('DROP DATABASE pwagg_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('pwagg_admin', 'DROP DATABASE pwagg_test');
 DROP SERVER pwagg_svr CASCADE;

--- a/test/expected/query_cancel.out
+++ b/test/expected/query_cancel.out
@@ -8,32 +8,14 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_http;
 CREATE SERVER cancel_binary FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'cancel_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS cancel_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE cancel_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE cancel_test.t1 (c1 Int32)
+CREATE SERVER cancel_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_admin;
+CALL clickhouse_perform('cancel_admin', 'DROP DATABASE IF EXISTS cancel_test');
+CALL clickhouse_perform('cancel_admin', 'CREATE DATABASE cancel_test');
+CALL clickhouse_perform('cancel_admin', 'CREATE TABLE cancel_test.t1 (c1 Int32)
     ENGINE = MergeTree ORDER BY c1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO cancel_test.t1
+CALL clickhouse_perform('cancel_admin', 'INSERT INTO cancel_test.t1
     SELECT number FROM numbers(100)');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE cancel_http_ft (c1 int)
     SERVER cancel_http OPTIONS (table_name 't1');
 CREATE FOREIGN TABLE cancel_binary_ft (c1 int)
@@ -89,9 +71,4 @@ DROP USER MAPPING FOR CURRENT_USER SERVER cancel_http;
 DROP USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
 DROP SERVER cancel_http;
 DROP SERVER cancel_binary;
-SELECT clickhouse_raw_query('DROP DATABASE cancel_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('cancel_admin', 'DROP DATABASE cancel_test');

--- a/test/expected/raw_query.out
+++ b/test/expected/raw_query.out
@@ -1,0 +1,18 @@
+-- clickhouse_raw_query() is deprecated and drops out next release.
+-- Prefer clickhouse_query() / clickhouse_perform().
+SELECT clickhouse_raw_query('CREATE DATABASE IF NOT EXISTS raw_query_test');
+WARNING:  pg_clickhouse: clickhouse_raw_query() is deprecated
+HINT:  Use clickhouse_query() or clickhouse_perform(); clickhouse_raw_query() will be removed in the next release.
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('DROP DATABASE raw_query_test', 'host=localhost port=8123');
+WARNING:  pg_clickhouse: clickhouse_raw_query() is deprecated
+HINT:  Use clickhouse_query() or clickhouse_perform(); clickhouse_raw_query() will be removed in the next release.
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+

--- a/test/expected/re2_functions.out
+++ b/test/expected/re2_functions.out
@@ -5,40 +5,22 @@ SELECT NOT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS n
 \endif
 CREATE SERVER re2_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 're2_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER re2_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS re2_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE re2_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER re2_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER re2_admin;
+CALL clickhouse_perform('re2_admin', 'DROP DATABASE IF EXISTS re2_test');
+CALL clickhouse_perform('re2_admin', 'CREATE DATABASE re2_test');
+CALL clickhouse_perform('re2_admin', $$
     CREATE TABLE re2_test.t1 (
         id   Int32,
         val  String
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('re2_admin', $$
     INSERT INTO re2_test.t1 VALUES
         (1, 'POSIX uses BRE and ERE'),
         (2, 're2 uses finite automata'),
         (3, 'PCRE supports backtracking')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA re2_test;
 IMPORT FOREIGN SCHEMA re2_test FROM SERVER re2_svr INTO re2_test;
 SET search_path = re2_test, public;
@@ -373,11 +355,6 @@ SELECT id FROM t1 WHERE array_length(re2extractallgroupshorizontal(val, '(\w+) (
 
 DROP EXTENSION re2;
 DROP USER MAPPING FOR CURRENT_USER SERVER re2_svr;
-SELECT clickhouse_raw_query('DROP DATABASE re2_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('re2_admin', 'DROP DATABASE re2_test');
 DROP SERVER re2_svr CASCADE;
 NOTICE:  drop cascades to foreign table t1

--- a/test/expected/regex.out
+++ b/test/expected/regex.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 NOTICE:  regexp_like PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
@@ -667,11 +647,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, '.') 
 \unset ECHO
 NOTICE:  regexp_like: SELECT val FROM regex_test.strings
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('regex_admin', 'DROP DATABASE regex_test');
 DROP SERVER regex_loopback CASCADE;
 NOTICE:  drop cascades to foreign table strings

--- a/test/expected/regex_1.out
+++ b/test/expected/regex_1.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 NOTICE:  regexp_like PUSHED DOWN: t
 NOTICE:  (val1)
 NOTICE:  (val2)
@@ -645,11 +625,6 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM strings WHERE regexp_match(val, '.') 
 \unset ECHO
 NOTICE:  regexp_like: SELECT val FROM regex_test.strings
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE regex_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('regex_admin', 'DROP DATABASE regex_test');
 DROP SERVER regex_loopback CASCADE;
 NOTICE:  drop cascades to foreign table strings

--- a/test/expected/stream_out.out
+++ b/test/expected/stream_out.out
@@ -1,32 +1,14 @@
 CREATE SERVER try_http FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'try_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER try_http;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS try_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE try_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE try_test.t1 (c1 Int32)
+CREATE SERVER try_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER try_admin;
+CALL clickhouse_perform('try_admin', 'DROP DATABASE IF EXISTS try_test');
+CALL clickhouse_perform('try_admin', 'CREATE DATABASE try_test');
+CALL clickhouse_perform('try_admin', 'CREATE TABLE try_test.t1 (c1 Int32)
     ENGINE = MergeTree ORDER BY c1');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('INSERT INTO try_test.t1
+CALL clickhouse_perform('try_admin', 'INSERT INTO try_test.t1
     SELECT number FROM numbers(3500)');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE try_http_ft (c1 int)
     SERVER try_http OPTIONS (table_name 't1');
 SELECT * FROM try_http_ft;
@@ -3543,9 +3525,4 @@ SELECT count(*), min(c1), max(c1), sum(c1::bigint) FROM try_http_ft;
 DROP USER MAPPING FOR CURRENT_USER SERVER try_http;
 DROP SERVER try_http CASCADE;
 NOTICE:  drop cascades to foreign table try_http_ft
-SELECT clickhouse_raw_query('DROP DATABASE try_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('try_admin', 'DROP DATABASE try_test');

--- a/test/expected/subplan_pushdown.out
+++ b/test/expected/subplan_pushdown.out
@@ -10,7 +10,9 @@
 -- correlated / NOT IN SQL we generate), so the whole test aborts on older
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -20,61 +22,31 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER subplan_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'subplan_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.items
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE IF EXISTS subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.items
     (item_id Int32, grp Int32, price Decimal(15,2), qty Int32)
     ENGINE = MergeTree ORDER BY item_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.sales
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.sales
     (sale_id Int32, item_id Int32, amount Decimal(15,2), region String)
     ENGINE = MergeTree ORDER BY sale_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.items VALUES
     (1, 1, 10.00, 5), (2, 1, 20.00, 3), (3, 1, 30.00, 8),
     (4, 2, 15.00, 2), (5, 2, 25.00, 7), (6, 3, 50.00, 1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Sale 8 distinguishes correct correlation from inner-scope capture: under
 -- correct per-item correlation its group (item 1) has avg 166.67 so the
 -- 1.5x threshold is 250.00 and sale 8 (250.00) does NOT qualify; under a
 -- capture bug the threshold collapses to the global 1.5*avg = 241.88 and
 -- sale 8 WOULD qualify.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.sales VALUES
     (1, 1, 100.00, 'east'), (2, 1, 150.00, 'west'),
     (3, 2, 200.00, 'east'), (4, 3, 120.00, 'east'),
     (5, 4,  80.00, 'west'), (6, 5, 300.00, 'east'),
     (7, 5,  90.00, 'west'), (8, 1, 250.00, 'east')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA subplan_test;
 IMPORT FOREIGN SCHEMA subplan_test FROM SERVER subplan_svr INTO subplan_test;
 SET SESSION search_path = subplan_test,public;
@@ -370,21 +342,11 @@ DROP ROLE regress_subplan_nomap;
 --     and a NOT EXISTS poison check for NULLs in the set — each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
     (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
@@ -494,9 +456,4 @@ DETAIL:  drop cascades to foreign table subplan_test.items
 drop cascades to foreign table subplan_test.sales
 DROP USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 DROP SERVER subplan_svr CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE subplan_test');

--- a/test/expected/subplan_pushdown_1.out
+++ b/test/expected/subplan_pushdown_1.out
@@ -10,7 +10,9 @@
 -- correlated / NOT IN SQL we generate), so the whole test aborts on older
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -20,61 +22,31 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER subplan_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'subplan_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.items
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE IF EXISTS subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.items
     (item_id Int32, grp Int32, price Decimal(15,2), qty Int32)
     ENGINE = MergeTree ORDER BY item_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.sales
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.sales
     (sale_id Int32, item_id Int32, amount Decimal(15,2), region String)
     ENGINE = MergeTree ORDER BY sale_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.items VALUES
     (1, 1, 10.00, 5), (2, 1, 20.00, 3), (3, 1, 30.00, 8),
     (4, 2, 15.00, 2), (5, 2, 25.00, 7), (6, 3, 50.00, 1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Sale 8 distinguishes correct correlation from inner-scope capture: under
 -- correct per-item correlation its group (item 1) has avg 166.67 so the
 -- 1.5x threshold is 250.00 and sale 8 (250.00) does NOT qualify; under a
 -- capture bug the threshold collapses to the global 1.5*avg = 241.88 and
 -- sale 8 WOULD qualify.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.sales VALUES
     (1, 1, 100.00, 'east'), (2, 1, 150.00, 'west'),
     (3, 2, 200.00, 'east'), (4, 3, 120.00, 'east'),
     (5, 4,  80.00, 'west'), (6, 5, 300.00, 'east'),
     (7, 5,  90.00, 'west'), (8, 1, 250.00, 'east')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA subplan_test;
 IMPORT FOREIGN SCHEMA subplan_test FROM SERVER subplan_svr INTO subplan_test;
 SET SESSION search_path = subplan_test,public;
@@ -373,21 +345,11 @@ DROP ROLE regress_subplan_nomap;
 --     and a NOT EXISTS poison check for NULLs in the set — each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
     (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
@@ -497,9 +459,4 @@ DETAIL:  drop cascades to foreign table subplan_test.items
 drop cascades to foreign table subplan_test.sales
 DROP USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 DROP SERVER subplan_svr CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE subplan_test');

--- a/test/expected/subplan_pushdown_2.out
+++ b/test/expected/subplan_pushdown_2.out
@@ -10,7 +10,9 @@
 -- correlated / NOT IN SQL we generate), so the whole test aborts on older
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -20,61 +22,31 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER subplan_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'subplan_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.items
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE IF EXISTS subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.items
     (item_id Int32, grp Int32, price Decimal(15,2), qty Int32)
     ENGINE = MergeTree ORDER BY item_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.sales
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.sales
     (sale_id Int32, item_id Int32, amount Decimal(15,2), region String)
     ENGINE = MergeTree ORDER BY sale_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.items VALUES
     (1, 1, 10.00, 5), (2, 1, 20.00, 3), (3, 1, 30.00, 8),
     (4, 2, 15.00, 2), (5, 2, 25.00, 7), (6, 3, 50.00, 1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Sale 8 distinguishes correct correlation from inner-scope capture: under
 -- correct per-item correlation its group (item 1) has avg 166.67 so the
 -- 1.5x threshold is 250.00 and sale 8 (250.00) does NOT qualify; under a
 -- capture bug the threshold collapses to the global 1.5*avg = 241.88 and
 -- sale 8 WOULD qualify.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.sales VALUES
     (1, 1, 100.00, 'east'), (2, 1, 150.00, 'west'),
     (3, 2, 200.00, 'east'), (4, 3, 120.00, 'east'),
     (5, 4,  80.00, 'west'), (6, 5, 300.00, 'east'),
     (7, 5,  90.00, 'west'), (8, 1, 250.00, 'east')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA subplan_test;
 IMPORT FOREIGN SCHEMA subplan_test FROM SERVER subplan_svr INTO subplan_test;
 SET SESSION search_path = subplan_test,public;
@@ -373,21 +345,11 @@ DROP ROLE regress_subplan_nomap;
 --     and a NOT EXISTS poison check for NULLs in the set — each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
     (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
@@ -497,9 +459,4 @@ DETAIL:  drop cascades to foreign table subplan_test.items
 drop cascades to foreign table subplan_test.sales
 DROP USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 DROP SERVER subplan_svr CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE subplan_test');

--- a/test/expected/subplan_pushdown_3.out
+++ b/test/expected/subplan_pushdown_3.out
@@ -10,7 +10,9 @@
 -- correlated / NOT IN SQL we generate), so the whole test aborts on older
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -20,61 +22,31 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER subplan_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'subplan_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.items
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE IF EXISTS subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.items
     (item_id Int32, grp Int32, price Decimal(15,2), qty Int32)
     ENGINE = MergeTree ORDER BY item_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.sales
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.sales
     (sale_id Int32, item_id Int32, amount Decimal(15,2), region String)
     ENGINE = MergeTree ORDER BY sale_id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.items VALUES
     (1, 1, 10.00, 5), (2, 1, 20.00, 3), (3, 1, 30.00, 8),
     (4, 2, 15.00, 2), (5, 2, 25.00, 7), (6, 3, 50.00, 1)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Sale 8 distinguishes correct correlation from inner-scope capture: under
 -- correct per-item correlation its group (item 1) has avg 166.67 so the
 -- 1.5x threshold is 250.00 and sale 8 (250.00) does NOT qualify; under a
 -- capture bug the threshold collapses to the global 1.5*avg = 241.88 and
 -- sale 8 WOULD qualify.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.sales VALUES
     (1, 1, 100.00, 'east'), (2, 1, 150.00, 'west'),
     (3, 2, 200.00, 'east'), (4, 3, 120.00, 'east'),
     (5, 4,  80.00, 'west'), (6, 5, 300.00, 'east'),
     (7, 5,  90.00, 'west'), (8, 1, 250.00, 'east')
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA subplan_test;
 IMPORT FOREIGN SCHEMA subplan_test FROM SERVER subplan_svr INTO subplan_test;
 SET SESSION search_path = subplan_test,public;
@@ -373,21 +345,11 @@ DROP ROLE regress_subplan_nomap;
 --     and a NOT EXISTS poison check for NULLs in the set — each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
     (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
@@ -497,9 +459,4 @@ DETAIL:  drop cascades to foreign table subplan_test.items
 drop cascades to foreign table subplan_test.sales
 DROP USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 DROP SERVER subplan_svr CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE subplan_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE subplan_test');

--- a/test/expected/subplan_pushdown_4.out
+++ b/test/expected/subplan_pushdown_4.out
@@ -10,7 +10,9 @@
 -- correlated / NOT IN SQL we generate), so the whole test aborts on older
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258

--- a/test/expected/subquery_eq.out
+++ b/test/expected/subquery_eq.out
@@ -6,7 +6,9 @@ SET datestyle = 'ISO';
 -- SubPlan pushdown is gated on ClickHouse 25.8+ (older analyzers reject the
 -- correlated SQL we generate), so the whole test aborts on older servers
 -- rather than carry version-specific expected output.
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER sub_eq_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_admin;
+SELECT clickhouse_server_version('sub_eq_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -16,72 +18,42 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER sub_eq_svr FOREIGN DATA WRAPPER clickhouse_fdw
        OPTIONS(dbname 'sub_eq_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE region (
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE IF EXISTS sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', 'CREATE DATABASE sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.region (
         r_regionkey  Int32,
         r_name       String,
         r_comment    String)
     ENGINE = MergeTree ORDER BY (r_regionkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO region
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.region
     VALUES (0,'AFRICA','lar deposits.')
          , (1,'AMERICA','hs use ironic, even requests. s')
          , (2,'ASIA','ges. thinly even pinto beans ca')
          , (3,'EUROPE','ly final courts cajole furiously final excuse')
          , (4,'MIDDLE EAST','quickly special accounts cajole carefully blithely close requests.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+$$);
 -- Create and load TPC-H Tables.
-SELECT clickhouse_raw_query($$
-    CREATE TABLE nation (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.nation (
         n_nationkey  Int32,
         n_name       String,
         n_regionkey  Int32,
         n_comment    String)
     ENGINE = MergeTree ORDER BY (n_nationkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO nation
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.nation
     VALUES (6,'FRANCE',3,'ruefully final requests. regular, ironi')
          , (7,'GERMANY',3,'platelets.')
          , (19,'ROMANIA',3,'asymptotes are about the furious multipliers.')
          , (22,'RUSSIA',3,'requests against the platelets.')
          , (23,'UNITED KINGDOM',3,'means boost carefully special requests.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE part (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.part (
         p_partkey     Int32,
         p_name        String,
         p_mfgr        String,
@@ -92,14 +64,9 @@ SELECT clickhouse_raw_query($$
         p_retailprice Decimal(15,2),
         p_comment     String)
     ENGINE = MergeTree ORDER BY (p_partkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO part
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.part
     VALUES (20428,'chocolate ivory lace aquamarine spring','Manufacturer#4','Brand#43','LARGE BRUSHED BRASS',15,'MED BOX',1348.42,'al foxes. irony')
          , (70284,'slate chartreuse metallic firebrick plum','Manufacturer#4','Brand#44','STANDARD PLATED BRASS',15,'MED BAG',1254.28,'s wake silently a')
          , (73936,'cyan light indian salmon goldenrod','Manufacturer#4','Brand#45','ECONOMY PLATED BRASS',15,'JUMBO DRUM',1909.93,'foxes kin')
@@ -108,14 +75,9 @@ SELECT clickhouse_raw_query($$
          , (109220,'violet snow steel purple turquoise','Manufacturer#4','Brand#41','ECONOMY BURNISHED BRASS',15,'WRAP PACK',1229.22,'cites')
          , (170979,'lawn blue steel burnished cream','Manufacturer#4','Brand#45','PROMO BRUSHED BRASS',15,'MED BAG',2049.97,'are busily')
          , (186694,'chocolate sandy seashell indian forest','Manufacturer#4','Brand#45','PROMO POLISHED BRASS',15,'SM BAG',1780.69,'e the carefully re')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE supplier (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.supplier (
         s_suppkey     Int32,
         s_name        String,
         s_address     String,
@@ -124,14 +86,9 @@ SELECT clickhouse_raw_query($$
         s_acctbal     Decimal(15,2),
         s_comment     String)
     ENGINE = MergeTree ORDER BY (s_suppkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO supplier
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.supplier
     VALUES (1731,'Supplier#000001731','Dqy8LQtY5i8GygrdOC1lt,OVsIgrGoL8Z3PMs',7,'17-115-638-8685',686.5,'lar requests. final, final platelets around the carefully even deposit')
          , (2931,'Supplier#000002931','aUivhoesqMqv0FmJcPBMxBSl8DJvXBGj',7,'17-905-318-3455',555.18,'t the fluffily ironic packages wake furiously')
          , (3113,'Supplier#000003113','HjX8M2Bjlz7pAcLzpyKT9 wNb',7,'17-164-471-2650',-604.88,'he ruthlessly final requests. express requests cajole quick')
@@ -139,28 +96,18 @@ SELECT clickhouse_raw_query($$
          , (3937,'Supplier#000003937','kqEOwdVW,qJsJdcv6PwDJ6ii14mugDK3OgZN ngI',7,'17-621-453-7063',-63.88,'y pending asymptotes. foxes are. deposits sleep quickly b')
          , (5299,'Supplier#000005299','m7Y2G8Pg,kl5AoMPK',7,'17-904-495-9057',-752.27,'. carefully close foxes x-ray. carefully even package')
          , (9733,'Supplier#000009733','XIkUGlZFKq4IiZsAIRxFwzVBw7D',7,'17-789-292-3060',-271.69,'ions. boldly regular requests play furiously. furiously busy')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE partsupp (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.partsupp (
         ps_partkey     Int32,
         ps_suppkey     Int32,
         ps_availqty    Int32,
         ps_supplycost  Decimal(15,2),
         ps_comment     String)
     ENGINE = MergeTree ORDER BY (ps_partkey, ps_suppkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO partsupp
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.partsupp
     VALUES (20428,429,5391,624.88,'among the furiously pending deposits. slyly even instruction')
          , (20428,2931,5672,97.08,'lly final ideas. dolphins are slyly.')
          , (20428,5433,990,457,'ly. carefully regular packages wake never.')
@@ -193,12 +140,7 @@ SELECT clickhouse_raw_query($$
          , (186694,4249,9871,999.65,'all asymptotes cajole furiously ironic, pending dependencies.')
          , (186694,6695,9308,448.14,'serve closely above the even deposits.')
          , (186694,9213,154,593.87,'forges hang furiously pending deposits.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+$$);
 -- Import the foreign tables.
 CREATE SCHEMA sub_eq_test;
 IMPORT FOREIGN SCHEMA sub_eq_test FROM SERVER sub_eq_svr INTO sub_eq_test;
@@ -273,12 +215,7 @@ EXPLAIN (VERBOSE, COSTS OFF) :query2
 (8 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE sub_eq_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
 DROP SERVER sub_eq_svr CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/test/expected/subquery_eq_1.out
+++ b/test/expected/subquery_eq_1.out
@@ -6,7 +6,9 @@ SET datestyle = 'ISO';
 -- SubPlan pushdown is gated on ClickHouse 25.8+ (older analyzers reject the
 -- correlated SQL we generate), so the whole test aborts on older servers
 -- rather than carry version-specific expected output.
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER sub_eq_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_admin;
+SELECT clickhouse_server_version('sub_eq_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -16,72 +18,42 @@ SELECT (split_part(:'ch_version', '.', 1)::int,
 CREATE SERVER sub_eq_svr FOREIGN DATA WRAPPER clickhouse_fdw
        OPTIONS(dbname 'sub_eq_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE region (
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE IF EXISTS sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', 'CREATE DATABASE sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.region (
         r_regionkey  Int32,
         r_name       String,
         r_comment    String)
     ENGINE = MergeTree ORDER BY (r_regionkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO region
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.region
     VALUES (0,'AFRICA','lar deposits.')
          , (1,'AMERICA','hs use ironic, even requests. s')
          , (2,'ASIA','ges. thinly even pinto beans ca')
          , (3,'EUROPE','ly final courts cajole furiously final excuse')
          , (4,'MIDDLE EAST','quickly special accounts cajole carefully blithely close requests.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+$$);
 -- Create and load TPC-H Tables.
-SELECT clickhouse_raw_query($$
-    CREATE TABLE nation (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.nation (
         n_nationkey  Int32,
         n_name       String,
         n_regionkey  Int32,
         n_comment    String)
     ENGINE = MergeTree ORDER BY (n_nationkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO nation
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.nation
     VALUES (6,'FRANCE',3,'ruefully final requests. regular, ironi')
          , (7,'GERMANY',3,'platelets.')
          , (19,'ROMANIA',3,'asymptotes are about the furious multipliers.')
          , (22,'RUSSIA',3,'requests against the platelets.')
          , (23,'UNITED KINGDOM',3,'means boost carefully special requests.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE part (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.part (
         p_partkey     Int32,
         p_name        String,
         p_mfgr        String,
@@ -92,14 +64,9 @@ SELECT clickhouse_raw_query($$
         p_retailprice Decimal(15,2),
         p_comment     String)
     ENGINE = MergeTree ORDER BY (p_partkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO part
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.part
     VALUES (20428,'chocolate ivory lace aquamarine spring','Manufacturer#4','Brand#43','LARGE BRUSHED BRASS',15,'MED BOX',1348.42,'al foxes. irony')
          , (70284,'slate chartreuse metallic firebrick plum','Manufacturer#4','Brand#44','STANDARD PLATED BRASS',15,'MED BAG',1254.28,'s wake silently a')
          , (73936,'cyan light indian salmon goldenrod','Manufacturer#4','Brand#45','ECONOMY PLATED BRASS',15,'JUMBO DRUM',1909.93,'foxes kin')
@@ -108,14 +75,9 @@ SELECT clickhouse_raw_query($$
          , (109220,'violet snow steel purple turquoise','Manufacturer#4','Brand#41','ECONOMY BURNISHED BRASS',15,'WRAP PACK',1229.22,'cites')
          , (170979,'lawn blue steel burnished cream','Manufacturer#4','Brand#45','PROMO BRUSHED BRASS',15,'MED BAG',2049.97,'are busily')
          , (186694,'chocolate sandy seashell indian forest','Manufacturer#4','Brand#45','PROMO POLISHED BRASS',15,'SM BAG',1780.69,'e the carefully re')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE supplier (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.supplier (
         s_suppkey     Int32,
         s_name        String,
         s_address     String,
@@ -124,14 +86,9 @@ SELECT clickhouse_raw_query($$
         s_acctbal     Decimal(15,2),
         s_comment     String)
     ENGINE = MergeTree ORDER BY (s_suppkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO supplier
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.supplier
     VALUES (1731,'Supplier#000001731','Dqy8LQtY5i8GygrdOC1lt,OVsIgrGoL8Z3PMs',7,'17-115-638-8685',686.5,'lar requests. final, final platelets around the carefully even deposit')
          , (2931,'Supplier#000002931','aUivhoesqMqv0FmJcPBMxBSl8DJvXBGj',7,'17-905-318-3455',555.18,'t the fluffily ironic packages wake furiously')
          , (3113,'Supplier#000003113','HjX8M2Bjlz7pAcLzpyKT9 wNb',7,'17-164-471-2650',-604.88,'he ruthlessly final requests. express requests cajole quick')
@@ -139,28 +96,18 @@ SELECT clickhouse_raw_query($$
          , (3937,'Supplier#000003937','kqEOwdVW,qJsJdcv6PwDJ6ii14mugDK3OgZN ngI',7,'17-621-453-7063',-63.88,'y pending asymptotes. foxes are. deposits sleep quickly b')
          , (5299,'Supplier#000005299','m7Y2G8Pg,kl5AoMPK',7,'17-904-495-9057',-752.27,'. carefully close foxes x-ray. carefully even package')
          , (9733,'Supplier#000009733','XIkUGlZFKq4IiZsAIRxFwzVBw7D',7,'17-789-292-3060',-271.69,'ions. boldly regular requests play furiously. furiously busy')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    CREATE TABLE partsupp (
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.partsupp (
         ps_partkey     Int32,
         ps_suppkey     Int32,
         ps_availqty    Int32,
         ps_supplycost  Decimal(15,2),
         ps_comment     String)
     ENGINE = MergeTree ORDER BY (ps_partkey, ps_suppkey);
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
-    INSERT INTO partsupp
+$$);
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.partsupp
     VALUES (20428,429,5391,624.88,'among the furiously pending deposits. slyly even instruction')
          , (20428,2931,5672,97.08,'lly final ideas. dolphins are slyly.')
          , (20428,5433,990,457,'ly. carefully regular packages wake never.')
@@ -193,12 +140,7 @@ SELECT clickhouse_raw_query($$
          , (186694,4249,9871,999.65,'all asymptotes cajole furiously ironic, pending dependencies.')
          , (186694,6695,9308,448.14,'serve closely above the even deposits.')
          , (186694,9213,154,593.87,'forges hang furiously pending deposits.')
-$$, 'dbname=sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+$$);
 -- Import the foreign tables.
 CREATE SCHEMA sub_eq_test;
 IMPORT FOREIGN SCHEMA sub_eq_test FROM SERVER sub_eq_svr INTO sub_eq_test;
@@ -273,12 +215,7 @@ EXPLAIN (VERBOSE, COSTS OFF) :query2
 (8 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE sub_eq_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE sub_eq_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
 DROP SERVER sub_eq_svr CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/test/expected/subquery_eq_2.out
+++ b/test/expected/subquery_eq_2.out
@@ -6,7 +6,9 @@ SET datestyle = 'ISO';
 -- SubPlan pushdown is gated on ClickHouse 25.8+ (older analyzers reject the
 -- correlated SQL we generate), so the whole test aborts on older servers
 -- rather than carry version-specific expected output.
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER sub_eq_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_admin;
+SELECT clickhouse_server_version('sub_eq_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258

--- a/test/expected/subquery_pushdown.out
+++ b/test/expected/subquery_pushdown.out
@@ -3,44 +3,26 @@
 SET datestyle = 'ISO';
 CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER subquery_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_admin;
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE IF EXISTS subquery_test');
+CALL clickhouse_perform('subquery_admin', 'CREATE DATABASE subquery_test');
 -- Create TPC-H orders table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.orders
 	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
 	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
 	ENGINE = MergeTree ORDER BY o_orderkey;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Create TPC-H lineitem table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.lineitem
 	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
 	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
 	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
 	 l_receiptdate Date, l_shipinstruct FixedString(25), l_shipmode FixedString(10), l_comment String)
 	ENGINE = MergeTree ORDER BY (l_orderkey, l_linenumber);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert sample orders data
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.orders VALUES
 	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
 	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
@@ -51,13 +33,8 @@ SELECT clickhouse_raw_query($$
 	(7, 106, 'O', 7000.00, '1993-07-25', '4-NOT SPECIFIED', 'Clerk#000000007', 0, 'order7'),
 	(8, 107, 'O', 8000.00, '1993-08-20', '5-LOW', 'Clerk#000000008', 0, 'order8');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.lineitem VALUES
 	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
 	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
@@ -66,11 +43,6 @@ SELECT clickhouse_raw_query($$
 	(7, 70, 7, 1, 70.00, 700.00, 0.10, 0.05, 'N', 'O', '1993-07-30', '1993-07-25', '1993-08-05', 'DELIVER IN PERSON', 'AIR', 'item7'),
 	(8, 80, 8, 1, 80.00, 800.00, 0.10, 0.05, 'N', 'O', '1993-08-25', '1993-08-30', '1993-08-28', 'DELIVER IN PERSON', 'TRUCK', 'item8');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Create foreign tables (matching TPC-H schema types)
 CREATE SCHEMA subquery_test;
 IMPORT FOREIGN SCHEMA "subquery_test" FROM SERVER subquery_loopback INTO subquery_test;
@@ -161,12 +133,7 @@ ORDER BY o_orderkey;
 (6 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE subquery_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
 DROP SERVER subquery_loopback CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/subquery_pushdown_1.out
+++ b/test/expected/subquery_pushdown_1.out
@@ -3,44 +3,26 @@
 SET datestyle = 'ISO';
 CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CREATE SERVER subquery_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_admin;
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE IF EXISTS subquery_test');
+CALL clickhouse_perform('subquery_admin', 'CREATE DATABASE subquery_test');
 -- Create TPC-H orders table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.orders
 	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
 	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
 	ENGINE = MergeTree ORDER BY o_orderkey;
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Create TPC-H lineitem table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.lineitem
 	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
 	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
 	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
 	 l_receiptdate Date, l_shipinstruct FixedString(25), l_shipmode FixedString(10), l_comment String)
 	ENGINE = MergeTree ORDER BY (l_orderkey, l_linenumber);
 ');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert sample orders data
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.orders VALUES
 	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
 	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
@@ -51,13 +33,8 @@ SELECT clickhouse_raw_query($$
 	(7, 106, 'O', 7000.00, '1993-07-25', '4-NOT SPECIFIED', 'Clerk#000000007', 0, 'order7'),
 	(8, 107, 'O', 8000.00, '1993-08-20', '5-LOW', 'Clerk#000000008', 0, 'order8');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.lineitem VALUES
 	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
 	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
@@ -66,11 +43,6 @@ SELECT clickhouse_raw_query($$
 	(7, 70, 7, 1, 70.00, 700.00, 0.10, 0.05, 'N', 'O', '1993-07-30', '1993-07-25', '1993-08-05', 'DELIVER IN PERSON', 'AIR', 'item7'),
 	(8, 80, 8, 1, 80.00, 800.00, 0.10, 0.05, 'N', 'O', '1993-08-25', '1993-08-30', '1993-08-28', 'DELIVER IN PERSON', 'TRUCK', 'item8');
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Create foreign tables (matching TPC-H schema types)
 CREATE SCHEMA subquery_test;
 IMPORT FOREIGN SCHEMA "subquery_test" FROM SERVER subquery_loopback INTO subquery_test;
@@ -161,12 +133,7 @@ ORDER BY o_orderkey;
 (6 rows)
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE subquery_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
 DROP SERVER subquery_loopback CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/timezone.out
+++ b/test/expected/timezone.out
@@ -6,19 +6,11 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER tz_bin_svr;
 CREATE SERVER tz_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER tz_http_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS tz_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE tz_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER tz_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER tz_admin;
+CALL clickhouse_perform('tz_admin', 'DROP DATABASE IF EXISTS tz_test');
+CALL clickhouse_perform('tz_admin', 'CREATE DATABASE tz_test');
+CALL clickhouse_perform('tz_admin', $$
     CREATE TABLE tz_test.ts (
         id        Int,
         server_ts DateTime,
@@ -27,13 +19,8 @@ SELECT clickhouse_raw_query($$
         lax_ts    DateTime('America/Los_Angeles')
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some records, all times set to 10:00:00 UTC.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('tz_admin', $$
     INSERT INTO tz_test.ts
     SELECT number,
            addMonths(toDateTime('2020-01-01 10:00:00', 'UTC'), number * 3),
@@ -42,22 +29,18 @@ SELECT clickhouse_raw_query($$
            addMonths(toDateTime('2020-01-01 10:00:00', 'UTC'), number * 3)
     FROM numbers(0, 4)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+-- Read as text under UTC, so every column shows the instant that was stored.
+SET session timezone = 'UTC';
+SELECT * FROM clickhouse_query('tz_admin', $$
     SELECT * FROM tz_test.ts ORDER BY id
-$$);
-                                         clickhouse_raw_query                                         
-------------------------------------------------------------------------------------------------------
- 0       2020-01-01T10:00:00Z    2020-01-01T10:00:00Z    2020-01-01T10:00:00Z    2020-01-01T10:00:00Z+
- 1       2020-04-01T10:00:00Z    2020-04-01T10:00:00Z    2020-04-01T10:00:00Z    2020-04-01T10:00:00Z+
- 2       2020-07-01T10:00:00Z    2020-07-01T10:00:00Z    2020-07-01T10:00:00Z    2020-07-01T10:00:00Z+
- 3       2020-10-01T10:00:00Z    2020-10-01T10:00:00Z    2020-10-01T10:00:00Z    2020-10-01T10:00:00Z+
- 
-(1 row)
+$$) AS t(id text, server_ts text, utc_ts text, nyc_ts text, lax_ts text);
+ id |       server_ts        |         utc_ts         |         nyc_ts         |         lax_ts         
+----+------------------------+------------------------+------------------------+------------------------
+ 0  | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00
+ 1  | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00
+ 2  | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00
+ 3  | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00
+(4 rows)
 
 CREATE SCHEMA tz_bin;
 IMPORT FOREIGN SCHEMA tz_test FROM SERVER tz_bin_svr INTO tz_bin;

--- a/test/expected/timezone_1.out
+++ b/test/expected/timezone_1.out
@@ -6,19 +6,11 @@ CREATE USER MAPPING FOR CURRENT_USER SERVER tz_bin_svr;
 CREATE SERVER tz_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER tz_http_svr;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS tz_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE tz_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER tz_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER tz_admin;
+CALL clickhouse_perform('tz_admin', 'DROP DATABASE IF EXISTS tz_test');
+CALL clickhouse_perform('tz_admin', 'CREATE DATABASE tz_test');
+CALL clickhouse_perform('tz_admin', $$
     CREATE TABLE tz_test.ts (
         id        Int,
         server_ts DateTime,
@@ -27,13 +19,8 @@ SELECT clickhouse_raw_query($$
         lax_ts    DateTime('America/Los_Angeles')
     ) ENGINE = MergeTree ORDER BY id
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- Insert some records, all times set to 10:00:00 UTC.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('tz_admin', $$
     INSERT INTO tz_test.ts
     SELECT number,
            addMonths(toDateTime('2020-01-01 10:00:00', 'UTC'), number * 3),
@@ -42,22 +29,18 @@ SELECT clickhouse_raw_query($$
            addMonths(toDateTime('2020-01-01 10:00:00', 'UTC'), number * 3)
     FROM numbers(0, 4)
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+-- Read as text under UTC, so every column shows the instant that was stored.
+SET session timezone = 'UTC';
+SELECT * FROM clickhouse_query('tz_admin', $$
     SELECT * FROM tz_test.ts ORDER BY id
-$$);
-                                         clickhouse_raw_query                                         
-------------------------------------------------------------------------------------------------------
- 0       2020-01-01T10:00:00Z    2020-01-01T10:00:00Z    2020-01-01T10:00:00Z    2020-01-01T10:00:00Z+
- 1       2020-04-01T10:00:00Z    2020-04-01T10:00:00Z    2020-04-01T10:00:00Z    2020-04-01T10:00:00Z+
- 2       2020-07-01T10:00:00Z    2020-07-01T10:00:00Z    2020-07-01T10:00:00Z    2020-07-01T10:00:00Z+
- 3       2020-10-01T10:00:00Z    2020-10-01T10:00:00Z    2020-10-01T10:00:00Z    2020-10-01T10:00:00Z+
- 
-(1 row)
+$$) AS t(id text, server_ts text, utc_ts text, nyc_ts text, lax_ts text);
+ id |       server_ts        |         utc_ts         |         nyc_ts         |         lax_ts         
+----+------------------------+------------------------+------------------------+------------------------
+ 0  | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00 | 2020-01-01 10:00:00+00
+ 1  | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00 | 2020-04-01 10:00:00+00
+ 2  | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00 | 2020-07-01 10:00:00+00
+ 3  | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00 | 2020-10-01 10:00:00+00
+(4 rows)
 
 CREATE SCHEMA tz_bin;
 IMPORT FOREIGN SCHEMA tz_test FROM SERVER tz_bin_svr INTO tz_bin;

--- a/test/expected/where_sub.out
+++ b/test/expected/where_sub.out
@@ -1,30 +1,17 @@
 CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER where_sub_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_admin;
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE IF EXISTS where_sub_test');
+CALL clickhouse_perform('where_sub_admin', 'CREATE DATABASE where_sub_test');
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.orders  (
         id     Int32,
         date   Date,
         class  String
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.lines (
         order_id    Int32,
         num         Int32,
@@ -32,11 +19,6 @@ SELECT clickhouse_raw_query($$
         updated_at  Date
     ) ENGINE = MergeTree ORDER BY (order_id, num);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA where_sub;
 IMPORT FOREIGN SCHEMA "where_sub_test" FROM SERVER where_sub_loopback INTO where_sub;
 -- \d where_sub.orders
@@ -60,12 +42,7 @@ SELECT class, COUNT(*) AS order_count
    Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r3 ON (((r3.created_at < r3.updated_at)) AND ((r1.id = r3.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/where_sub_1.out
+++ b/test/expected/where_sub_1.out
@@ -1,30 +1,17 @@
 CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CREATE SERVER where_sub_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_admin;
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE IF EXISTS where_sub_test');
+CALL clickhouse_perform('where_sub_admin', 'CREATE DATABASE where_sub_test');
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.orders  (
         id     Int32,
         date   Date,
         class  String
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.lines (
         order_id    Int32,
         num         Int32,
@@ -32,11 +19,6 @@ SELECT clickhouse_raw_query($$
         updated_at  Date
     ) ENGINE = MergeTree ORDER BY (order_id, num);
 $$);
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 CREATE SCHEMA where_sub;
 IMPORT FOREIGN SCHEMA "where_sub_test" FROM SERVER where_sub_loopback INTO where_sub;
 -- \d where_sub.orders
@@ -60,12 +42,7 @@ SELECT class, COUNT(*) AS order_count
    Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r2 ON (((r2.created_at < r2.updated_at)) AND ((r1.id = r2.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
 (4 rows)
 
-SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;
 NOTICE:  drop cascades to 2 other objects

--- a/test/expected/window_functions.out
+++ b/test/expected/window_functions.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -377,11 +357,6 @@
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/expected/window_functions_1.out
+++ b/test/expected/window_functions_1.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -370,11 +350,6 @@ DETAIL:  Remote Query: SELECT entity_id, amount, cume_dist() OVER (ORDER BY amou
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/expected/window_functions_2.out
+++ b/test/expected/window_functions_2.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -350,11 +330,6 @@ DETAIL:  Remote Query: SELECT entity_id, amount, cume_dist() OVER (ORDER BY amou
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/expected/window_functions_3.out
+++ b/test/expected/window_functions_3.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -343,11 +323,6 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/expected/window_functions_4.out
+++ b/test/expected/window_functions_4.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -343,11 +323,6 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/expected/window_functions_5.out
+++ b/test/expected/window_functions_5.out
@@ -1,24 +1,4 @@
 \unset ECHO
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
-
 -- ROW_NUMBER pushdown (binary)
            QUERY PLAN            
 ---------------------------------
@@ -336,11 +316,6 @@ DETAIL:  Remote Query: SELECT entity_id, amount, percent_rank() OVER (ORDER BY a
  lead_200  | 2026-03-20 11:00:00+00 |   2 |   2
  lead_300  | 2026-03-05 08:00:00+00 |   1 |   1
 (5 rows)
-
- clickhouse_raw_query 
-----------------------
- 
-(1 row)
 
 NOTICE:  drop cascades to foreign table wf_bin.events
 NOTICE:  drop cascades to foreign table wf_http.events

--- a/test/sql/aggregates.sql
+++ b/test/sql/aggregates.sql
@@ -13,9 +13,12 @@ CREATE SERVER agg_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER agg_http_svr;
 
 -- Create a ClickHouse table to query.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS agg_test');
-SELECT clickhouse_raw_query('CREATE DATABASE agg_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER agg_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER agg_admin;
+
+CALL clickhouse_perform('agg_admin', 'DROP DATABASE IF EXISTS agg_test');
+CALL clickhouse_perform('agg_admin', 'CREATE DATABASE agg_test');
+CALL clickhouse_perform('agg_admin', $$
     CREATE TABLE agg_test.hits (
         id          Int64               NOT NULL,
         uuid        UUID                NOT NULL,
@@ -29,7 +32,7 @@ $$);
 
 /* Queries used to generate the insert values below.
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('agg_admin', $$
     INSERT INTO agg_test.hits
     WITH gen AS (
         SELECT toDateTime64(concat('2025-12-19 10:42:00.', floor(randUniform(0, 999999))), 6, 'UTC') - (rand() % 86400 * 14) AS ts
@@ -44,12 +47,13 @@ SELECT clickhouse_raw_query($$
         cast(randChiSquared(1) * rand() %8+1 AS Decimal(10, 2))
     FROM gen;
 $$);
-SELECT clickhouse_raw_query('select * from agg_test.hits format values');
+SELECT * FROM clickhouse_query('agg_admin',
+    'select * from agg_test.hits format values') AS t(v text);
 
 */
 
 -- Insert data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('agg_admin', $$
     INSERT INTO agg_test.hits VALUES
     (3498231651,'8cab5a51-8927-43f4-8104-b2c81ffc3d8a','2025-12-05 11:51:04.390884','2025-12-05','/users/283434',304,1.29),
     (1431223188,'691a0477-c3fa-404d-a478-d4caaaa24832','2025-12-05 12:22:20.135213','2025-12-05','/users/802683',541,8.38),
@@ -104,14 +108,14 @@ SELECT clickhouse_raw_query($$
 $$);
 
 -- Set up a table with some numeric values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('agg_admin', $$
     CREATE TABLE agg_test.agg_numbers (
         a Int16,
         b Float32
     ) ENGINE = MergeTree ORDER BY (a);
 $$);
  
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('agg_admin', $$
     INSERT INTO agg_test.agg_numbers
     VALUES (56, 7.8)
          , (100, 99.097)

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -1,9 +1,12 @@
 CREATE SERVER arr_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'arr_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER arr_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS arr_test');
-SELECT clickhouse_raw_query('CREATE DATABASE arr_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER arr_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER arr_admin;
+
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE IF EXISTS arr_test');
+CALL clickhouse_perform('arr_admin', 'CREATE DATABASE arr_test');
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.t1 (
         id   Int32,
         vals Array(Int32),
@@ -11,19 +14,19 @@ SELECT clickhouse_raw_query($$
         list String
     ) ENGINE = MergeTree ORDER BY id
 $$);
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     INSERT INTO arr_test.t1 VALUES
         (1, [10,20,30], ['a','b','c'], 'aa-bb-cc'),
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('arr_admin', $$
     CREATE TABLE arr_test.empty_arrays (
         id   Int32,
         vals Array(Int32)
     ) ENGINE = MergeTree ORDER BY id
 $$);
-SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
+CALL clickhouse_perform('arr_admin', 'INSERT INTO arr_test.empty_arrays VALUES (4, [])');
 
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
@@ -47,7 +50,7 @@ SELECT * FROM t1 WHERE array_remove(vals, 20) = ARRAY[10,30];
 -- Use a DO block to test arrayRemove on 26+ only.
 DO $$
 DECLARE
-	chv int[] := regexp_matches(clickhouse_raw_query('SELECT version()'), '^(\d+)\.(\d+)')::int[];
+	chv int[] := regexp_matches(clickhouse_server_version('arr_svr'), '^(\d+)\.(\d+)')::int[];
     result record;
 BEGIN
     IF chv[1] >= 26 THEN
@@ -321,5 +324,5 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE array_fill(7, ARRAY[2], vals
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE string_to_array(list, '/', 'nil') = ARRAY['x','','z'];
 
 DROP USER MAPPING FOR CURRENT_USER SERVER arr_svr;
-SELECT clickhouse_raw_query('DROP DATABASE arr_test');
+CALL clickhouse_perform('arr_admin', 'DROP DATABASE arr_test');
 DROP SERVER arr_svr CASCADE;

--- a/test/sql/binary.sql
+++ b/test/sql/binary.sql
@@ -3,29 +3,32 @@ CREATE SERVER binary_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'binary_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_test');
-SELECT clickhouse_raw_query('CREATE DATABASE binary_test');
+CREATE SERVER binary_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_admin;
+
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE IF EXISTS binary_test');
+CALL clickhouse_perform('binary_admin', 'CREATE DATABASE binary_test');
 
 -- integer types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ints (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Float64, c11 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ints SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2, cast(number % 2 as Bool)
     FROM numbers(10);');
 
 -- date and string types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.types (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -36,51 +39,51 @@ SELECT clickhouse_raw_query('INSERT INTO binary_test.types SELECT
     FROM numbers(10);');
 
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.arrays SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
 
 -- nested arrays
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.nested_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.nested_arrays VALUES
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
 
 -- ragged nested arrays must error: postgres requires hyper-rectangles
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.ragged_arrays (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.tuples (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
     c3 UInt8
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.tuples SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
     number % 2
     FROM numbers(10);');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.bytes (
+CALL clickhouse_perform('binary_admin', 'CREATE TABLE binary_test.bytes (
     c1 Int8,
     c2 String,
     c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO binary_test.bytes SELECT
+CALL clickhouse_perform('binary_admin', 'INSERT INTO binary_test.bytes SELECT
     number,
     SHA1(''val'' || toString(number)),
     MD5(''val'' || toString(number))
@@ -185,16 +188,11 @@ WHERE c3 IN (
 )
 ORDER BY c1;
 
--- clickhouse_raw_query over the binary protocol
-SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
-SELECT clickhouse_raw_query('SELECT number FROM numbers(3) ORDER BY number', 'driver=binary port=9000');
-SELECT clickhouse_raw_query('SELECT [1,2,3] AS arr, (1, ''a'') AS tup', 'driver=binary port=9000');
-SELECT clickhouse_raw_query('SELECT NULL', 'driver=binary port=9000');
-SELECT clickhouse_raw_query('CREATE TABLE binary_test.raw (c1 Int32) ENGINE = Memory', 'driver=binary port=9000');
--- explicit http driver still works
-SELECT clickhouse_raw_query('SELECT 1', 'driver=http port=8123');
 -- unknown driver is rejected
-SELECT clickhouse_raw_query('SELECT 1', 'driver=bogus');
+CREATE SERVER binary_bogus FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS(driver 'bogus');
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_bogus;
+SELECT * FROM clickhouse_query('binary_bogus', 'SELECT 1') AS t(x int);
 
 -- clickhouse_query: server-based typed rowset over the binary driver
 SELECT * FROM clickhouse_query(
@@ -214,10 +212,11 @@ SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1') AS t(x int, y text
 -- mismatch is rejected even when query returns no rows
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT 1 WHERE 0')
     AS t(x int, y text);
--- DDL returns zero columns, required placeholder column list is ignored
-SELECT * FROM clickhouse_query(
+-- DDL returns zero columns, so it runs through clickhouse_perform
+CALL clickhouse_perform(
     'binary_loopback', 'CREATE TABLE ddl (c1 Int32) ENGINE = Memory'
-) AS t(x int);
+);
+-- zero columns returned yields no rows; the statement still ran remotely
 SELECT * FROM clickhouse_query('binary_loopback', 'DROP TABLE ddl') AS t(x int);
 -- value not coercible to the declared type is rejected
 SELECT * FROM clickhouse_query('binary_loopback', 'SELECT ''abc''') AS t(x int);
@@ -276,6 +275,6 @@ DROP TYPE nested_tup, nested_tup_inner;
 \endif
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_test');
+CALL clickhouse_perform('binary_admin', 'DROP DATABASE binary_test');
 
 DROP SERVER binary_loopback CASCADE;

--- a/test/sql/binary_compression.sql
+++ b/test/sql/binary_compression.sql
@@ -1,12 +1,15 @@
 SET datestyle = 'ISO';
 
--- Seed a small table through the http helper (clickhouse_raw_query is http).
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS compression_test');
-SELECT clickhouse_raw_query('CREATE DATABASE compression_test');
-SELECT clickhouse_raw_query('CREATE TABLE compression_test.t (
+-- Seed a small table through the http admin server.
+CREATE SERVER comp_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER comp_admin;
+
+CALL clickhouse_perform('comp_admin', 'DROP DATABASE IF EXISTS compression_test');
+CALL clickhouse_perform('comp_admin', 'CREATE DATABASE compression_test');
+CALL clickhouse_perform('comp_admin', 'CREATE TABLE compression_test.t (
     c1 Int32, c2 String
 ) ENGINE = MergeTree ORDER BY c1;');
-SELECT clickhouse_raw_query('INSERT INTO compression_test.t
+CALL clickhouse_perform('comp_admin', 'INSERT INTO compression_test.t
     SELECT number, format(''row {0}'', toString(number)) FROM numbers(5);');
 
 -- One server, reconfigured per case: ALTER SERVER invalidates the cached
@@ -43,5 +46,5 @@ SELECT * FROM ft ORDER BY c1;
 
 DROP FOREIGN TABLE ft;
 DROP USER MAPPING FOR CURRENT_USER SERVER comp;
-SELECT clickhouse_raw_query('DROP DATABASE compression_test');
+CALL clickhouse_perform('comp_admin', 'DROP DATABASE compression_test');
 DROP SERVER comp CASCADE;

--- a/test/sql/binary_inserts.sql
+++ b/test/sql/binary_inserts.sql
@@ -2,53 +2,56 @@ SET datestyle = 'ISO';
 CREATE SERVER binary_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'binary_inserts_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
 
-SELECT clickhouse_raw_query('drop database if exists binary_inserts_test');
-SELECT clickhouse_raw_query('create database binary_inserts_test');
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.ints (
+CREATE SERVER binary_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_inserts_admin;
+
+CALL clickhouse_perform('binary_inserts_admin', 'drop database if exists binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'create database binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.uints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.floats (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.null_ints (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.complex (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.nested_arrays (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.addr (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.bytes (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
 
-SELECT clickhouse_raw_query('CREATE TABLE binary_inserts_test.not_nullable (
+CALL clickhouse_perform('binary_inserts_admin', 'CREATE TABLE binary_inserts_test.not_nullable (
 	c1 Int8, c2 Nullable(Enum(''x''=1)), c3 Nullable(Enum16(''x''=1)), c4 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree ORDER BY (c1);');
 
@@ -148,7 +151,7 @@ SELECT * FROM bbytes ORDER BY c1;
 -- Nul bytes should truncate TEXT columns.
 SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
-SELECT clickhouse_raw_query('TRUNCATE binary_inserts_test.bytes');
+CALL clickhouse_perform('binary_inserts_admin', 'TRUNCATE binary_inserts_test.bytes');
 
 -- Should fail.
 INSERT INTO bytes
@@ -157,7 +160,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
+CALL clickhouse_perform('binary_inserts_admin', 'ALTER TABLE binary_inserts_test.bytes MODIFY COLUMN c3 String');
 
 -- Should succeed.
 INSERT INTO bytes
@@ -168,7 +171,7 @@ SELECT * FROM bbytes ORDER BY c1;
 SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -212,7 +215,7 @@ INSERT INTO null_vals VALUES(
 SELECT * FROM null_vals;
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('binary_inserts_admin', $$
 	CREATE TABLE binary_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -277,5 +280,5 @@ COPY null_ints (c1, c2) FROM stdin;
 SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_inserts_test');
+CALL clickhouse_perform('binary_inserts_admin', 'DROP DATABASE binary_inserts_test');
 DROP SERVER binary_inserts_loopback CASCADE;

--- a/test/sql/binary_nullable_json.sql
+++ b/test/sql/binary_nullable_json.sql
@@ -2,9 +2,12 @@ CREATE SERVER binary_nullable_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 	OPTIONS(dbname 'binary_nullable_json_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_nullable_json_test');
-SELECT clickhouse_raw_query('CREATE DATABASE binary_nullable_json_test');
-SELECT clickhouse_raw_query('CREATE TABLE binary_nullable_json_test.json_vals (
+CREATE SERVER binary_nullable_json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_admin;
+
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE IF EXISTS binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'CREATE TABLE binary_nullable_json_test.json_vals (
 	c1 Int32, c2 Nullable(JSON)
 ) ENGINE = MergeTree ORDER BY (c1);');
 
@@ -15,5 +18,5 @@ SELECT * FROM json_vals ORDER BY c1;
 
 DROP FOREIGN TABLE json_vals;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_nullable_json_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE binary_nullable_json_test');
+CALL clickhouse_perform('binary_nullable_json_admin', 'DROP DATABASE binary_nullable_json_test');
 DROP SERVER binary_nullable_json_loopback CASCADE;

--- a/test/sql/binary_queries.sql
+++ b/test/sql/binary_queries.sql
@@ -5,17 +5,20 @@ CREATE SERVER binary_queries_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIO
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS binary_queries_test');
-SELECT clickhouse_raw_query('CREATE DATABASE binary_queries_test');
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t1
+CREATE SERVER binary_queries_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER binary_queries_admin;
+
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE IF EXISTS binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
+CALL clickhouse_perform('binary_queries_admin', 'CREATE TABLE binary_queries_test.t4 (c1 Int, c2 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
 
 CREATE SCHEMA binary_queries_test;
@@ -58,7 +61,7 @@ CREATE FOREIGN TABLE ft6 (
 	c3 text
 ) SERVER binary_queries_loopback2 OPTIONS (table_name 't4');
 
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t1
         SELECT number,
                number % 10,
@@ -70,13 +73,13 @@ select clickhouse_raw_query($$
                'foo'
         FROM numbers(1, 110);$$);
 
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t2
         SELECT number,
                concat('AAA', toString(number))
         FROM numbers(1, 100);$$);
 
-select clickhouse_raw_query($$
+CALL clickhouse_perform('binary_queries_admin', $$
     INSERT INTO binary_queries_test.t4
         SELECT number,
                number + 1,
@@ -218,7 +221,7 @@ WHERE t1.c1 < 4
 GROUP BY t4.c1
 ORDER BY t4.c1;
 
-SELECT clickhouse_raw_query('DROP DATABASE binary_queries_test');
+CALL clickhouse_perform('binary_queries_admin', 'DROP DATABASE binary_queries_test');
 
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_queries_loopback;

--- a/test/sql/column_name.sql
+++ b/test/sql/column_name.sql
@@ -11,12 +11,15 @@ CREATE SERVER cn_bin_loopback FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER cn_http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER cn_bin_loopback;
 
-SELECT clickhouse_raw_query('drop database if exists cn_test');
-SELECT clickhouse_raw_query('create database cn_test');
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.t_http (
+CREATE SERVER cn_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER cn_admin;
+
+CALL clickhouse_perform('cn_admin', 'drop database if exists cn_test');
+CALL clickhouse_perform('cn_admin', 'create database cn_test');
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.t_http (
     ch_id Int32, ch_val String, plain Nullable(Int32)
 ) ENGINE = MergeTree ORDER BY (ch_id);');
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.t_bin (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.t_bin (
     ch_id Int32, ch_val String, plain Nullable(Int32)
 ) ENGINE = MergeTree ORDER BY (ch_id);');
 
@@ -51,7 +54,7 @@ SELECT * FROM cn_bin  ORDER BY pg_id;
 
 -- Dropped attnum: forces lazy populator to skip an attisdropped slot when
 -- materializing the cache entry on first INSERT.
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.td (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.td (
     ch_id Int32, ch_val String
 ) ENGINE = MergeTree ORDER BY (ch_id);');
 
@@ -67,7 +70,7 @@ SELECT * FROM cn_drop ORDER BY pg_id;
 
 -- Drop column after the cache is primed by an INSERT and SELECT, to confirm
 -- the ATTNUM syscache invalidation purges stale CustomColumnInfo entries.
-SELECT clickhouse_raw_query('CREATE TABLE cn_test.tlate (
+CALL clickhouse_perform('cn_admin', 'CREATE TABLE cn_test.tlate (
     discarded Nullable(Int32), ch_id Int32, ch_val String
 ) ENGINE = MergeTree ORDER BY (ch_id);');
 
@@ -87,6 +90,6 @@ SELECT * FROM cn_drop_late ORDER BY pg_id;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER cn_http_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER cn_bin_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE cn_test');
+CALL clickhouse_perform('cn_admin', 'DROP DATABASE cn_test');
 DROP SERVER cn_http_loopback CASCADE;
 DROP SERVER cn_bin_loopback CASCADE;

--- a/test/sql/concurrent_scans.sql
+++ b/test/sql/concurrent_scans.sql
@@ -6,12 +6,15 @@ CREATE SERVER concur_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS (dbname 'concur_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS concur_test');
-SELECT clickhouse_raw_query('CREATE DATABASE concur_test');
-SELECT clickhouse_raw_query('CREATE TABLE concur_test.sales (
+CREATE SERVER concur_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER concur_admin;
+
+CALL clickhouse_perform('concur_admin', 'DROP DATABASE IF EXISTS concur_test');
+CALL clickhouse_perform('concur_admin', 'CREATE DATABASE concur_test');
+CALL clickhouse_perform('concur_admin', 'CREATE TABLE concur_test.sales (
     sale_id Int32, item_id Int32, amount Decimal(15, 2)
 ) ENGINE = MergeTree ORDER BY sale_id;');
-SELECT clickhouse_raw_query($$INSERT INTO concur_test.sales VALUES
+CALL clickhouse_perform('concur_admin', $$INSERT INTO concur_test.sales VALUES
     (1, 1, 100), (2, 1, 150), (3, 2, 200), (8, 1, 250)$$);
 
 CREATE SCHEMA concur;
@@ -43,4 +46,4 @@ DROP FOREIGN TABLE concur.sales;
 DROP USER MAPPING FOR CURRENT_USER SERVER concur_loopback;
 DROP SERVER concur_loopback;
 DROP SCHEMA concur;
-SELECT clickhouse_raw_query('DROP DATABASE concur_test');
+CALL clickhouse_perform('concur_admin', 'DROP DATABASE concur_test');

--- a/test/sql/custom_casts.sql
+++ b/test/sql/custom_casts.sql
@@ -2,17 +2,20 @@ CREATE SERVER casts_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'casts_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER casts_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS casts_test');
-SELECT clickhouse_raw_query('CREATE DATABASE casts_test');
+CREATE SERVER casts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER casts_admin;
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('casts_admin', 'DROP DATABASE IF EXISTS casts_test');
+CALL clickhouse_perform('casts_admin', 'CREATE DATABASE casts_test');
+
+CALL clickhouse_perform('casts_admin', $$
 	CREATE TABLE casts_test.things (
         num  integer,
         name text
     ) ENGINE = MergeTree ORDER BY (num);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('casts_admin', $$
 	INSERT INTO casts_test.things
 	SELECT number, toString(number)
 	  FROM numbers(10);
@@ -48,5 +51,5 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT num FROM things WHERE toUint128(name) IN (1,
 SELECT num FROM things WHERE toUint128(name) IN (1, 2, 3);
 
 DROP USER MAPPING FOR CURRENT_USER SERVER casts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE casts_test');
+CALL clickhouse_perform('casts_admin', 'DROP DATABASE casts_test');
 DROP SERVER casts_loopback CASCADE;

--- a/test/sql/decimal.sql
+++ b/test/sql/decimal.sql
@@ -4,8 +4,11 @@ CREATE SERVER http_decimal_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_decimal_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_decimal_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS decimal_test');
-SELECT clickhouse_raw_query('CREATE DATABASE decimal_test');
+CREATE SERVER decimal_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER decimal_admin;
+
+CALL clickhouse_perform('decimal_admin', 'DROP DATABASE IF EXISTS decimal_test');
+CALL clickhouse_perform('decimal_admin', 'CREATE DATABASE decimal_test');
 
 \set ECHO errors
 SELECT split_part(clickhouse_server_version('binary_decimal_loopback'), '.', 1)::int <= 23 AS ch23 \gset
@@ -16,7 +19,7 @@ SELECT split_part(clickhouse_server_version('binary_decimal_loopback'), '.', 1):
 \endif
 \set ECHO all
 
-SELECT clickhouse_raw_query(format($$
+CALL clickhouse_perform('decimal_admin', format($$
     CREATE TABLE decimal_test.decimals (
         id     Int32          NOT NULL,
         dec    Decimal(8, 0)  NOT NULL,
@@ -49,7 +52,7 @@ INSERT INTO dec_http.decimals VALUES
 SELECT * FROM dec_bin.decimals ORDER BY id;
 SELECT * FROM dec_http.decimals ORDER BY id;
 
-SELECT clickhouse_raw_query('DROP DATABASE decimal_test');
+CALL clickhouse_perform('decimal_admin', 'DROP DATABASE decimal_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_decimal_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_decimal_loopback;
 DROP SERVER binary_decimal_loopback CASCADE;

--- a/test/sql/deparse_checks.sql
+++ b/test/sql/deparse_checks.sql
@@ -1,14 +1,17 @@
 CREATE SERVER deparse_lookback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'deparse_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
 
-SELECT clickhouse_raw_query('drop database if exists deparse_test');
-SELECT clickhouse_raw_query('create database deparse_test');
-SELECT clickhouse_raw_query('
+CREATE SERVER deparse_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER deparse_admin;
+
+CALL clickhouse_perform('deparse_admin', 'drop database if exists deparse_test');
+CALL clickhouse_perform('deparse_admin', 'create database deparse_test');
+CALL clickhouse_perform('deparse_admin', '
 	create table deparse_test.t1 (a int, b Int8)
 	engine = MergeTree()
 	order by a');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('deparse_admin', '
 	insert into deparse_test.t1 select number % 10, number % 10 > 5 from numbers(1, 100);');
 
 CREATE SCHEMA deparse_test;
@@ -26,5 +29,5 @@ SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
 SELECT * FROM t1 ORDER BY a NULLS FIRST, b LIMIT 3;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER deparse_lookback;
-SELECT clickhouse_raw_query('DROP DATABASE deparse_test');
+CALL clickhouse_perform('deparse_admin', 'DROP DATABASE deparse_test');
 DROP SERVER deparse_lookback CASCADE;

--- a/test/sql/docs_offload_partition.sql
+++ b/test/sql/docs_offload_partition.sql
@@ -10,8 +10,11 @@ CREATE SERVER offload_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'offload_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER offload_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS offload_test');
-SELECT clickhouse_raw_query('CREATE DATABASE offload_test');
+CREATE SERVER offload_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER offload_admin;
+
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE IF EXISTS offload_test');
+CALL clickhouse_perform('offload_admin', 'CREATE DATABASE offload_test');
 
 -- Load documented helpers without echoing their bodies; round-trips below guard
 -- against drift, a parse error still surfaces
@@ -102,5 +105,5 @@ DROP TABLE offload_events, offload_plain, offload_badcol, offload_bylist,
 DROP FUNCTION clickhouse_offload_range(regclass, regclass[], name, text, text, name);
 DROP FUNCTION clickhouse_offload_create_table(regclass, name, text, text, text);
 DROP USER MAPPING FOR CURRENT_USER SERVER offload_svr;
-SELECT clickhouse_raw_query('DROP DATABASE offload_test');
+CALL clickhouse_perform('offload_admin', 'DROP DATABASE offload_test');
 DROP SERVER offload_svr CASCADE;

--- a/test/sql/engine_args.sql
+++ b/test/sql/engine_args.sql
@@ -2,9 +2,12 @@ CREATE SERVER engine_args_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'engine_args_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER engine_args_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS engine_args_test');
-SELECT clickhouse_raw_query('CREATE DATABASE engine_args_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER engine_args_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER engine_args_admin;
+
+CALL clickhouse_perform('engine_args_admin', 'DROP DATABASE IF EXISTS engine_args_test');
+CALL clickhouse_perform('engine_args_admin', 'CREATE DATABASE engine_args_test');
+CALL clickhouse_perform('engine_args_admin', $$
 	CREATE TABLE engine_args_test.innocuous (
         id UInt32,
         value String
@@ -13,19 +16,19 @@ SELECT clickhouse_raw_query($$
 	ORDER BY id
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     INSERT INTO engine_args_test.innocuous
     VALUES (1, 'public'), (2, 'data'), (3, 'here')
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     CREATE TABLE IF NOT EXISTS engine_args_test.sensitive (
         id UInt32,
         password String
     ) ENGINE=MergeTree() ORDER BY id;
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('engine_args_admin', $$
     INSERT INTO engine_args_test.sensitive
     VALUES (1, 'admin123'), (2, 'password!')
 $$);
@@ -190,6 +193,6 @@ OPTIONS (
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(id) FROM engine_args_test.name_var9;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engine_args_svr;
-SELECT clickhouse_raw_query('DROP DATABASE engine_args_test');
+CALL clickhouse_perform('engine_args_admin', 'DROP DATABASE engine_args_test');
 
 DROP SERVER engine_args_svr CASCADE;

--- a/test/sql/engines.sql
+++ b/test/sql/engines.sql
@@ -1,44 +1,47 @@
 CREATE SERVER engines_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'engines_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
 
-SELECT clickhouse_raw_query('drop database if exists engines_test');
-SELECT clickhouse_raw_query('create database engines_test');
-SELECT clickhouse_raw_query('
+CREATE SERVER engines_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER engines_admin;
+
+CALL clickhouse_perform('engines_admin', 'drop database if exists engines_test');
+CALL clickhouse_perform('engines_admin', 'create database engines_test');
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t1 (a int, b int)
 	engine = MergeTree()
 	order by a');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t2 (a int, b AggregateFunction(sum, Int32))
 	engine = AggregatingMergeTree()
 	order by a');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t3 (a int, b Array(Int32), c Array(Int32))
 	engine = MergeTree()
 	order by a');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t1 select number % 10, number from numbers(1, 100);');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t2 select number % 10 as a, sumState(toInt32(number)) as b from numbers(1, 100) group by a;');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	insert into engines_test.t3 select number % 10,
 		[1, number % 10 + 1], [1, 1] from numbers(1, 100);');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t1_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumState(b) as b from engines_test.t1 group by a;');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create materialized view engines_test.t3_aggr
 		engine=AggregatingMergeTree()
 		order by a populate as select a, sumMapState(b, c) as b from engines_test.t3 group by a;');
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('engines_admin', '
 	create table engines_test.t4 (a int,
 		b AggregateFunction(sum, Int32),
 		c AggregateFunction(sumMap, Array(Int32), Array(Int32)),
@@ -77,5 +80,5 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER
 EXPLAIN (VERBOSE, COSTS OFF) SELECT a, percentile_disc(0.75) WITHIN GROUP (ORDER BY f) / sum(d) FROM t4 GROUP BY a;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER engines_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE engines_test');
+CALL clickhouse_perform('engines_admin', 'DROP DATABASE engines_test');
 DROP SERVER engines_loopback CASCADE;

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -6,14 +6,17 @@ CREATE SERVER functions_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'functions_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS functions_test');
-SELECT clickhouse_raw_query('CREATE DATABASE functions_test');
+CREATE SERVER functions_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER functions_admin;
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE IF EXISTS functions_test');
+CALL clickhouse_perform('functions_admin', 'CREATE DATABASE functions_test');
+
+CALL clickhouse_perform('functions_admin', $$
 	CREATE TABLE functions_test.t1 (a int, b int, c DateTime) ENGINE = MergeTree ORDER BY (a);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t1 VALUES
 		(1, 1, '2019-01-01 10:00:00'),
 		(2, 2, '2019-01-02 10:00:00'),
@@ -21,23 +24,23 @@ SELECT clickhouse_raw_query($$
 		(2, 3, '2019-01-02 10:00:00')
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	drop dictionary if exists functions_test.t3_dict
 $$);
 
-SELECT clickhouse_raw_query('
+CALL clickhouse_perform('functions_admin', '
 	create table functions_test.t3 (a Int32, b Nullable(Int32))
 	engine = MergeTree()
 	order by a');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t3_map (key1 Int32, key2 String,
         val String) engine=TinyLog();');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
-SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t4 (val String) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+CALL clickhouse_perform('functions_admin', 'CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
 		('2026-11-16T32:13:26'),
@@ -47,7 +50,7 @@ SELECT clickhouse_raw_query($$
 		('2030-03-20T02:16:30')
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t7 VALUES
 		('2025-10-15'),
 		('2024-11-16'),
@@ -57,7 +60,7 @@ SELECT clickhouse_raw_query($$
 		('2020-03-20')
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t8 VALUES
 		('2026-08-02T12:00:00'),
 		('2026-08-03T12:00:00'),
@@ -68,7 +71,7 @@ SELECT clickhouse_raw_query($$
 		('2026-08-08T12:00:00')
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -86,25 +89,25 @@ CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
 CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
 	  FROM numbers(10);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t3_map
 	SELECT toString(number+1), 'key' || toString(number+1), 'val' || toString(number+1)
 	  FROM numbers(10);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	INSERT INTO functions_test.t4
 	SELECT 'val' || toString(number+1)
 	  FROM numbers(2);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
 	create dictionary functions_test.t3_dict
     (key1 Int32, key2 String, val String)
     primary key key1, key2
@@ -410,7 +413,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE date_trunc('day', c) > date_
 DO $$
 DECLARE
 	-- Capture the CLickHouse major an minor version parse.
-	chv int[] := regexp_matches(clickhouse_raw_query('SELECT version()'), '^(\d+)\.(\d+)')::int[];
+	chv int[] := regexp_matches(clickhouse_server_version('functions_loopback'), '^(\d+)\.(\d+)')::int[];
 	opt TEXT = '';
 	output JSONB;
     result record;
@@ -421,10 +424,10 @@ BEGIN
 			opt := ' SETTINGS enable_time_time64_type = 1';
 		END IF;
 		-- Set up a foreign table mapping timetz to Time64.
-		PERFORM clickhouse_raw_query(
+		CALL clickhouse_perform('functions_admin',
 			'CREATE TABLE functions_test.times (t64 Time64) engine=TinyLog()' || opt
 		);
-		PERFORM clickhouse_raw_query($q$
+		CALL clickhouse_perform('functions_admin', $q$
 			INSERT INTO functions_test.times
 			VALUES ('16:14:50.922787819'),
 				   ('00:00:00'),
@@ -583,7 +586,7 @@ SELECT to_char(ts, t4.val) FROM t5, t4 LIMIT 1;
 
 -- reverse pushes down as reverseUTF8 to preserve code-point order on
 -- multi-byte input
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('Ωαβ'), ('hello')
 $$);
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -690,7 +693,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT i64 FROM t6 WHERE f64 < pi();
 
 -- lower(text) / upper(text) push down as lowerUTF8 / upperUTF8.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES ('VAL3'), ('Mixed')
 $$);
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -785,7 +788,7 @@ SELECT val FROM t4 WHERE encode(val::bytea, val) = val;
 -- a trailing newline, 60 wraps once mid-string. Matching the pushed-down base64
 -- against PG's own MIME output of the same bytes confirms they agree
 -- byte-for-byte.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('functions_admin', $$
     INSERT INTO functions_test.t4 VALUES (repeat('a', 57)), (repeat('a', 60))
 $$);
 SELECT octet_length(val) AS n FROM t4
@@ -812,5 +815,5 @@ WHERE encode(val::bytea, 'base64url') IN (
 \endif
 
 DROP USER MAPPING FOR CURRENT_USER SERVER functions_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE functions_test');
+CALL clickhouse_perform('functions_admin', 'DROP DATABASE functions_test');
 DROP SERVER functions_loopback CASCADE;

--- a/test/sql/http.sql
+++ b/test/sql/http.sql
@@ -5,25 +5,28 @@ CREATE SERVER http_loopback2 FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS http_test');
-SELECT clickhouse_raw_query('CREATE DATABASE http_test', '');
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t1
+CREATE SERVER http_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_admin;
+
+CALL clickhouse_perform('http_admin', 'DROP DATABASE IF EXISTS http_test');
+CALL clickhouse_perform('http_admin', 'CREATE DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t1
 	(c1 Int, c2 Int, c3 String, c4 Date, c5 Date, c6 String, c7 String, c8 String)
 	ENGINE = MergeTree PARTITION BY c4 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t2 (c1 Int, c2 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t2 (c1 Int, c2 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t3 (c1 Int, c3 String)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t3 (c1 Int, c3 String)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t4 (c1 Int, c2 Int, c3 String, c4 Bool)
 	ENGINE = MergeTree PARTITION BY c1 % 10000 ORDER BY (c1);');
-SELECT clickhouse_raw_query('
-	CREATE TABLE tcopy
+CALL clickhouse_perform('http_admin', '
+	CREATE TABLE http_test.tcopy
 		(c1 Int32, c2 Int64, c3 Date, c4 Nullable(DateTime), c5 DateTime, c6 String)
 	ENGINE = MergeTree
 	PARTITION BY c3
 	ORDER BY (c1, c2, c3);
-', 'dbname=http_test');
+');
 
 CREATE FOREIGN TABLE ft1 (
 	c0 int,
@@ -237,9 +240,6 @@ SELECT COUNT(DISTINCT c1) FROM ft2;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT COUNT(DISTINCT c1) FILTER (WHERE c1 < 20) FROM ft2;
 
 /* Disallow line endings in database names. */
-SELECT clickhouse_raw_query('SELECT 1', E'dbname=''http_test\r\nX-My-Header: 123''');
--- SELECT clickhouse_raw_query('SELECT 1', E$$dbname='test\rX-My-Header: 123'$$);
-
 CREATE SERVER http_loopback_bad FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname E'http_test\r\nX-My-Header: 123');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 
@@ -265,7 +265,7 @@ DROP SERVER http_bad_fetch;
  * Native names the column type on the wire, so a String value like `[foo]bar`
  * stays text instead of reading as a CH array literal.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk
     (id String, term String) ENGINE = MergeTree ORDER BY id');
 
 CREATE FOREIGN TABLE ft_brk (id text, term text)
@@ -285,7 +285,7 @@ SELECT id, term FROM ft_brk ORDER BY id;
  * Mixed row: real Array(String) column alongside a String column whose value
  * starts with `[`. The parser must stay in sync across columns.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_brk_mix
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_brk_mix
     (id String, tags Array(String), term String) ENGINE = MergeTree ORDER BY id');
 
 CREATE FOREIGN TABLE ft_brk_mix (id text, tags text[], term text)
@@ -302,9 +302,9 @@ SELECT id, tags, term FROM ft_brk_mix ORDER BY id;
  * whose unescaped content happens to start with `\N` (or be exactly `\N`)
  * must not be misread as NULL.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_nullmark
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_nullmark
     (id String, s String) ENGINE = MergeTree ORDER BY id');
-SELECT clickhouse_raw_query(
+CALL clickhouse_perform('http_admin', 
     'INSERT INTO http_test.t_nullmark VALUES'
     || ' (''1'', ''\\N''),'             /* exactly the 2-char NULL marker as data */
     || ' (''2'', ''\\N foo bar''),'     /* starts with \N */
@@ -321,9 +321,9 @@ FROM ft_nullmark ORDER BY id;
  * bytea columns take raw bytes without the input function. NULL maps to SQL
  * NULL, empty string stays empty, embedded zero bytes survive.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_bytea
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_bytea
     (id String, v Nullable(String)) ENGINE = MergeTree ORDER BY id');
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_bytea VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_bytea VALUES
     (''1'', NULL),
     (''2'', ''''),
     (''3'', char(97, 0, 98)),
@@ -339,9 +339,9 @@ SELECT id, v, v IS NULL AS is_null, octet_length(v) FROM ft_bytea ORDER BY id;
  * unchanged, so an ISO timestamp is rejected rather than trimmed to its time
  * of day.
  */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.t_timestr
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.t_timestr
     (id String, v String) ENGINE = MergeTree ORDER BY id');
-SELECT clickhouse_raw_query('INSERT INTO http_test.t_timestr VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.t_timestr VALUES
     (''1'', ''Z''),
     (''2'', ''xZ''),
     (''3'', ''1970-01-01T00:00:00Z'')');
@@ -355,20 +355,20 @@ SELECT v FROM ft_timestr WHERE id = '2';
 
 /* nested arrays via http: rectangular maps to multi-dim, jagged shapes are
  * rejected -- matching the binary path. */
-SELECT clickhouse_raw_query('CREATE TABLE http_test.nested_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.nested_arrays (
     c1 Int8, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO http_test.nested_arrays VALUES
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.nested_arrays VALUES
     (1, [[1,2],[3,4]], [[''a'',''b''],[''c'',''d'']]),
     (2, [[5,6],[7,8]], [[''e'',''f''],[''g'',''h'']]);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_test.ragged_arrays (
+CALL clickhouse_perform('http_admin', 'CREATE TABLE http_test.ragged_arrays (
     c1 Int8, c2 Array(Array(Int32))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
+CALL clickhouse_perform('http_admin', 'INSERT INTO http_test.ragged_arrays VALUES (1, [[1,2,3],[4]]);');
 
 CREATE FOREIGN TABLE ft_nested_arrays (
     c1 int2,
@@ -456,7 +456,7 @@ CREATE SERVER http_min_tls_bad FOREIGN DATA WRAPPER clickhouse_fdw
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback_bad;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback2;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_test');
+CALL clickhouse_perform('http_admin', 'DROP DATABASE http_test');
 DROP SERVER http_loopback_bad CASCADE;
 DROP SERVER http_loopback2 CASCADE;
 DROP SERVER http_loopback CASCADE;

--- a/test/sql/http_inserts.sql
+++ b/test/sql/http_inserts.sql
@@ -2,49 +2,52 @@ SET datestyle = 'ISO';
 CREATE SERVER http_inserts_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'http_inserts_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
 
-SELECT clickhouse_raw_query('drop database if exists http_inserts_test');
-SELECT clickhouse_raw_query('create database http_inserts_test');
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.ints (
+CREATE SERVER http_inserts_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER http_inserts_admin;
+
+CALL clickhouse_perform('http_inserts_admin', 'drop database if exists http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'create database http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.uints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.uints (
     c1 UInt8, c2 UInt16, c3 UInt32, c4 UInt64, c5 Bool
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.floats (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.floats (
     c1 Float32, c2 Float64
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.null_ints (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.null_ints (
     c1 Int8, c2 Nullable(Int32)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.complex (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.complex (
     c1 Int32, c2 Date, c3 DateTime, c4 String, c5 FixedString(10), c6 LowCardinality(String), c7 Date32, c8 DateTime64(3)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.arrays (
     c1 Int32, c2 Array(Int32), c3 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.nested_arrays (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.nested_arrays (
     c1 Int32, c2 Array(Array(Int32)), c3 Array(Array(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.addr (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.addr (
     c1 UUID, c2 IPv4, c3 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
 
-SELECT clickhouse_raw_query('CREATE TABLE http_inserts_test.bytes (
+CALL clickhouse_perform('http_inserts_admin', 'CREATE TABLE http_inserts_test.bytes (
 	c1 Int8, c2 String, c3 FixedString(16)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);');
 
@@ -141,7 +144,7 @@ SELECT * FROM bbytes ORDER BY c1;
 -- Nul bytes should truncate TEXT columns.
 SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
-SELECT clickhouse_raw_query('TRUNCATE http_inserts_test.bytes');
+CALL clickhouse_perform('http_inserts_admin', 'TRUNCATE http_inserts_test.bytes');
 
 -- Should fail.
 INSERT INTO bytes
@@ -150,7 +153,7 @@ SELECT n, sha224(bytea('val'||n)), decode(md5('int'||n), 'hex')
 
 -- Remove FixedString length.
 ALTER FOREIGN TABLE bytes ALTER c3 TYPE TEXT;
-SELECT clickhouse_raw_query('ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
+CALL clickhouse_perform('http_inserts_admin', 'ALTER TABLE http_inserts_test.bytes MODIFY COLUMN c3 String');
 
 -- Should succeed.
 INSERT INTO bytes
@@ -161,7 +164,7 @@ SELECT * FROM bbytes ORDER BY c1;
 SELECT c1, encode(c2::bytea, 'hex'), encode(c3::bytea, 'hex') FROM bytes ORDER BY c1;
 
 -- Test NULL values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.null_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -206,7 +209,7 @@ INSERT INTO null_vals VALUES(
 SELECT * FROM null_vals;
 
 -- Test default values.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('http_inserts_admin', $$
 	CREATE TABLE http_inserts_test.default_vals (
 		c1 UInt8,
 		-- INT2OID
@@ -265,5 +268,5 @@ COPY null_ints (c1, c2) FROM stdin;
 SELECT * FROM null_ints WHERE c1 >= 20 ORDER BY c1;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER http_inserts_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE http_inserts_test');
+CALL clickhouse_perform('http_inserts_admin', 'DROP DATABASE http_inserts_test');
 DROP SERVER http_inserts_loopback CASCADE;

--- a/test/sql/ilike_regex.sql
+++ b/test/sql/ilike_regex.sql
@@ -9,10 +9,13 @@ CREATE SERVER ilike_regex_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'ilike_regex_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS ilike_regex_test');
-SELECT clickhouse_raw_query('CREATE DATABASE ilike_regex_test');
+CREATE SERVER ilike_regex_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER ilike_regex_admin;
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE IF EXISTS ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', 'CREATE DATABASE ilike_regex_test');
+
+CALL clickhouse_perform('ilike_regex_admin', $$
     CREATE TABLE ilike_regex_test.events (
         id     Int32,
         name   String,
@@ -20,7 +23,7 @@ SELECT clickhouse_raw_query($$
     ) ENGINE = MergeTree ORDER BY id
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('ilike_regex_admin', $$
     INSERT INTO ilike_regex_test.events VALUES
         (1, 'page_view',   '/users/profile'),
         (2, 'Page_View',   '/users/settings'),
@@ -157,7 +160,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name ~* 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM ilike_regex_bin.events WHERE name !~* '^page' ORDER BY id;
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE ilike_regex_test');
+CALL clickhouse_perform('ilike_regex_admin', 'DROP DATABASE ilike_regex_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_bin_svr;
 DROP USER MAPPING FOR CURRENT_USER SERVER ilike_regex_http_svr;
 DROP SERVER ilike_regex_bin_svr CASCADE;

--- a/test/sql/import_schema.sql
+++ b/test/sql/import_schema.sql
@@ -10,26 +10,29 @@ CREATE SCHEMA clickhouse_except;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test');
-SELECT clickhouse_raw_query('CREATE DATABASE import_test');
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS import_test_2');
-SELECT clickhouse_raw_query('CREATE DATABASE import_test_2');
+CREATE SERVER import_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER import_admin;
+
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE IF EXISTS import_test_2');
+CALL clickhouse_perform('import_admin', 'CREATE DATABASE import_test_2');
 
 -- numeric types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ints (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ints (
     c1 Int8, c2 Int16, c3 Int32, c4 Int64,
     c5 UInt8, c6 UInt16, c7 UInt32, c8 UInt64,
     c9 Float32, c10 Nullable(Float64)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, number + 9.2 FROM numbers(10);');
-SELECT clickhouse_raw_query('INSERT INTO import_test.ints SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.ints SELECT
     number, number + 1, number + 2, number + 3, number + 4, number + 5,
     number + 6, number + 7, number + 8.1, NULL FROM numbers(10, 2);');
 
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types (
     c1 Date, c2 DateTime, c3 String, c4 FixedString(5), c5 UUID,
     c6 Enum8(''one'' = 1, ''two'' = 2),
     c7 Enum16(''one'' = 1, ''two'' = 2, ''three'' = 3),
@@ -37,7 +40,7 @@ SELECT clickhouse_raw_query('CREATE TABLE import_test.types (
     c8 LowCardinality(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types SELECT
     addDays(toDate(''1990-01-01''), number),
     addMinutes(addSeconds(addDays(toDateTime(''1990-01-01 10:00:00'', ''UTC''), number), number), number),
     format(''number {0}'', toString(number)),
@@ -49,20 +52,20 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.types SELECT
     format(''cardinal {0}'', toString(number))
     FROM numbers(10);');
 
-SELECT clickhouse_raw_query('CREATE TABLE import_test.types2 (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.types2 (
     c1 LowCardinality(Nullable(String))
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_nullable_key = 1;
 ');
-SELECT clickhouse_raw_query('INSERT INTO import_test.types2 SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.types2 SELECT
     format(''cardinal {0}'', toString(number + 1))
     FROM numbers(10);');
 
-SELECT clickhouse_raw_query('CREATE TABLE import_test.ip (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.ip (
     c1 IPv4,
     c2 IPv6
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ip VALUES
     ('116.106.34.242', '2001:44c8:129:2632:33:0:252:2'),
     ('116.106.34.243', '2a02:e980:1e::1'),
@@ -70,24 +73,24 @@ SELECT clickhouse_raw_query($$
 $$);
 
 -- array types
-SELECT clickhouse_raw_query('CREATE TABLE import_test.arrays (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.arrays (
     c1 Array(Int), c2 Array(String)
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO import_test.arrays SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.arrays SELECT
     [number, number + 1],
     [format(''num{0}'', toString(number)), format(''num{0}'', toString(number + 1))]
     FROM numbers(10);');
 
 -- tuple
-SELECT clickhouse_raw_query('CREATE TABLE import_test.tuples (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.tuples (
     c1 Int8,
     c2 Tuple(Int, String, Float32),
 	c3 Nested(a Int, b Int),
 	c4 Int16
 ) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
 ');
-SELECT clickhouse_raw_query('INSERT INTO import_test.tuples SELECT
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.tuples SELECT
     number,
     (number, toString(number), number + 1.0),
 	[toInt32(number),1,1],
@@ -96,20 +99,20 @@ SELECT clickhouse_raw_query('INSERT INTO import_test.tuples SELECT
     FROM numbers(10);');
 
 -- datetime with timezones
-SELECT clickhouse_raw_query('CREATE TABLE import_test.timezones (
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test.timezones (
 	t1 DateTime64(6,''UTC''),
 	t2 DateTime64(6,''Europe/Berlin''),
 	t4 DateTime(''Europe/Berlin''),
 	t5 DateTime64(6))
 	ENGINE = MergeTree ORDER BY (t1) SETTINGS index_granularity=8192;');
 
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'',
 	''2020-01-01 11:00:00'')');
 
-SELECT clickhouse_raw_query('INSERT INTO import_test.timezones VALUES (
+CALL clickhouse_perform('import_admin', 'INSERT INTO import_test.timezones VALUES (
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
 	''2020-01-01 12:00:00'',
@@ -171,7 +174,7 @@ IMPORT FOREIGN SCHEMA "import_test" EXCEPT (ints, types) FROM SERVER import_loop
 \d+ clickhouse_except.tuples;
 
 -- check custom database
-SELECT clickhouse_raw_query('CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
+CALL clickhouse_perform('import_admin', 'CREATE TABLE import_test_2.custom_option (a Int64) ENGINE = MergeTree ORDER BY (a)');
 IMPORT FOREIGN SCHEMA "import_test_2" FROM SERVER import_loopback INTO clickhouse;
 
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
@@ -179,7 +182,7 @@ ALTER FOREIGN TABLE clickhouse.custom_option OPTIONS (DROP database);
 EXPLAIN VERBOSE SELECT * FROM clickhouse.custom_option;
 
 -- check overflows.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('import_admin', $$
     INSERT INTO import_test.ints (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) VALUES
     (
         -- Min values
@@ -195,11 +198,13 @@ SELECT clickhouse_raw_query($$
     )
 $$);
 
-SELECT clickhouse_raw_query($$
-    SELECT * FROM import_test.ints
+SELECT * FROM clickhouse_query('import_admin', $$
+    SELECT c1, c2, c3, c4, c5, c6, c7, c9, c10
+    FROM import_test.ints
     WHERE c1 IN (127, -128)
     ORDER BY c1;
-$$);
+$$) AS t(c1 text, c2 text, c3 text, c4 text, c5 text,
+         c6 text, c7 text, c9 text, c10 text);
 
 -- Error on 18446744073709551615.
 SELECT * FROM clickhouse_bin.ints
@@ -228,7 +233,7 @@ ORDER BY c1;
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER import_loopback_bin;
 
-SELECT clickhouse_raw_query('DROP DATABASE import_test');
-SELECT clickhouse_raw_query('DROP DATABASE import_test_2');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test');
+CALL clickhouse_perform('import_admin', 'DROP DATABASE import_test_2');
 DROP SERVER import_loopback_bin CASCADE;
 DROP SERVER import_loopback CASCADE;

--- a/test/sql/in_null_semantics.sql
+++ b/test/sql/in_null_semantics.sql
@@ -14,15 +14,18 @@ CREATE SERVER in_null_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'in_null_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS in_null_test');
-SELECT clickhouse_raw_query('CREATE DATABASE in_null_test');
+CREATE SERVER in_null_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER in_null_admin;
+
+CALL clickhouse_perform('in_null_admin', 'DROP DATABASE IF EXISTS in_null_test');
+CALL clickhouse_perform('in_null_admin', 'CREATE DATABASE in_null_test');
 
 -- xn imports as a plain (nullable) int column, xp as int NOT NULL, and arr
 -- as int[]; its elements' nullability is never provable at plan time
-SELECT clickhouse_raw_query('CREATE TABLE in_null_test.tnull
+CALL clickhouse_perform('in_null_admin', 'CREATE TABLE in_null_test.tnull
     (id Int32, xn Nullable(Int32), xp Int32, arr Array(Int32))
     ENGINE = MergeTree ORDER BY id');
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('in_null_admin', $$
     INSERT INTO in_null_test.tnull
     VALUES (1, 1, 1, [1, 500]), (2, 2, 2, [500]), (3, NULL, 3, [])
 $$);
@@ -219,6 +222,6 @@ ORDER BY id;
 -- Cleanup
 SET SESSION search_path = public;
 DROP SCHEMA in_null_test CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE in_null_test');
+CALL clickhouse_perform('in_null_admin', 'DROP DATABASE in_null_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER in_null_svr;
 DROP SERVER in_null_svr;

--- a/test/sql/json.sql
+++ b/test/sql/json.sql
@@ -4,9 +4,12 @@ CREATE SERVER http_json_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbn
 CREATE USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 CREATE USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS json_test');
-SELECT clickhouse_raw_query('CREATE DATABASE json_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER json_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER json_admin;
+
+CALL clickhouse_perform('json_admin', 'DROP DATABASE IF EXISTS json_test');
+CALL clickhouse_perform('json_admin', 'CREATE DATABASE json_test');
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.things (
         id   Int32 NOT NULL,
         data JSON NOT NULL
@@ -296,7 +299,7 @@ SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 SELECT * FROM json_bin.things WHERE (data -> 'name')::text = '"widget"';
 
 -- Edge cases: JSON keys that require identifier quoting.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.special_keys (
         id   Int32 NOT NULL,
         data JSON NOT NULL
@@ -479,14 +482,14 @@ SELECT * FROM json_bin.json_special_keys WHERE data ->> '123numeric' = 'num';
 -- =======================================================================
 
 -- Create a table with nested JSON for multi-level path tests.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     CREATE TABLE json_test.events (
         id         UInt32,
         event_name String,
         props      JSON
     ) ENGINE = MergeTree ORDER BY (event_name, id);
 $$);
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('json_admin', $$
     INSERT INTO json_test.events VALUES
         (1, 'order', '{"customerId": "C100", "address": {"city": "Paris", "zip": "75001"}}'),
         (2, 'order', '{"customerId": "C200", "address": {"city": "London", "zip": "SW1A"}}');
@@ -638,7 +641,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM json_http.json_events
 WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
 
-SELECT clickhouse_raw_query('DROP DATABASE json_test');
+CALL clickhouse_perform('json_admin', 'DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;
 DROP USER MAPPING FOR CURRENT_USER SERVER http_json_loopback;
 DROP SERVER binary_json_loopback CASCADE;

--- a/test/sql/param.sql
+++ b/test/sql/param.sql
@@ -9,9 +9,12 @@ CREATE SERVER param_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER param_http_svr;
 
 -- Create the schema in ClickHouse.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS param_test');
-SELECT clickhouse_raw_query('CREATE DATABASE param_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER param_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER param_admin;
+
+CALL clickhouse_perform('param_admin', 'DROP DATABASE IF EXISTS param_test');
+CALL clickhouse_perform('param_admin', 'CREATE DATABASE param_test');
+CALL clickhouse_perform('param_admin', $$
     CREATE TABLE param_test.ft1 (
         c1 Int,
         c2 Int,
@@ -25,7 +28,7 @@ SELECT clickhouse_raw_query($$
 $$);
 
 -- Insert some data.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('param_admin', $$
     INSERT INTO param_test.ft1
     SELECT number,
            number % 10,
@@ -120,12 +123,12 @@ PREPARE st6 AS SELECT * FROM bin_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 PREPARE st7 AS INSERT INTO bin_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 EXECUTE st6;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE bin_test.ft1 OPTIONS (SET table_name 'ft1');
 
 -- implicit parameter
@@ -223,12 +226,12 @@ PREPARE st6 AS SELECT * FROM http_test.ft1 t1 WHERE t1.c1 = t1.c2 ORDER BY t1.c1
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 PREPARE st7 AS INSERT INTO http_test.ft1 (c1,c2,c3) VALUES (1001,101,'foo');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-SELECT clickhouse_raw_query('RENAME TABLE param_test.ft1 TO param_test.t1');
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.ft1 TO param_test.t1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 't1');
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st6;
 EXECUTE st6;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st7;
-SELECT clickhouse_raw_query('RENAME TABLE param_test.t1 TO param_test.ft1');
+CALL clickhouse_perform('param_admin', 'RENAME TABLE param_test.t1 TO param_test.ft1');
 ALTER FOREIGN TABLE http_test.ft1 OPTIONS (SET table_name 'ft1');
 
 -- implicit parameter

--- a/test/sql/partitioning_binary.sql
+++ b/test/sql/partitioning_binary.sql
@@ -9,10 +9,13 @@ CREATE SERVER pwagg_bin_svr FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_svr;
 
 -- ClickHouse holds cold data
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS pwagg_bin_test');
-SELECT clickhouse_raw_query('CREATE DATABASE pwagg_bin_test');
-SELECT clickhouse_raw_query('CREATE TABLE pwagg_bin_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
-SELECT clickhouse_raw_query($$INSERT INTO pwagg_bin_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
+CREATE SERVER pwagg_bin_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_admin;
+
+CALL clickhouse_perform('pwagg_bin_admin', 'DROP DATABASE IF EXISTS pwagg_bin_test');
+CALL clickhouse_perform('pwagg_bin_admin', 'CREATE DATABASE pwagg_bin_test');
+CALL clickhouse_perform('pwagg_bin_admin', 'CREATE TABLE pwagg_bin_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
+CALL clickhouse_perform('pwagg_bin_admin', $$INSERT INTO pwagg_bin_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
 
 -- Partitioned table whose cold 2023 range lives on ClickHouse as a foreign
 -- partition while the hot 2024 range stays local: the layout a consumer builds
@@ -54,5 +57,5 @@ RESET enable_partitionwise_aggregate;
 
 DROP TABLE events_bin;
 DROP USER MAPPING FOR CURRENT_USER SERVER pwagg_bin_svr;
-SELECT clickhouse_raw_query('DROP DATABASE pwagg_bin_test');
+CALL clickhouse_perform('pwagg_bin_admin', 'DROP DATABASE pwagg_bin_test');
 DROP SERVER pwagg_bin_svr CASCADE;

--- a/test/sql/partitioning_http.sql
+++ b/test/sql/partitioning_http.sql
@@ -6,10 +6,13 @@ CREATE SERVER pwagg_svr FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_svr;
 
 -- ClickHouse holds cold data
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS pwagg_test');
-SELECT clickhouse_raw_query('CREATE DATABASE pwagg_test');
-SELECT clickhouse_raw_query('CREATE TABLE pwagg_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
-SELECT clickhouse_raw_query($$INSERT INTO pwagg_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
+CREATE SERVER pwagg_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pwagg_admin;
+
+CALL clickhouse_perform('pwagg_admin', 'DROP DATABASE IF EXISTS pwagg_test');
+CALL clickhouse_perform('pwagg_admin', 'CREATE DATABASE pwagg_test');
+CALL clickhouse_perform('pwagg_admin', 'CREATE TABLE pwagg_test.events (id Int32, ts Date, val Int32, amt Float64) ENGINE = MergeTree ORDER BY ts');
+CALL clickhouse_perform('pwagg_admin', $$INSERT INTO pwagg_test.events VALUES (1,'2023-01-15',10,10),(2,'2023-02-10',20,20),(3,'2023-03-20',30,30),(4,'2023-04-05',40,40)$$);
 
 -- Partitioned table whose cold 2023 range lives on ClickHouse as a foreign
 -- partition while the hot 2024 range stays local: the layout a consumer builds
@@ -51,5 +54,5 @@ RESET enable_partitionwise_aggregate;
 
 DROP TABLE events;
 DROP USER MAPPING FOR CURRENT_USER SERVER pwagg_svr;
-SELECT clickhouse_raw_query('DROP DATABASE pwagg_test');
+CALL clickhouse_perform('pwagg_admin', 'DROP DATABASE pwagg_test');
 DROP SERVER pwagg_svr CASCADE;

--- a/test/sql/query_cancel.sql
+++ b/test/sql/query_cancel.sql
@@ -11,11 +11,14 @@ CREATE SERVER cancel_binary FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'cancel_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS cancel_test');
-SELECT clickhouse_raw_query('CREATE DATABASE cancel_test');
-SELECT clickhouse_raw_query('CREATE TABLE cancel_test.t1 (c1 Int32)
+CREATE SERVER cancel_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER cancel_admin;
+
+CALL clickhouse_perform('cancel_admin', 'DROP DATABASE IF EXISTS cancel_test');
+CALL clickhouse_perform('cancel_admin', 'CREATE DATABASE cancel_test');
+CALL clickhouse_perform('cancel_admin', 'CREATE TABLE cancel_test.t1 (c1 Int32)
     ENGINE = MergeTree ORDER BY c1');
-SELECT clickhouse_raw_query('INSERT INTO cancel_test.t1
+CALL clickhouse_perform('cancel_admin', 'INSERT INTO cancel_test.t1
     SELECT number FROM numbers(100)');
 
 CREATE FOREIGN TABLE cancel_http_ft (c1 int)
@@ -56,4 +59,4 @@ DROP USER MAPPING FOR CURRENT_USER SERVER cancel_http;
 DROP USER MAPPING FOR CURRENT_USER SERVER cancel_binary;
 DROP SERVER cancel_http;
 DROP SERVER cancel_binary;
-SELECT clickhouse_raw_query('DROP DATABASE cancel_test');
+CALL clickhouse_perform('cancel_admin', 'DROP DATABASE cancel_test');

--- a/test/sql/raw_query.sql
+++ b/test/sql/raw_query.sql
@@ -1,0 +1,4 @@
+-- clickhouse_raw_query() is deprecated and drops out next release.
+-- Prefer clickhouse_query() / clickhouse_perform().
+SELECT clickhouse_raw_query('CREATE DATABASE IF NOT EXISTS raw_query_test');
+SELECT clickhouse_raw_query('DROP DATABASE raw_query_test', 'host=localhost port=8123');

--- a/test/sql/re2_functions.sql
+++ b/test/sql/re2_functions.sql
@@ -7,15 +7,18 @@ SELECT NOT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = 're2') AS n
 CREATE SERVER re2_svr FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 're2_test');
 CREATE USER MAPPING FOR CURRENT_USER SERVER re2_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS re2_test');
-SELECT clickhouse_raw_query('CREATE DATABASE re2_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER re2_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER re2_admin;
+
+CALL clickhouse_perform('re2_admin', 'DROP DATABASE IF EXISTS re2_test');
+CALL clickhouse_perform('re2_admin', 'CREATE DATABASE re2_test');
+CALL clickhouse_perform('re2_admin', $$
     CREATE TABLE re2_test.t1 (
         id   Int32,
         val  String
     ) ENGINE = MergeTree ORDER BY id
 $$);
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('re2_admin', $$
     INSERT INTO re2_test.t1 VALUES
         (1, 'POSIX uses BRE and ERE'),
         (2, 're2 uses finite automata'),
@@ -111,5 +114,5 @@ SELECT id FROM t1 WHERE array_length(re2extractallgroupshorizontal(val, '(\w+) (
 
 DROP EXTENSION re2;
 DROP USER MAPPING FOR CURRENT_USER SERVER re2_svr;
-SELECT clickhouse_raw_query('DROP DATABASE re2_test');
+CALL clickhouse_perform('re2_admin', 'DROP DATABASE re2_test');
 DROP SERVER re2_svr CASCADE;

--- a/test/sql/regex.sql
+++ b/test/sql/regex.sql
@@ -3,14 +3,17 @@ CREATE SERVER regex_loopback FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'regex_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS regex_test');
-SELECT clickhouse_raw_query('CREATE DATABASE regex_test');
+CREATE SERVER regex_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER regex_admin;
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('regex_admin', 'DROP DATABASE IF EXISTS regex_test');
+CALL clickhouse_perform('regex_admin', 'CREATE DATABASE regex_test');
+
+CALL clickhouse_perform('regex_admin', $$
 	CREATE TABLE regex_test.strings(id Int32, val String) engine=TinyLog()
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('regex_admin', $$
 	INSERT INTO regex_test.strings
 	VALUES (1, 'val1'),
 		   (2, 'val2'),
@@ -269,5 +272,5 @@ $_$;
 \set ECHO all
 
 DROP USER MAPPING FOR CURRENT_USER SERVER regex_loopback;
-SELECT clickhouse_raw_query('DROP DATABASE regex_test');
+CALL clickhouse_perform('regex_admin', 'DROP DATABASE regex_test');
 DROP SERVER regex_loopback CASCADE;

--- a/test/sql/stream_out.sql
+++ b/test/sql/stream_out.sql
@@ -2,11 +2,14 @@ CREATE SERVER try_http FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'try_test', driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER try_http;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS try_test');
-SELECT clickhouse_raw_query('CREATE DATABASE try_test');
-SELECT clickhouse_raw_query('CREATE TABLE try_test.t1 (c1 Int32)
+CREATE SERVER try_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER try_admin;
+
+CALL clickhouse_perform('try_admin', 'DROP DATABASE IF EXISTS try_test');
+CALL clickhouse_perform('try_admin', 'CREATE DATABASE try_test');
+CALL clickhouse_perform('try_admin', 'CREATE TABLE try_test.t1 (c1 Int32)
     ENGINE = MergeTree ORDER BY c1');
-SELECT clickhouse_raw_query('INSERT INTO try_test.t1
+CALL clickhouse_perform('try_admin', 'INSERT INTO try_test.t1
     SELECT number FROM numbers(3500)');
 
 CREATE FOREIGN TABLE try_http_ft (c1 int)
@@ -18,4 +21,4 @@ SELECT count(*), min(c1), max(c1), sum(c1::bigint) FROM try_http_ft;
 
 DROP USER MAPPING FOR CURRENT_USER SERVER try_http;
 DROP SERVER try_http CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE try_test');
+CALL clickhouse_perform('try_admin', 'DROP DATABASE try_test');

--- a/test/sql/subplan_pushdown.sql
+++ b/test/sql/subplan_pushdown.sql
@@ -11,7 +11,10 @@
 -- servers rather than carry version-specific expected output.
 SET datestyle = 'ISO';
 
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER subplan_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_admin;
+
+SELECT clickhouse_server_version('subplan_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -23,17 +26,17 @@ CREATE SERVER subplan_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(dbname 'subplan_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subplan_test');
-SELECT clickhouse_raw_query('CREATE DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE IF EXISTS subplan_test');
+CALL clickhouse_perform('subplan_admin', 'CREATE DATABASE subplan_test');
 
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.items
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.items
     (item_id Int32, grp Int32, price Decimal(15,2), qty Int32)
     ENGINE = MergeTree ORDER BY item_id');
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.sales
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.sales
     (sale_id Int32, item_id Int32, amount Decimal(15,2), region String)
     ENGINE = MergeTree ORDER BY sale_id');
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.items VALUES
     (1, 1, 10.00, 5), (2, 1, 20.00, 3), (3, 1, 30.00, 8),
     (4, 2, 15.00, 2), (5, 2, 25.00, 7), (6, 3, 50.00, 1)
@@ -43,7 +46,7 @@ $$);
 -- 1.5x threshold is 250.00 and sale 8 (250.00) does NOT qualify; under a
 -- capture bug the threshold collapses to the global 1.5*avg = 241.88 and
 -- sale 8 WOULD qualify.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.sales VALUES
     (1, 1, 100.00, 'east'), (2, 1, 150.00, 'west'),
     (3, 2, 200.00, 'east'), (4, 3, 120.00, 'east'),
@@ -203,9 +206,9 @@ DROP ROLE regress_subplan_nomap;
 --     and a NOT EXISTS poison check for NULLs in the set — each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
-SELECT clickhouse_raw_query('CREATE TABLE subplan_test.maybe_null
+CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
     (id Int32, val Nullable(Int32)) ENGINE = MergeTree ORDER BY id');
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subplan_admin', $$
     INSERT INTO subplan_test.maybe_null VALUES (1, 1), (2, 2), (3, NULL), (4, 7)
 $$);
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
@@ -264,4 +267,4 @@ SET SESSION search_path = public;
 DROP SCHEMA subplan_test CASCADE;
 DROP USER MAPPING FOR CURRENT_USER SERVER subplan_svr;
 DROP SERVER subplan_svr CASCADE;
-SELECT clickhouse_raw_query('DROP DATABASE subplan_test');
+CALL clickhouse_perform('subplan_admin', 'DROP DATABASE subplan_test');

--- a/test/sql/subquery_eq.sql
+++ b/test/sql/subquery_eq.sql
@@ -7,7 +7,10 @@ SET datestyle = 'ISO';
 -- SubPlan pushdown is gated on ClickHouse 25.8+ (older analyzers reject the
 -- correlated SQL we generate), so the whole test aborts on older servers
 -- rather than carry version-specific expected output.
-SELECT clickhouse_raw_query($$SELECT version()$$) AS ch_version \gset
+CREATE SERVER sub_eq_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_admin;
+
+SELECT clickhouse_server_version('sub_eq_admin') AS ch_version \gset
 SELECT (split_part(:'ch_version', '.', 1)::int,
         split_part(:'ch_version', '.', 2)::int) < (25, 8) AS no_ch258 \gset
 \if :no_ch258
@@ -19,47 +22,47 @@ CREATE SERVER sub_eq_svr FOREIGN DATA WRAPPER clickhouse_fdw
        OPTIONS(dbname 'sub_eq_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS sub_eq_test');
-SELECT clickhouse_raw_query('CREATE DATABASE sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE IF EXISTS sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', 'CREATE DATABASE sub_eq_test');
 
-SELECT clickhouse_raw_query($$
-    CREATE TABLE region (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.region (
         r_regionkey  Int32,
         r_name       String,
         r_comment    String)
     ENGINE = MergeTree ORDER BY (r_regionkey);
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    INSERT INTO region
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.region
     VALUES (0,'AFRICA','lar deposits.')
          , (1,'AMERICA','hs use ironic, even requests. s')
          , (2,'ASIA','ges. thinly even pinto beans ca')
          , (3,'EUROPE','ly final courts cajole furiously final excuse')
          , (4,'MIDDLE EAST','quickly special accounts cajole carefully blithely close requests.')
-$$, 'dbname=sub_eq_test');
+$$);
 
 -- Create and load TPC-H Tables.
-SELECT clickhouse_raw_query($$
-    CREATE TABLE nation (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.nation (
         n_nationkey  Int32,
         n_name       String,
         n_regionkey  Int32,
         n_comment    String)
     ENGINE = MergeTree ORDER BY (n_nationkey);
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    INSERT INTO nation
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.nation
     VALUES (6,'FRANCE',3,'ruefully final requests. regular, ironi')
          , (7,'GERMANY',3,'platelets.')
          , (19,'ROMANIA',3,'asymptotes are about the furious multipliers.')
          , (22,'RUSSIA',3,'requests against the platelets.')
          , (23,'UNITED KINGDOM',3,'means boost carefully special requests.')
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    CREATE TABLE part (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.part (
         p_partkey     Int32,
         p_name        String,
         p_mfgr        String,
@@ -70,10 +73,10 @@ SELECT clickhouse_raw_query($$
         p_retailprice Decimal(15,2),
         p_comment     String)
     ENGINE = MergeTree ORDER BY (p_partkey);
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    INSERT INTO part
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.part
     VALUES (20428,'chocolate ivory lace aquamarine spring','Manufacturer#4','Brand#43','LARGE BRUSHED BRASS',15,'MED BOX',1348.42,'al foxes. irony')
          , (70284,'slate chartreuse metallic firebrick plum','Manufacturer#4','Brand#44','STANDARD PLATED BRASS',15,'MED BAG',1254.28,'s wake silently a')
          , (73936,'cyan light indian salmon goldenrod','Manufacturer#4','Brand#45','ECONOMY PLATED BRASS',15,'JUMBO DRUM',1909.93,'foxes kin')
@@ -82,10 +85,10 @@ SELECT clickhouse_raw_query($$
          , (109220,'violet snow steel purple turquoise','Manufacturer#4','Brand#41','ECONOMY BURNISHED BRASS',15,'WRAP PACK',1229.22,'cites')
          , (170979,'lawn blue steel burnished cream','Manufacturer#4','Brand#45','PROMO BRUSHED BRASS',15,'MED BAG',2049.97,'are busily')
          , (186694,'chocolate sandy seashell indian forest','Manufacturer#4','Brand#45','PROMO POLISHED BRASS',15,'SM BAG',1780.69,'e the carefully re')
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    CREATE TABLE supplier (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.supplier (
         s_suppkey     Int32,
         s_name        String,
         s_address     String,
@@ -94,10 +97,10 @@ SELECT clickhouse_raw_query($$
         s_acctbal     Decimal(15,2),
         s_comment     String)
     ENGINE = MergeTree ORDER BY (s_suppkey);
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    INSERT INTO supplier
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.supplier
     VALUES (1731,'Supplier#000001731','Dqy8LQtY5i8GygrdOC1lt,OVsIgrGoL8Z3PMs',7,'17-115-638-8685',686.5,'lar requests. final, final platelets around the carefully even deposit')
          , (2931,'Supplier#000002931','aUivhoesqMqv0FmJcPBMxBSl8DJvXBGj',7,'17-905-318-3455',555.18,'t the fluffily ironic packages wake furiously')
          , (3113,'Supplier#000003113','HjX8M2Bjlz7pAcLzpyKT9 wNb',7,'17-164-471-2650',-604.88,'he ruthlessly final requests. express requests cajole quick')
@@ -105,20 +108,20 @@ SELECT clickhouse_raw_query($$
          , (3937,'Supplier#000003937','kqEOwdVW,qJsJdcv6PwDJ6ii14mugDK3OgZN ngI',7,'17-621-453-7063',-63.88,'y pending asymptotes. foxes are. deposits sleep quickly b')
          , (5299,'Supplier#000005299','m7Y2G8Pg,kl5AoMPK',7,'17-904-495-9057',-752.27,'. carefully close foxes x-ray. carefully even package')
          , (9733,'Supplier#000009733','XIkUGlZFKq4IiZsAIRxFwzVBw7D',7,'17-789-292-3060',-271.69,'ions. boldly regular requests play furiously. furiously busy')
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    CREATE TABLE partsupp (
+CALL clickhouse_perform('sub_eq_admin', $$
+    CREATE TABLE sub_eq_test.partsupp (
         ps_partkey     Int32,
         ps_suppkey     Int32,
         ps_availqty    Int32,
         ps_supplycost  Decimal(15,2),
         ps_comment     String)
     ENGINE = MergeTree ORDER BY (ps_partkey, ps_suppkey);
-$$, 'dbname=sub_eq_test');
+$$);
 
-SELECT clickhouse_raw_query($$
-    INSERT INTO partsupp
+CALL clickhouse_perform('sub_eq_admin', $$
+    INSERT INTO sub_eq_test.partsupp
     VALUES (20428,429,5391,624.88,'among the furiously pending deposits. slyly even instruction')
          , (20428,2931,5672,97.08,'lly final ideas. dolphins are slyly.')
          , (20428,5433,990,457,'ly. carefully regular packages wake never.')
@@ -151,7 +154,7 @@ SELECT clickhouse_raw_query($$
          , (186694,4249,9871,999.65,'all asymptotes cajole furiously ironic, pending dependencies.')
          , (186694,6695,9308,448.14,'serve closely above the even deposits.')
          , (186694,9213,154,593.87,'forges hang furiously pending deposits.')
-$$, 'dbname=sub_eq_test');
+$$);
 
 -- Import the foreign tables.
 CREATE SCHEMA sub_eq_test;
@@ -210,6 +213,6 @@ EXPLAIN (VERBOSE, COSTS OFF) :query2
 :query2
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE sub_eq_test');
+CALL clickhouse_perform('sub_eq_admin', 'DROP DATABASE sub_eq_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER sub_eq_svr;
 DROP SERVER sub_eq_svr CASCADE;

--- a/test/sql/subquery_pushdown.sql
+++ b/test/sql/subquery_pushdown.sql
@@ -4,18 +4,21 @@ SET datestyle = 'ISO';
 CREATE SERVER subquery_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'subquery_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS subquery_test');
-SELECT clickhouse_raw_query('CREATE DATABASE subquery_test');
+CREATE SERVER subquery_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER subquery_admin;
+
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE IF EXISTS subquery_test');
+CALL clickhouse_perform('subquery_admin', 'CREATE DATABASE subquery_test');
 
 -- Create TPC-H orders table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.orders
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.orders
 	(o_orderkey Int32, o_custkey Int32, o_orderstatus FixedString(1), o_totalprice Decimal(15,2),
 	 o_orderdate Date, o_orderpriority FixedString(15), o_clerk FixedString(15), o_shippriority Int32, o_comment String)
 	ENGINE = MergeTree ORDER BY o_orderkey;
 ');
 
 -- Create TPC-H lineitem table (matching official schema)
-SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
+CALL clickhouse_perform('subquery_admin', 'CREATE TABLE subquery_test.lineitem
 	(l_orderkey Int32, l_partkey Int32, l_suppkey Int32, l_linenumber Int32,
 	 l_quantity Decimal(15,2), l_extendedprice Decimal(15,2), l_discount Decimal(15,2), l_tax Decimal(15,2),
 	 l_returnflag FixedString(1), l_linestatus FixedString(1), l_shipdate Date, l_commitdate Date,
@@ -24,7 +27,7 @@ SELECT clickhouse_raw_query('CREATE TABLE subquery_test.lineitem
 ');
 
 -- Insert sample orders data
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.orders VALUES
 	(1, 100, 'O', 1000.00, '1993-07-15', '1-URGENT', 'Clerk#000000001', 0, 'order1'),
 	(2, 101, 'O', 2000.00, '1993-07-20', '2-HIGH', 'Clerk#000000002', 0, 'order2'),
@@ -37,7 +40,7 @@ SELECT clickhouse_raw_query($$
 $$);
 
 -- Insert sample lineitem data (l_commitdate < l_receiptdate for some items)
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('subquery_admin', $$
 	INSERT INTO subquery_test.lineitem VALUES
 	(1, 10, 1, 1, 10.00, 100.00, 0.10, 0.05, 'N', 'O', '1993-07-20', '1993-07-15', '1993-07-25', 'DELIVER IN PERSON', 'TRUCK', 'item1'),
 	(2, 20, 2, 1, 20.00, 200.00, 0.10, 0.05, 'N', 'O', '1993-07-25', '1993-07-20', '1993-07-30', 'DELIVER IN PERSON', 'AIR', 'item2'),
@@ -110,6 +113,6 @@ WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = o_orderkey)
 ORDER BY o_orderkey;
 
 -- Cleanup
-SELECT clickhouse_raw_query('DROP DATABASE subquery_test');
+CALL clickhouse_perform('subquery_admin', 'DROP DATABASE subquery_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER subquery_loopback;
 DROP SERVER subquery_loopback CASCADE;

--- a/test/sql/timezone.sql
+++ b/test/sql/timezone.sql
@@ -8,9 +8,12 @@ CREATE SERVER tz_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
     OPTIONS(driver 'http');
 CREATE USER MAPPING FOR CURRENT_USER SERVER tz_http_svr;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS tz_test');
-SELECT clickhouse_raw_query('CREATE DATABASE tz_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER tz_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER tz_admin;
+
+CALL clickhouse_perform('tz_admin', 'DROP DATABASE IF EXISTS tz_test');
+CALL clickhouse_perform('tz_admin', 'CREATE DATABASE tz_test');
+CALL clickhouse_perform('tz_admin', $$
     CREATE TABLE tz_test.ts (
         id        Int,
         server_ts DateTime,
@@ -21,7 +24,7 @@ SELECT clickhouse_raw_query($$
 $$);
 
 -- Insert some records, all times set to 10:00:00 UTC.
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('tz_admin', $$
     INSERT INTO tz_test.ts
     SELECT number,
            addMonths(toDateTime('2020-01-01 10:00:00', 'UTC'), number * 3),
@@ -31,9 +34,11 @@ SELECT clickhouse_raw_query($$
     FROM numbers(0, 4)
 $$);
 
-SELECT clickhouse_raw_query($$
+-- Read as text under UTC, so every column shows the instant that was stored.
+SET session timezone = 'UTC';
+SELECT * FROM clickhouse_query('tz_admin', $$
     SELECT * FROM tz_test.ts ORDER BY id
-$$);
+$$) AS t(id text, server_ts text, utc_ts text, nyc_ts text, lax_ts text);
 
 CREATE SCHEMA tz_bin;
 IMPORT FOREIGN SCHEMA tz_test FROM SERVER tz_bin_svr INTO tz_bin;

--- a/test/sql/where_sub.sql
+++ b/test/sql/where_sub.sql
@@ -1,9 +1,12 @@
 CREATE SERVER where_sub_loopback FOREIGN DATA WRAPPER clickhouse_fdw OPTIONS(dbname 'where_sub_test', driver 'binary');
 CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS where_sub_test');
-SELECT clickhouse_raw_query('CREATE DATABASE where_sub_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER where_sub_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER where_sub_admin;
+
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE IF EXISTS where_sub_test');
+CALL clickhouse_perform('where_sub_admin', 'CREATE DATABASE where_sub_test');
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.orders  (
         id     Int32,
         date   Date,
@@ -11,7 +14,7 @@ SELECT clickhouse_raw_query($$
     ) ENGINE = MergeTree ORDER BY (id);
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('where_sub_admin', $$
     CREATE TABLE where_sub_test.lines (
         order_id    Int32,
         num         Int32,
@@ -38,6 +41,6 @@ SELECT class, COUNT(*) AS order_count
  GROUP BY class
  ORDER BY class;
 
-SELECT clickhouse_raw_query('DROP DATABASE where_sub_test');
+CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;

--- a/test/sql/window_functions.sql
+++ b/test/sql/window_functions.sql
@@ -13,9 +13,12 @@ CREATE SERVER wf_http_svr FOREIGN DATA WRAPPER clickhouse_fdw
 CREATE USER MAPPING FOR CURRENT_USER SERVER wf_http_svr;
 
 -- Create a ClickHouse table.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS wf_test');
-SELECT clickhouse_raw_query('CREATE DATABASE wf_test');
-SELECT clickhouse_raw_query($$
+CREATE SERVER wf_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER wf_admin;
+
+CALL clickhouse_perform('wf_admin', 'DROP DATABASE IF EXISTS wf_test');
+CALL clickhouse_perform('wf_admin', 'CREATE DATABASE wf_test');
+CALL clickhouse_perform('wf_admin', $$
     CREATE TABLE wf_test.events (
         id          UInt64,
         entity_id   String,
@@ -26,7 +29,7 @@ SELECT clickhouse_raw_query($$
     ORDER BY (event_name, ts_event)
 $$);
 
-SELECT clickhouse_raw_query($$
+CALL clickhouse_perform('wf_admin', $$
     INSERT INTO wf_test.events VALUES
     (1, 'lead_100', 'lead_created', '2026-03-01 10:00:00', 100),
     (2, 'lead_100', 'lead_created', '2026-03-15 14:00:00', 200),
@@ -372,7 +375,7 @@ FROM wf_bin.events
 WHERE event_name = 'lead_created';
 
 -- Clean up.
-SELECT clickhouse_raw_query('DROP DATABASE IF EXISTS wf_test');
+CALL clickhouse_perform('wf_admin', 'DROP DATABASE IF EXISTS wf_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER wf_bin_svr;
 DROP SERVER wf_bin_svr CASCADE;
 DROP USER MAPPING FOR CURRENT_USER SERVER wf_http_svr;


### PR DESCRIPTION
Add `clickhouse_perform` for DDL whose empty result has no columns

`clickhouse_raw_query` drifted from its "raw" roots with Native format,
from back when ClickHouse TSV output could be piped into text result.
Somewhat contrived massaging native blocks into TSV

This removal will allow discarding leftover TSV parsing