### PR TITLE
Reject JSON paths containing NULL elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ All notable changes to this project will be documented in this file. It uses the
     ClickHouse does not find an element. Thanks to Minh Vu for the PR ([#334])!
 *   Fixed `array_length()` pushdown to preserve empty-array and requested
     dimension semantics. Thanks to Minh Vu for the PR ([#336])!
+*   Taught `json_extract_path*()` and `jsonb_extract_path*()` not to push down
+    when the path array contains any `NULL` elements. Thanks to Minh Vu for
+    the PR ([#335])!
 
 ### 📚 Documentation
 
@@ -194,6 +197,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#333 fix: encode bytea array literals"
   [#334]: https://github.com/ClickHouse/pg_clickhouse/pull/334
     "ClickHouse/pg_clickhouse#334 Preserve array_position not-found semantics"
+  [#335]: https://github.com/ClickHouse/pg_clickhouse/pull/335
+    "ClickHouse/pg_clickhouse#335 Reject JSON paths containing NULL elements"
   [#336]: https://github.com/ClickHouse/pg_clickhouse/pull/336
     "ClickHouse/pg_clickhouse#336 Preserve array_length semantics"
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1031,6 +1031,11 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
                 return false;
             }
 
+            Const* path = (Const*)lsecond(fe->args);
+            if (array_contains_nulls(DatumGetArrayTypeP(path->constvalue))) {
+                return false;
+            }
+
             /* Only recurse on the column expression. */
             if (!foreign_expr_walker(
                     (Node*)linitial(fe->args), glob_cxt, EXPR_CTX_EXACT

--- a/test/expected/json.out
+++ b/test/expected/json.out
@@ -1752,6 +1752,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1956,6 +1970,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_1.out
+++ b/test/expected/json_1.out
@@ -1662,6 +1662,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1866,6 +1880,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_2.out
+++ b/test/expected/json_2.out
@@ -1752,6 +1752,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1956,6 +1970,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_3.out
+++ b/test/expected/json_3.out
@@ -1549,6 +1549,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1741,6 +1755,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_4.out
+++ b/test/expected/json_4.out
@@ -1323,6 +1323,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1506,6 +1520,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_5.out
+++ b/test/expected/json_5.out
@@ -1323,6 +1323,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1506,6 +1520,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/expected/json_6.out
+++ b/test/expected/json_6.out
@@ -1323,6 +1323,20 @@ SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city'
   1
 (1 row)
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on json_http.events
+   Output: id
+   Filter: (jsonb_extract_path_text(events.props, VARIADIC '{address,NULL,city}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -1506,6 +1520,17 @@ SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'c
 ----
   1
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Foreign Scan on json_http.json_events
+   Output: id
+   Filter: (json_extract_path(json_events.props, VARIADIC '{NULL}'::text[]) IS NULL)
+   Remote SQL: SELECT id, props FROM json_test.events
+(4 rows)
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
  clickhouse_raw_query 

--- a/test/sql/json.sql
+++ b/test/sql/json.sql
@@ -558,6 +558,13 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
 SELECT id FROM json_bin.events WHERE jsonb_extract_path(props, 'address', 'city') = '"Paris"'::jsonb;
 
+-- NULL path elements must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.events
+WHERE jsonb_extract_path_text(
+    props, VARIADIC ARRAY['address', NULL, 'city']::text[]
+) IS NULL;
+
 -- =======================================================================
 -- json_extract_path_text / json_extract_path pushdown
 -- =======================================================================
@@ -626,6 +633,10 @@ SELECT id FROM json_http.json_events WHERE json_extract_path(props, 'address', '
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
 SELECT id FROM json_bin.json_events WHERE json_extract_path(props, 'address', 'city')::text = '"Paris"';
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM json_http.json_events
+WHERE json_extract_path(props, VARIADIC ARRAY[NULL]::text[]) IS NULL;
 
 SELECT clickhouse_raw_query('DROP DATABASE json_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER binary_json_loopback;


### PR DESCRIPTION
## Summary

Prevents `json_extract_path*()` and `jsonb_extract_path*()` calls with a `NULL` path element from being pushed down.

## Problem

PostgreSQL returns `NULL` when any element of the variadic path is `NULL`. The FDW accepted such paths, then deconstructed the `text[]` and converted every element to text without consulting its null bitmap. That could dereference a NULL datum during planning or deparsing.

## Change

Reject constant paths containing a `NULL` element in the existing JSON-path shippability gate. PostgreSQL evaluates those expressions locally; non-NULL constant paths retain dot-notation pushdown.

## Tests

- Added planner regressions for text-returning and JSON-returning path functions.
- `gmake installcheck REGRESS=json` on PostgreSQL 19 with ClickHouse 26.3 and 23.3.
- `gmake installcheck` on PostgreSQL 19 with ClickHouse 26.3.