### PR TITLE
fix: encode bytea array literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,10 @@ All notable changes to this project will be documented in this file. It uses the
     PR ([#319])!
 *   Fixed omission of typmod behavior in binary driver causing incorrect values.
     For example, padding will be preserved in char(x) columns now ([#330]).
+*   Encode `bytea` array elements with the ClickHouse binary-literal
+    serializer previously for scalar values (now simplified), preventing
+    PostgreSQL `IN` lists from producing invalid or mismatched `FixedString`
+    comparisons. Thanks to @jxom for the PR (#333)!
 
 ### 📚 Documentation
 
@@ -178,6 +182,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#330 preserve typmod in binary driver"
   [#331]: https://github.com/ClickHouse/pg_clickhouse/pull/331
     "ClickHouse/pg_clickhouse#331 Preserve PostgreSQL DOW semantics in pushdown"
+  [#333]: https://github.com/ClickHouse/pg_clickhouse/pull/333
+    "ClickHouse/pg_clickhouse#333 fix: encode bytea array literals"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -3153,6 +3153,34 @@ ch_timestamp_out(PG_FUNCTION_ARGS) {
     PG_RETURN_CSTRING(result);
 }
 
+/*
+ * Emit printable ASCII as-is and \xHH for everything else. PG's bytea_out
+ * hex format (\xHHHH...) does not round-trip through CH's string lexer past
+ * a single byte: \x consumes exactly two hex digits.
+ */
+static void
+deparseByteaLiteral(StringInfo buf, Datum value) {
+    bytea* bp         = DatumGetByteaPP(value);
+    const char* bytes = VARDATA_ANY(bp);
+    int len           = VARSIZE_ANY_EXHDR(bp);
+
+    appendStringInfoChar(buf, '\'');
+    for (int i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)bytes[i];
+
+        if (c == '\'') {
+            appendStringInfoString(buf, "\\'");
+        } else if (c == '\\') {
+            appendStringInfoString(buf, "\\\\");
+        } else if (c >= 0x20 && c <= 0x7E) {
+            appendStringInfoChar(buf, (char)c);
+        } else {
+            appendStringInfo(buf, "\\x%02x", c);
+        }
+    }
+    appendStringInfoChar(buf, '\'');
+}
+
 static void
 emitArrayElement(
     StringInfo buf,
@@ -3165,6 +3193,11 @@ emitArrayElement(
 
     if (isnull) {
         appendStringInfoString(buf, "NULL");
+        return;
+    }
+
+    if (element_type == BYTEAOID) {
+        deparseByteaLiteral(buf, elt);
         return;
     }
 
@@ -3415,31 +3448,7 @@ deparseConst(Const* node, deparse_expr_cxt* context, int showtype) {
         deparseArray(node->constvalue, context);
         goto cleanup;
     } else if (node->consttype == BYTEAOID) {
-        /*
-         * Emit printable ASCII as-is and \xHH for everything else. PG's
-         * bytea_out hex format (\xHHHH...) doesn't round-trip through CH's
-         * string lexer past a single byte: \x consumes exactly two hex digits
-         * and any remaining hex chars become ASCII literals.
-         */
-        bytea* bp         = DatumGetByteaPP(node->constvalue);
-        const char* bytes = VARDATA_ANY(bp);
-        int len           = VARSIZE_ANY_EXHDR(bp);
-
-        appendStringInfoChar(buf, '\'');
-        for (int i = 0; i < len; i++) {
-            unsigned char c = (unsigned char)bytes[i];
-
-            if (c == '\'') {
-                appendStringInfoString(buf, "\\'");
-            } else if (c == '\\') {
-                appendStringInfoString(buf, "\\\\");
-            } else if (c >= 0x20 && c <= 0x7E) {
-                appendStringInfoChar(buf, (char)c);
-            } else {
-                appendStringInfo(buf, "\\x%02x", c);
-            }
-        }
-        appendStringInfoChar(buf, '\'');
+        deparseByteaLiteral(buf, node->constvalue);
         goto cleanup;
     } else {
         extval = OidOutputFunctionCall(typoutput, node->constvalue);

--- a/test/expected/binary.out
+++ b/test/expected/binary.out
@@ -365,6 +365,32 @@ SELECT * FROM fbytes ORDER BY c1;
   9 | \xda1a828a08d9d57450ce10a89cb5ee91dc2feed7 | \xa2da4af9e1d8f4d37887f719cda60bda
 (10 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.fbytes
+   Output: c1
+   Remote SQL: SELECT c1 FROM binary_test.bytes WHERE ((c3 IN ('\x8d\xe9,\xe2\x03<\xf3\xca\x03\xfa\x8c\xc6>zp?','\x91c\xc8\xc6m\x03\xc5\x12@L\xca\x85I\xa2P\xe7'))) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
+ c1 
+----
+  1
+  3
+(2 rows)
+
 -- clickhouse_raw_query over the binary protocol
 SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
  clickhouse_raw_query 

--- a/test/expected/binary_1.out
+++ b/test/expected/binary_1.out
@@ -365,6 +365,32 @@ SELECT * FROM fbytes ORDER BY c1;
   9 | \xda1a828a08d9d57450ce10a89cb5ee91dc2feed7 | \xa2da4af9e1d8f4d37887f719cda60bda
 (10 rows)
 
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.fbytes
+   Output: c1
+   Remote SQL: SELECT c1 FROM binary_test.bytes WHERE ((c3 IN ('\x8d\xe9,\xe2\x03<\xf3\xca\x03\xfa\x8c\xc6>zp?','\x91c\xc8\xc6m\x03\xc5\x12@L\xca\x85I\xa2P\xe7'))) ORDER BY c1 ASC NULLS LAST
+(3 rows)
+
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
+ c1 
+----
+  1
+  3
+(2 rows)
+
 -- clickhouse_raw_query over the binary protocol
 SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');
  clickhouse_raw_query 

--- a/test/sql/binary.sql
+++ b/test/sql/binary.sql
@@ -171,6 +171,19 @@ SELECT * FROM ftuples ORDER BY c1;
 
 -- Bytes.
 SELECT * FROM fbytes ORDER BY c1;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
+SELECT c1 FROM fbytes
+WHERE c3 IN (
+    decode('8de92ce2033cf3ca03fa8cc63e7a703f', 'hex'),
+    decode('9163c8c66d03c512404cca8549a250e7', 'hex')
+)
+ORDER BY c1;
 
 -- clickhouse_raw_query over the binary protocol
 SELECT clickhouse_raw_query('SELECT 1 AS a, ''x'' AS b', 'driver=binary port=9000');


### PR DESCRIPTION
Encodes `bytea` array elements with the same ClickHouse binary-literal serializer used for scalar values, preventing PostgreSQL `IN` lists from producing invalid or mismatched `FixedString` comparisons.
