### PR TITLE
Preserve array_position not-found semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ All notable changes to this project will be documented in this file. It uses the
 *   Coerce array elements in binary driver. `Array(Int32)` to `bigint[]`, or
     `quantilesExactLow()` results into `double precision[]`, no longer fails
     with `could not cast value from integer[] to bigint[]` ([#326]).
+*   Added support for the third argument to `array_position()` when it's a
+    positive constant value, pushing it down to a call to `arraySlice()` to
+    start the search from the specified index. Thanks to Minh Vu for the PR
+    ([#334])!
 
 ### 🐞 Bug Fixes
 
@@ -122,6 +126,8 @@ All notable changes to this project will be documented in this file. It uses the
     serializer previously for scalar values (now simplified), preventing
     PostgreSQL `IN` lists from producing invalid or mismatched `FixedString`
     comparisons. Thanks to @jxom for the PR (#333)!
+*   Fixed `array_position()` pushdown to return `NULL`, rather than zero, when
+    ClickHouse does not find an element. Thanks to Minh Vu for the PR ([#334])!
 
 ### 📚 Documentation
 
@@ -184,6 +190,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#331 Preserve PostgreSQL DOW semantics in pushdown"
   [#333]: https://github.com/ClickHouse/pg_clickhouse/pull/333
     "ClickHouse/pg_clickhouse#333 fix: encode bytea array literals"
+  [#334]: https://github.com/ClickHouse/pg_clickhouse/pull/334
+    "ClickHouse/pg_clickhouse#334 Preserve array_position not-found semantics"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1224,7 +1224,11 @@ equivalents as follows:
 *   `extract(field FROM source)`: same mappings as `date_part`
 *   `date(timestamp)` & `date(timestamptz)`: [toDate](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#toDate)
     (deparsed as CH alias `date`)
-*   `array_position`: [indexOf](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf)
+*   `array_position`: [indexOf](https://clickhouse.com/docs/sql-reference/functions/array-functions#indexOf) with
+    [nullIf](https://clickhouse.com/docs/reference/functions/regular-functions/functions-for-nulls#nullif)
+    to convert `0` to `NULL` and
+    [arraySlice](https://clickhouse.com/docs/sql-reference/functions/array-functions#arraySlice)
+    when there's a third argument for the search starting index; note that `nan` currently [does not match](https://github.com/ClickHouse/ClickHouse/issues/113169)
 *   `array_cat`: [arrayConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayConcat)
 *   `array_append`: [arrayPushBack](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushBack)
 *   `array_prepend`: [arrayPushFront](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushFront)

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -33,6 +33,7 @@
 #define F_TIMEZONE_TEXT_TIMESTAMPTZ F_TIMESTAMPTZ_ZONE
 #define F_DATE_PART_TEXT_TIMESTAMPTZ F_TIMESTAMPTZ_PART
 #define F_ARRAY_POSITION_ANYCOMPATIBLEARRAY_ANYCOMPATIBLE F_ARRAY_POSITION
+#define F_ARRAY_POSITION_ANYCOMPATIBLEARRAY_ANYCOMPATIBLE_INT4 3278
 #define F_BTRIM_TEXT_TEXT F_BTRIM
 #define F_BTRIM_TEXT F_BTRIM1
 #define F_STRPOS 868
@@ -464,7 +465,9 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
         def->ch_name = "toTimeZone";
         return true;
     case F_ARRAY_POSITION_ANYCOMPATIBLEARRAY_ANYCOMPATIBLE:
-        def->ch_name = "indexOf";
+    case F_ARRAY_POSITION_ANYCOMPATIBLEARRAY_ANYCOMPATIBLE_INT4:
+        def->cf_type = CF_ARRAY_POSITION;
+        def->ch_name = "\1";
         return true;
     case F_BTRIM_TEXT_TEXT:
     case F_BTRIM_TEXT:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -4591,6 +4591,31 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             deparseExpr((Expr*)linitial(node->args), context);
             appendStringInfoChar(buf, ')');
             return;
+        case CF_ARRAY_POSITION:
+            appendStringInfoChar(buf, '(');
+            /* Use nullIf() to Convert CH 0 return value to NULL. */
+            appendStringInfoString(buf, "nullIf(indexOf(");
+            if (list_length(node->args) == 3) {
+                /* Use arraySlice() to start search from the specified index. */
+                appendStringInfoString(buf, "arraySlice(");
+                deparseExpr((Expr*)linitial(node->args), context);
+                appendStringInfoString(buf, ", ");
+                deparseExpr((Expr*)list_nth(node->args, 2), context);
+                appendStringInfoString(buf, "), ");
+            } else {
+                deparseExpr((Expr*)linitial(node->args), context);
+                appendStringInfoString(buf, ", ");
+            }
+            deparseExpr((Expr*)list_nth(node->args, 1), context);
+            appendStringInfoString(buf, "), 0)");
+            if (list_length(node->args) == 3) {
+                /* Restore start index to index number. */
+                appendStringInfoString(buf, " + (");
+                deparseExpr((Expr*)list_nth(node->args, 2), context);
+                appendStringInfoString(buf, " - 1)");
+            }
+            appendStringInfoChar(buf, ')');
+            return;
         case CF_TRIM_ARRAY:
             /* arrayResize(arr, length(arr) - n) */
             appendStringInfoChar(buf, '(');

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -426,6 +426,7 @@ typedef enum {
     CF_CURRENT_SCHEMA,         /* CF_CURRENT_SCHEMA → string literal */
     CF_CLOCK_TIMESTAMP,        /* clock_timestamp → nowInBlock64(6, $TZ) */
     CF_ARRAY_LENGTH,           /* array_length → length, drop dim arg */
+    CF_ARRAY_POSITION,         /* array_position → nullIf(indexOf(), 0) */
     CF_ARRAY_PREPEND,          /* array_prepend → arrayPushFront, swap args */
     CF_STRING_TO_ARRAY,        /* string_to_array → splitByString, swap
                                 * args */

--- a/src/shipable.c
+++ b/src/shipable.c
@@ -248,6 +248,25 @@ chfdw_is_shippable(
                     return false;
                 }
             } break;
+            case CF_ARRAY_POSITION: {
+                FuncExpr* func = (FuncExpr*)node;
+                List* args     = func->args;
+
+                if (list_length(args) == 2) {
+                    break;
+                }
+
+                if (list_length(args) != 3) {
+                    return false;
+                }
+                /* We allow positive third argument > 0. */
+                Expr* start = (Expr*)list_nth(args, 2);
+                if (!IsA(start, Const) || ((Const*)start)->constisnull ||
+                    DatumGetInt32(((Const*)start)->constvalue) <= 0) {
+                    return false;
+                }
+                break;
+            }
             case CF_TO_CHAR: {
                 /* format must be a constant with exact CH translation */
                 Expr* fmt = (Expr*)list_nth(((FuncExpr*)node)->args, 1);

--- a/test/expected/array_functions.out
+++ b/test/expected/array_functions.out
@@ -115,14 +115,14 @@ SELECT * FROM t1 WHERE cardinality(vals) = 3;
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
 
--- array_position → indexOf
+-- array_position → nullIf(indexOf, 0)
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((indexOf(vals, 20) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 20), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
@@ -130,6 +130,135 @@ SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
 ----+------------+---------+----------
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
+
+-- array_position returns NULL rather than zero when the value is absent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 999), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Returns no records because result is `NULL` not `0`.
+SELECT id FROM t1 WHERE array_position(vals, 999) = 0 ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Third argument constant > 0 should push down arraySlice().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) = 2))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE ((((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) * 10) = 20)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- Third argument should push down arraySlice(), not found should return NULL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 999), 0) + (2 - 1)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should be safe to start search outside array bounds.
+SELECT id FROM t1
+WHERE array_position(vals, 20, 100) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should not find 10 in index 1 because we're starting from 2.
+SELECT id FROM t1
+WHERE array_position(vals, 10, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Third argument < 1 should prevent pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 0) = 2
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, 0) = 2)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+-- Non-constant third argument should not push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, id) IS NOT NULL
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, t1.id) IS NOT NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
 
 -- array_length → length (drops dimension arg)
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/expected/array_functions_1.out
+++ b/test/expected/array_functions_1.out
@@ -115,14 +115,14 @@ SELECT * FROM t1 WHERE cardinality(vals) = 3;
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
 
--- array_position → indexOf
+-- array_position → nullIf(indexOf, 0)
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((indexOf(vals, 20) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 20), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
@@ -130,6 +130,135 @@ SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
 ----+------------+---------+----------
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
+
+-- array_position returns NULL rather than zero when the value is absent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 999), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Returns no records because result is `NULL` not `0`.
+SELECT id FROM t1 WHERE array_position(vals, 999) = 0 ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Third argument constant > 0 should push down arraySlice().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) = 2))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE ((((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) * 10) = 20)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- Third argument should push down arraySlice(), not found should return NULL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 999), 0) + (2 - 1)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should be safe to start search outside array bounds.
+SELECT id FROM t1
+WHERE array_position(vals, 20, 100) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should not find 10 in index 1 because we're starting from 2.
+SELECT id FROM t1
+WHERE array_position(vals, 10, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Third argument < 1 should prevent pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 0) = 2
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, 0) = 2)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+-- Non-constant third argument should not push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, id) IS NOT NULL
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, t1.id) IS NOT NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
 
 -- array_length → length (drops dimension arg)
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/expected/array_functions_2.out
+++ b/test/expected/array_functions_2.out
@@ -115,14 +115,14 @@ SELECT * FROM t1 WHERE cardinality(vals) = 3;
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
 
