### PR TITLE
Preserve array_length semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ All notable changes to this project will be documented in this file. It uses the
     comparisons. Thanks to @jxom for the PR (#333)!
 *   Fixed `array_position()` pushdown to return `NULL`, rather than zero, when
     ClickHouse does not find an element. Thanks to Minh Vu for the PR ([#334])!
+*   Fixed `array_length()` pushdown to preserve empty-array and requested
+    dimension semantics. Thanks to Minh Vu for the PR ([#336])!
 
 ### 📚 Documentation
 
@@ -192,6 +194,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#333 fix: encode bytea array literals"
   [#334]: https://github.com/ClickHouse/pg_clickhouse/pull/334
     "ClickHouse/pg_clickhouse#334 Preserve array_position not-found semantics"
+  [#336]: https://github.com/ClickHouse/pg_clickhouse/pull/336
+    "ClickHouse/pg_clickhouse#336 Preserve array_length semantics"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1233,7 +1233,8 @@ equivalents as follows:
 *   `array_append`: [arrayPushBack](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushBack)
 *   `array_prepend`: [arrayPushFront](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayPushFront)
 *   `array_remove`: [arrayRemove](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayRemove)
-*   `array_length` & `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
+*   `cardinality`: [length](https://clickhouse.com/docs/sql-reference/functions/array-functions#length)
+*   `array_length(array, 1)`: `nullIf(length(array), 0)`
 *   `array_to_string`: [arrayStringConcat](https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayStringConcat)
 *   `string_to_array`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString)
 *   `split_part`: [splitByString](https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByString) + array subscript

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -646,9 +646,11 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
     case F_ARRAY_TO_STRING_ANYARRAY_TEXT:
         def->ch_name = "arrayStringConcat";
         return true;
-    case F_CARDINALITY:
     case F_ARRAY_LENGTH:
         def->cf_type = CF_ARRAY_LENGTH;
+        def->ch_name = "\1";
+        return true;
+    case F_CARDINALITY:
         def->ch_name = "length";
         return true;
     case F_ARRAY_REVERSE:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1041,6 +1041,22 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
         }
 
         /*
+         * ClickHouse length() only represents the first dimension. A
+         * non-empty PostgreSQL array has the same first-dimension length,
+         * but empty arrays return NULL rather than zero.
+         */
+        if (cdef && cdef->cf_type == CF_ARRAY_LENGTH) {
+            if (list_length(fe->args) != 2 || !IsA(lsecond(fe->args), Const)) {
+                return false;
+            }
+
+            Const* dimension = (Const*)lsecond(fe->args);
+            if (dimension->constisnull || DatumGetInt32(dimension->constvalue) != 1) {
+                return false;
+            }
+        }
+
+        /*
          * Recurse to input subexpressions.
          */
         if (!foreign_expr_walker((Node*)fe->args, glob_cxt, EXPR_CTX_EXACT)) {
@@ -4587,9 +4603,9 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             return;
         }
         case CF_ARRAY_LENGTH:
-            appendStringInfoChar(buf, '(');
+            appendStringInfoString(buf, "(nullIf(length(");
             deparseExpr((Expr*)linitial(node->args), context);
-            appendStringInfoChar(buf, ')');
+            appendStringInfoString(buf, "), 0))");
             return;
         case CF_ARRAY_POSITION:
             appendStringInfoChar(buf, '(');

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -425,7 +425,7 @@ typedef enum {
     CF_CURRENT_DATABASE,       /* CURRENT_DATABASE → string literal */
     CF_CURRENT_SCHEMA,         /* CF_CURRENT_SCHEMA → string literal */
     CF_CLOCK_TIMESTAMP,        /* clock_timestamp → nowInBlock64(6, $TZ) */
-    CF_ARRAY_LENGTH,           /* array_length → length, drop dim arg */
+    CF_ARRAY_LENGTH,           /* array_length(array, 1) → nullIf(length(), 0) */
     CF_ARRAY_POSITION,         /* array_position → nullIf(indexOf(), 0) */
     CF_ARRAY_PREPEND,          /* array_prepend → arrayPushFront, swap args */
     CF_STRING_TO_ARRAY,        /* string_to_array → splitByString, swap

--- a/test/expected/array_functions.out
+++ b/test/expected/array_functions.out
@@ -36,6 +36,23 @@ $$);
  
 (1 row)
 
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.empty_arrays (
+        id   Int32,
+        vals Array(Int32)
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -260,14 +277,14 @@ ORDER BY id;
    Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
 (4 rows)
 
--- array_length → length (drops dimension arg)
+-- array_length → nullIf(length(), 0) for the first dimension
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((length(vals) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(length(vals), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
@@ -275,6 +292,49 @@ SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
 ----+---------+-------+------
   2 | {40,50} | {d,e} | x//z
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.empty_arrays
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.empty_arrays WHERE (((nullIf(length(vals), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Other dimensions and dynamic dimensions must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, 2) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, 2) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, t1.id) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+ id 
+----
+  2
+  3
+(2 rows)
 
 -- array_prepend → arrayPushFront (args reversed)
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -622,4 +682,6 @@ SELECT clickhouse_raw_query('DROP DATABASE arr_test');
 (1 row)
 
 DROP SERVER arr_svr CASCADE;
-NOTICE:  drop cascades to foreign table t1
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table empty_arrays
+drop cascades to foreign table t1

--- a/test/expected/array_functions_1.out
+++ b/test/expected/array_functions_1.out
@@ -36,6 +36,23 @@ $$);
  
 (1 row)
 
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.empty_arrays (
+        id   Int32,
+        vals Array(Int32)
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -260,14 +277,14 @@ ORDER BY id;
    Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
 (4 rows)
 
--- array_length → length (drops dimension arg)
+-- array_length → nullIf(length(), 0) for the first dimension
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((length(vals) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(length(vals), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
@@ -275,6 +292,49 @@ SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
 ----+---------+-------+------
   2 | {40,50} | {d,e} | x//z
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.empty_arrays
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.empty_arrays WHERE (((nullIf(length(vals), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Other dimensions and dynamic dimensions must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, 2) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, 2) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, t1.id) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+ id 
+----
+  2
+  3
+(2 rows)
 
 -- array_prepend → arrayPushFront (args reversed)
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -594,4 +654,6 @@ SELECT clickhouse_raw_query('DROP DATABASE arr_test');
 (1 row)
 
 DROP SERVER arr_svr CASCADE;
-NOTICE:  drop cascades to foreign table t1
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table empty_arrays
+drop cascades to foreign table t1

--- a/test/expected/array_functions_2.out
+++ b/test/expected/array_functions_2.out
@@ -36,6 +36,23 @@ $$);
  
 (1 row)
 
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.empty_arrays (
+        id   Int32,
+        vals Array(Int32)
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
+SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
+ clickhouse_raw_query 
+----------------------
+ 
+(1 row)
+
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -260,14 +277,14 @@ ORDER BY id;
    Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
 (4 rows)
 
--- array_length → length (drops dimension arg)
+-- array_length → nullIf(length(), 0) for the first dimension
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Foreign Scan on arr_test.t1
    Output: id, vals, tags, list
-   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE ((length(vals) = 2))
+   Remote SQL: SELECT id, vals, tags, list FROM arr_test.t1 WHERE (((nullIf(length(vals), 0)) = 2))
 (3 rows)
 
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
@@ -275,6 +292,49 @@ SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
 ----+---------+-------+------
   2 | {40,50} | {d,e} | x//z
 (1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on arr_test.empty_arrays
+   Output: id
+   Remote SQL: SELECT id FROM arr_test.empty_arrays WHERE (((nullIf(length(vals), 0)) IS NULL)) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+ id 
+----
+  4
+(1 row)
+
+-- Other dimensions and dynamic dimensions must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, 2) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, 2) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Foreign Scan on arr_test.t1
+   Output: id
+   Filter: (array_length(t1.vals, t1.id) IS NULL)
+   Remote SQL: SELECT id, vals FROM arr_test.t1 ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+ id 
+----
+  2
+  3
+(2 rows)
 
 -- array_prepend → arrayPushFront (args reversed)
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -618,4 +678,6 @@ SELECT clickhouse_raw_query('DROP DATABASE arr_test');
 (1 row)
 
 DROP SERVER arr_svr CASCADE;
-NOTICE:  drop cascades to foreign table t1
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to foreign table empty_arrays
+drop cascades to foreign table t1

--- a/test/expected/re2_functions.out
+++ b/test/expected/re2_functions.out
@@ -339,11 +339,11 @@ SELECT id FROM t1 WHERE re2splitbyregexp(' ', val, 2) = ARRAY['re2','uses'];
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM t1 WHERE array_length(re2extractallgroupsvertical(val, '(\w+) (\w+)'), 1) > 0;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
    Output: id
-   Remote SQL: SELECT id FROM re2_test.t1 WHERE ((length(extractAllGroupsVertical(val, '(\\w+) (\\w+)')) > 0))
+   Remote SQL: SELECT id FROM re2_test.t1 WHERE (((nullIf(length(extractAllGroupsVertical(val, '(\\w+) (\\w+)')), 0)) > 0))
 (3 rows)
 
 SELECT id FROM t1 WHERE array_length(re2extractallgroupsvertical(val, '(\w+) (\w+)'), 1) > 0;
@@ -356,11 +356,11 @@ SELECT id FROM t1 WHERE array_length(re2extractallgroupsvertical(val, '(\w+) (\w
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM t1 WHERE array_length(re2extractallgroupshorizontal(val, '(\w+) (\w+)'), 1) = 2;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan on re2_test.t1
    Output: id
-   Remote SQL: SELECT id FROM re2_test.t1 WHERE ((length(extractAllGroupsHorizontal(val, '(\\w+) (\\w+)')) = 2))
+   Remote SQL: SELECT id FROM re2_test.t1 WHERE (((nullIf(length(extractAllGroupsHorizontal(val, '(\\w+) (\\w+)')), 0)) = 2))
 (3 rows)
 
 SELECT id FROM t1 WHERE array_length(re2extractallgroupshorizontal(val, '(\w+) (\w+)'), 1) = 2;

--- a/test/sql/array_functions.sql
+++ b/test/sql/array_functions.sql
@@ -17,6 +17,14 @@ SELECT clickhouse_raw_query($$
         (2, [40,50],    ['d','e'], 'x//z'),
         (3, [60],       ['f'], 'Edit -> Insert -> Line Break')
 $$);
+SELECT clickhouse_raw_query($$
+    CREATE TABLE arr_test.empty_arrays (
+        id   Int32,
+        vals Array(Int32)
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+SELECT clickhouse_raw_query('INSERT INTO arr_test.empty_arrays VALUES (4, [])');
+
 CREATE SCHEMA arr_test;
 IMPORT FOREIGN SCHEMA arr_test FROM SERVER arr_svr INTO arr_test;
 SET search_path = arr_test, public;
@@ -120,10 +128,20 @@ SELECT id FROM t1
 WHERE array_position(vals, 20, id) IS NOT NULL
 ORDER BY id;
 
--- array_length → length (drops dimension arg)
+-- array_length → nullIf(length(), 0) for the first dimension
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
 SELECT * FROM t1 WHERE array_length(vals, 1) = 2;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+SELECT id FROM empty_arrays WHERE array_length(vals, 1) IS NULL ORDER BY id;
+
+-- Other dimensions and dynamic dimensions must evaluate locally.
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, 2) IS NULL ORDER BY id;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
+SELECT id FROM t1 WHERE array_length(vals, id) IS NULL ORDER BY id;
 
 -- array_prepend → arrayPushFront (args reversed)
 EXPLAIN (VERBOSE, COSTS OFF)


### PR DESCRIPTION
## Summary

Preserves PostgreSQL `array_length()` semantics while retaining safe ClickHouse pushdown for first-dimension lookups.

## Problem

`array_length()` and `cardinality()` were both rewritten to `length()`. That discarded `array_length()`'s requested dimension and returned `0` for empty arrays, where PostgreSQL returns `NULL`.

## Change

- Keep `cardinality()` mapped directly to `length()`.
- Push down `array_length(array, 1)` as `nullIf(length(array), 0)`.
- Evaluate non-first, `NULL`, and dynamic dimensions locally.

## Tests

- Added coverage for an empty foreign array returning `NULL`.
- Added planner coverage confirming literal non-first and dynamic dimensions stay local.
- `gmake installcheck REGRESS=array_functions` on PostgreSQL 19 with ClickHouse 26.3.
- `gmake installcheck` on PostgreSQL 19 with ClickHouse 26.3.
- Repository hooks, including formatting and static analysis.