### PR TITLE
Preserve PostgreSQL DOW semantics in pushdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ All notable changes to this project will be documented in this file. It uses the
 *   Fixed a use-after-free of a foreign scan's batch memory context on rescan
     that could corrupt memory and hang ([#296]).
 *   Fixed subsecond precision lost inserting timestamps over HTTP ([#300]).
+*   Fixed `date_part('dow', ...)` and `EXTRACT(DOW FROM ...)` pushdown to use
+    PostgreSQL's Sunday (`0`) through Saturday (`6`) numbering, rather than
+    ClickHouse's default Monday through Sunday scheme. Thanks to Minh Vu for
+    the PR ([#331])!
 *   Fixed undefined behavior: out-of-bounds reads in key/value iteration, and
     binary driver's simple query path; `CollapsingMergeTree` validation; missing
     rejection of non-`Const`/null units in `date_trunc`/`date_part` pushdown;
@@ -172,6 +176,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#326 pg-clickhouse-c"
   [#330]: https://github.com/ClickHouse/pg_clickhouse/pull/330
     "ClickHouse/pg_clickhouse#330 preserve typmod in binary driver"
+  [#331]: https://github.com/ClickHouse/pg_clickhouse/pull/331
+    "ClickHouse/pg_clickhouse#331 Preserve PostgreSQL DOW semantics in pushdown"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -4421,8 +4421,9 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             return;
         }
         case CF_DATE_PART: {
-            Const* arg     = (Const*)linitial(node->args);
-            char* parttype = TextDatumGetCString(arg->constvalue);
+            Const* arg        = (Const*)linitial(node->args);
+            char* parttype    = TextDatumGetCString(arg->constvalue);
+            bool postgres_dow = false;
 
             CSTRING_TOLOWER(parttype);
 
@@ -4432,6 +4433,7 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
                 appendStringInfoString(buf, "toDayOfYear");
             } else if (strcmp(parttype, "dow") == 0) {
                 appendStringInfoString(buf, "toDayOfWeek");
+                postgres_dow = true;
             } else if (strcmp(parttype, "year") == 0) {
                 appendStringInfoString(buf, "toYear");
             } else if (strcmp(parttype, "month") == 0) {
@@ -4461,6 +4463,10 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             pfree(parttype);
             appendStringInfoChar(buf, '(');
             deparseExpr(list_nth(node->args, 1), context);
+            if (postgres_dow) {
+                /* Mode 2 aligns with Postgres behavior (Sunday = 0). */
+                appendStringInfoString(buf, ", 2");
+            }
             appendStringInfoChar(buf, ')');
             return;
         }

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1129,11 +1151,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1142,6 +1164,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1346,11 +1389,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2925,7 +2968,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2934,4 +2977,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_0.out
+++ b/test/expected/functions_0.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1129,11 +1151,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1142,6 +1164,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1346,11 +1389,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2887,7 +2930,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2896,4 +2939,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1129,11 +1151,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1142,6 +1164,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1346,11 +1389,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2899,7 +2942,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2908,4 +2951,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1129,11 +1151,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1142,6 +1164,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1346,11 +1389,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2887,7 +2930,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2896,4 +2939,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1129,11 +1151,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1142,6 +1164,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1346,11 +1389,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2875,7 +2918,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2884,4 +2927,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2921,7 +2964,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2930,4 +2973,5 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8
 drop cascades to foreign table times

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2909,7 +2952,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2918,3 +2961,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2909,7 +2952,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2918,3 +2961,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2885,7 +2928,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2894,3 +2937,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_8.out
+++ b/test/expected/functions_8.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2869,7 +2912,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2878,3 +2921,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/expected/functions_9.out
+++ b/test/expected/functions_9.out
@@ -88,6 +88,12 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=Tiny
  
 (1 row)
 
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
 		('2025-10-15T20:12:25'),
@@ -117,6 +123,21 @@ $$);
 (1 row)
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -136,6 +157,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
 	SELECT number+1, number+2
@@ -860,12 +882,12 @@ SELECT date_part('doy'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d
 (2 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-                                                                                      QUERY PLAN                                                                                      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
    Output: (date_part('dow'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
-   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC')) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'))) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC')) ASC NULLS LAST
+   Remote SQL: SELECT toDayOfWeek(toTimeZone(c, 'UTC'), 2) FROM functions_test.t1 GROUP BY (toDayOfWeek(toTimeZone(c, 'UTC'), 2)) ORDER BY toDayOfWeek(toTimeZone(c, 'UTC'), 2) ASC NULLS LAST
 (4 rows)
 
 SELECT date_part('dow'::text, timezone('UTC'::text, c)) as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -1125,11 +1147,11 @@ SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
@@ -1138,6 +1160,27 @@ SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
  2026-11-17 00:13:26
  2028-01-18 15:15:28
 (2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_part('dow'::text, ts))
+   Relations: Aggregate on (t8)
+   Remote SQL: SELECT toDayOfWeek(ts, 2) FROM functions_test.t8 GROUP BY (toDayOfWeek(ts, 2)) ORDER BY toDayOfWeek(ts, 2) ASC NULLS LAST
+(4 rows)
+
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+ dow 
+-----
+   0
+   1
+   2
+   3
+   4
+   5
+   6
+(7 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
                                  QUERY PLAN                                 
@@ -1342,11 +1385,11 @@ SELECT ts FROM t5 WHERE EXTRACT(doy FROM ts) = 351;
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
  Foreign Scan on public.t5
    Output: ts
-   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts) = 2))
+   Remote SQL: SELECT ts FROM functions_test.t5 WHERE ((toDayOfWeek(ts, 2) = 2))
 (3 rows)
 
 SELECT ts FROM t5 WHERE EXTRACT(dow FROM ts) = 2;
@@ -2862,7 +2905,7 @@ SELECT clickhouse_raw_query('DROP DATABASE functions_test');
 (1 row)
 
 DROP SERVER functions_loopback CASCADE;
-NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to 9 other objects
 DETAIL:  drop cascades to foreign table t1
 drop cascades to foreign table t2
 drop cascades to foreign table t3
@@ -2871,3 +2914,4 @@ drop cascades to foreign table t4
 drop cascades to foreign table t5
 drop cascades to foreign table t6
 drop cascades to foreign table t7
+drop cascades to foreign table t8

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -35,6 +35,7 @@ SELECT clickhouse_raw_query('CREATE TABLE functions_test.t4 (val String) engine=
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t5 (ts DateTime) engine=TinyLog();');
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t6 (i64 Int64, f64 Float64) engine=TinyLog();');
 SELECT clickhouse_raw_query('CREATE TABLE functions_test.t7(dt Date) engine=TinyLog();');
+SELECT clickhouse_raw_query('CREATE TABLE functions_test.t8 (ts DateTime) engine=TinyLog();');
 
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t5 VALUES
@@ -57,6 +58,17 @@ SELECT clickhouse_raw_query($$
 $$);
 
 SELECT clickhouse_raw_query($$
+	INSERT INTO functions_test.t8 VALUES
+		('2026-08-02T12:00:00'),
+		('2026-08-03T12:00:00'),
+		('2026-08-04T12:00:00'),
+		('2026-08-05T12:00:00'),
+		('2026-08-06T12:00:00'),
+		('2026-08-07T12:00:00'),
+		('2026-08-08T12:00:00')
+$$);
+
+SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t6 VALUES
 		(20423, 20423.123),
 		(2042323443, 2042323443.232),
@@ -72,6 +84,7 @@ CREATE FOREIGN TABLE t4 (val text) SERVER functions_loopback;
 CREATE FOREIGN TABLE t5 (ts timestamp) SERVER functions_loopback;
 CREATE FOREIGN TABLE t6 (i64 BIGINT, f64 FLOAT8) SERVER functions_loopback;
 CREATE FOREIGN TABLE t7 (ts date) SERVER functions_loopback;
+CREATE FOREIGN TABLE t8 (ts timestamp) SERVER functions_loopback;
 
 SELECT clickhouse_raw_query($$
 	INSERT INTO functions_test.t3
@@ -274,6 +287,8 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('doy', ts) = '351
 SELECT ts FROM t5 WHERE date_part('doy', ts) = '351';
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
 SELECT ts FROM t5 WHERE date_part('dow', ts) = '2';
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
+SELECT date_part('dow', ts) AS dow FROM t8 GROUP BY dow ORDER BY dow;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
 SELECT ts FROM t5 WHERE date_part('quarter', ts) = '1';
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ts FROM t5 WHERE date_part('isoyear', ts) = '2025';


### PR DESCRIPTION
Fix DOW pushdown to preserve PostgreSQL semantics.

| | Sunday | Monday | Saturday |
|---|---:|---:|---:|
| PostgreSQL `date_part('dow', ...)` | 0 | 1 | 6 |
| ClickHouse `toDayOfWeek()` | 7 | 1 | 6 |

The old mapping could return `7` for Sunday and omit Sunday from filters such as `date_part('dow', ts) = 0`.

Deparse DOW as `toDayOfWeek(expr, 2)`, which uses the PostgreSQL numbering.

Tests:

- Covers all seven days and pins the generated remote SQL.
- Passed `functions.sql` on ClickHouse 23.3.22.3 and 26.3.17.56.