--- array_position → indexOf
+-- array_position → nullIf(indexOf, 0)
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((indexOf(vals, 20) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 20), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
@@ -130,6 +130,135 @@ SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
 ----+------------+---------+----------
   1 | {10,20,30} | {a,b,c} | aa-bb-cc
 (1 row)
+
+-- array_position returns NULL rather than zero when the value is absent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(vals, 999), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Returns no records because result is `NULL` not `0`.
+SELECT id FROM t1 WHERE array_position(vals, 999) = 0 ORDER BY id;
+ id 
+----
+(0 rows)
+
+-- Third argument constant > 0 should push down arraySlice().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id, vals, tags, list
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) = 2))
+(3 rows)
+
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+ id |    vals    |  tags   |   list   
+----+------------+---------+----------
+  1 | {10,20,30} | {a,b,c} | aa-bb-cc
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE ((((nullIf(indexOf(arraySlice(vals, 2), 20), 0) + (2 - 1)) * 10) = 20)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- Third argument should push down arraySlice(), not found should return NULL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.t1 WHERE (((nullIf(indexOf(arraySlice(vals, 2), 999), 0) + (2 - 1)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should be safe to start search outside array bounds.
+SELECT id FROM t1
+WHERE array_position(vals, 20, 100) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Should not find 10 in index 1 because we're starting from 2.
+SELECT id FROM t1
+WHERE array_position(vals, 10, 2) IS NULL
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+-- Third argument < 1 should prevent pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 0) = 2
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, 0) = 2)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+-- Non-constant third argument should not push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, id) IS NOT NULL
+ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_position(t1.vals, 20, t1.id) IS NOT NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
 
 -- array_length → length (drops dimension arg)
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -17,7 +17,6 @@ SELECT clickhouse_raw_query($$
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
-
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -65,10 +64,61 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE cardinality(vals) = 3;
 SELECT * FROM t1 WHERE cardinality(vals) = 3;
 
--- array_position → indexOf
+-- array_position → nullIf(indexOf, 0)
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
 SELECT * FROM t1 WHERE array_position(vals, 20) = 2;
+
+-- array_position returns NULL rather than zero when the value is absent.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+SELECT id FROM t1 WHERE array_position(vals, 999) IS NULL ORDER BY id;
+-- Returns no records because result is `NULL` not `0`.
+SELECT id FROM t1 WHERE array_position(vals, 999) = 0 ORDER BY id;
+
+-- Third argument constant > 0 should push down arraySlice().
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+SELECT * FROM t1 WHERE array_position(vals, 20, 2) = 2;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+SELECT id FROM t1
+WHERE array_position(vals, 20, 2) * 10 = 20
+ORDER BY id;
+
+-- Third argument should push down arraySlice(), not found should return NULL.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+SELECT id FROM t1
+WHERE array_position(vals, 999, 2) IS NULL
+ORDER BY id;
+
+-- Should be safe to start search outside array bounds.
+SELECT id FROM t1
+WHERE array_position(vals, 20, 100) IS NULL
+ORDER BY id;
+
+-- Should not find 10 in index 1 because we're starting from 2.
+SELECT id FROM t1
+WHERE array_position(vals, 10, 2) IS NULL
+ORDER BY id;
+
+-- Third argument < 1 should prevent pushdown.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, 0) = 2
+ORDER BY id;
+
+-- Non-constant third argument should not push down.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1
+WHERE array_position(vals, 20, id) IS NOT NULL
+ORDER BY id;
 
 -- array_length → length (drops dimension arg)
 EXPLAIN (VERBOSE, COSTS OFF)


### PR DESCRIPTION
## Summary

Preserves PostgreSQL `array_position()` not-found and start-position semantics for supported expressions pushed to ClickHouse.

## Change

- The two-argument form uses `nullIf(indexOf(...), 0)` so an absent value returns `NULL`.
- Positive constant third arguments use `arraySlice()` and restore the original position with `start - 1`.
- Dynamic, NULL, or non-positive third arguments remain local.
- Floating-point arrays remain eligible for pushdown. ClickHouse currently differs from PostgreSQL for `NaN` matching: `indexOf([1.1, nan], nan)` returns `0` instead of `1`. This is tracked in [ClickHouse#113169](https://github.com/ClickHouse/ClickHouse/issues/113169).
- The translated expression is parenthesized so nested arithmetic keeps PostgreSQL operator precedence.

## Tests

- Found and absent values, including `= 0` and `IS NULL` predicates.
- Positive starts, including a value before the start position, absent values, out-of-range starts, non-positive starts, and dynamic starts.
- Nested arithmetic with a three-argument call.
- `gmake installcheck` on PostgreSQL 19 / ClickHouse 26.3.
- `gmake installcheck REGRESS=array_functions` on PostgreSQL 19 / ClickHouse 23.3.
