### PR TITLE
Avoid NULL dereference for ordered aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,18 @@ All notable changes to this project will be documented in this file. It uses the
     `CALL clickhouse_perform(server, sql)` to run statements that return none;
     both take a foreign server rather than a connection string. ([#346])
 
+### 🐞 Bug Fixes
+
+*   Fixed an issue where a check for ordered aggregates incorrectly handled
+    custom aggregates that were not part of an extension. It now properly
+    keeps custom aggregate execution local. Thanks to Minh Vu for the PR
+    ([#337])!
+
   [v0.11.0]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.10.0...v0.11.0
   [#346]: https://github.com/ClickHouse/pg_clickhouse/pull/346
     "ClickHouse/pg_clickhouse#346 remove clickhouse_raw_query"
+  [#337]: https://github.com/ClickHouse/pg_clickhouse/pull/337
+    "ClickHouse/pg_clickhouse#337 Avoid NULL dereference for ordered aggregates"
 
 ## [v0.10.0] — 2026-08-11
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -345,10 +345,8 @@ chfdw_check_for_ordered_aggregate(Aggref* agg) {
     }
 
     /* Accept all ordered aggregates defined by pg_clickhouse. */
-    Oid extoid    = getExtensionOfObject(ProcedureRelationId, agg->aggfnoid);
-    char* extname = get_extension_name(extoid);
-
-    return STR_EQUAL(extname, "pg_clickhouse");
+    Oid extoid = getExtensionOfObject(ProcedureRelationId, agg->aggfnoid);
+    return get_extension_oid("pg_clickhouse", true) == extoid;
 }
 
 /*

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_0.out
+++ b/test/expected/functions_0.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_8.out
+++ b/test/expected/functions_8.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/expected/functions_9.out
+++ b/test/expected/functions_9.out
@@ -703,6 +703,35 @@ SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LA
  {2,2,2}
 (1 row)
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Aggregate
+   Output: local_ordered_count() WITHIN GROUP (ORDER BY a)
+   ->  Foreign Scan on public.t1
+         Output: a, b, c
+         Remote SQL: SELECT a FROM functions_test.t1
+(5 rows)
+
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+ local_ordered_count 
+---------------------
+                   4
+(1 row)
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                        QUERY PLAN                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -223,6 +223,25 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITH
 SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a) FILTER (WHERE b = 1) FROM t1;
 SELECT percentile_disc(ARRAY[0.25, 0.5, 0.75]) WITHIN GROUP (ORDER BY a NULLS LAST) FROM t1;
 
+CREATE FUNCTION local_ordered_sfunc(integer, integer)
+RETURNS integer
+LANGUAGE SQL
+IMMUTABLE
+AS 'SELECT $1 + 1';
+
+CREATE AGGREGATE local_ordered_count(ORDER BY integer) (
+    SFUNC = local_ordered_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+SELECT local_ordered_count() WITHIN GROUP (ORDER BY a) FROM t1;
+
+DROP AGGREGATE local_ordered_count(integer);
+DROP FUNCTION local_ordered_sfunc(integer, integer);
+
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 


### PR DESCRIPTION
## Summary

`chfdw_check_for_ordered_aggregate()` called `get_extension_name()` and then `strcmp()` without handling aggregates that are not owned by an extension. Planning an extensionless ordered-set aggregate could therefore dereference NULL and crash the backend.

This change returns false for invalid or missing extension OIDs, frees the extension name, and adds a regression covering a local ordered-set aggregate. The regression confirms that the aggregate stays local while the foreign scan retrieves its input column.

## Testing

- `pg-build-test`
- `make installcheck REGRESS=functions`
