### PR TITLE
Preserve fractional seconds in to_timestamp()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,9 @@ All notable changes to this project will be documented in this file. It uses the
 *   Taught `json_extract_path*()` and `jsonb_extract_path*()` not to push down
     when the path array contains any `NULL` elements. Thanks to Minh Vu for
     the PR ([#335])!
+*   Fixed loss of subsecond precision in `to_timestamp(float8)` by mapping it
+    to the ClickHouse `toDateTime64()` function instead of
+    `fromUnixTimestamp()`. Thanks to Minh Vu for the PR ([#338]).
 
 ### 📚 Documentation
 
@@ -222,6 +225,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#335 Reject JSON paths containing NULL elements"
   [#336]: https://github.com/ClickHouse/pg_clickhouse/pull/336
     "ClickHouse/pg_clickhouse#336 Preserve array_length semantics"
+  [#338]: https://github.com/ClickHouse/pg_clickhouse/pull/338
+    "ClickHouse/pg_clickhouse#338 Preserve fractional seconds in to_timestamp()"
 
 ## [v0.3.2] — 2026-06-16
 

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1308,7 +1308,7 @@ equivalents as follows:
 *   `jsonb_extract_path_text`: [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `jsonb_extract_path`: [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `bit_count(bytea)`: [bitCount](https://clickhouse.com/docs/sql-reference/functions/bit-functions#bitcount)
-*   `to_timestamp(float8)`: [fromUnixTimestamp](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#fromUnixTimestamp)
+*   `to_timestamp(float8)`: [toDateTime64](https://clickhouse.com/docs/sql-reference/functions/type-conversion-functions#todatetime64)
 *   `to_char(timestamp[tz], fmt)`: [formatDateTime](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#formatDateTime)
     when `fmt` is a string constant whose every keyword has a faithful
     ClickHouse equivalent. See [to_char()](#to_char) under Compatibility

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -594,11 +594,9 @@ lookup_builtin_func(Oid funcid, builtin_func_def* def) {
         return true;
         /* CH lacks "power", maps to pow */
     case F_TO_TIMESTAMP_FLOAT8:
-        def->ch_name     = "fromUnixTimestamp(toInt64";
-        def->paren_count = 2;
+        def->cf_type = CF_TO_TIMESTAMP;
+        def->ch_name = "\1";
         return true;
-        /* ClickHouse doesn't work with subsecond precision */
-        /* timestamps. */
     case F_TO_CHAR_TIMESTAMP_TEXT:
     case F_TO_CHAR_TIMESTAMPTZ_TEXT:
         def->cf_type = CF_TO_CHAR;

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -4406,6 +4406,12 @@ deparseFuncExpr(FuncExpr* node, deparse_expr_cxt* context) {
             appendStringInfo(buf, "nowInBlock64(6, %s)", QUOTED_TZ);
             return;
         }
+        case CF_TO_TIMESTAMP: {
+            appendStringInfoString(buf, "toDateTime64(");
+            deparseExpr((Expr*)linitial(node->args), context);
+            appendStringInfoString(buf, ", 6, 'UTC')");
+            return;
+        }
         case CF_DATE_TRUNC: {
             Const* arg      = (Const*)linitial(node->args);
             char* trunctype = TextDatumGetCString(arg->constvalue);

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -396,6 +396,7 @@ typedef enum {
     CF_CURRENT_DATABASE,       /* CURRENT_DATABASE → string literal */
     CF_CURRENT_SCHEMA,         /* CF_CURRENT_SCHEMA → string literal */
     CF_CLOCK_TIMESTAMP,        /* clock_timestamp → nowInBlock64(6, $TZ) */
+    CF_TO_TIMESTAMP,           /* to_timestamp → toDateTime64($arg, 6, 'UTC') */
     CF_ARRAY_LENGTH,           /* array_length(array, 1) → nullIf(length(), 0) */
     CF_ARRAY_POSITION,         /* array_position → nullIf(indexOf(), 0) */
     CF_ARRAY_PREPEND,          /* array_prepend → arrayPushFront, swap args */

--- a/test/expected/functions.out
+++ b/test/expected/functions.out
@@ -1538,11 +1538,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1552,11 +1552,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1566,11 +1566,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1580,14 +1580,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_0.out
+++ b/test/expected/functions_0.out
@@ -1538,11 +1538,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1552,11 +1552,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1566,11 +1566,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1580,14 +1580,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_1.out
+++ b/test/expected/functions_1.out
@@ -1538,11 +1538,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1552,11 +1552,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1566,11 +1566,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1580,14 +1580,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_2.out
+++ b/test/expected/functions_2.out
@@ -1538,11 +1538,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1552,11 +1552,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1566,11 +1566,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1580,14 +1580,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_3.out
+++ b/test/expected/functions_3.out
@@ -1538,11 +1538,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1552,11 +1552,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1566,11 +1566,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1580,14 +1580,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_4.out
+++ b/test/expected/functions_4.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_5.out
+++ b/test/expected/functions_5.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_6.out
+++ b/test/expected/functions_6.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_7.out
+++ b/test/expected/functions_7.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_8.out
+++ b/test/expected/functions_8.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/expected/functions_9.out
+++ b/test/expected/functions_9.out
@@ -1534,11 +1534,11 @@ SELECT key1 FROM t3_map WHERE md5(val) LIKE 'a%' ORDER BY key1;
 
 -- Check to_timestamp(float8).
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
@@ -1548,11 +1548,11 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
@@ -1562,11 +1562,11 @@ SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(0);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(0);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(i64)) = '1970-01-01 00:00:00'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(i64, 6, 'UTC') = '1970-01-01 00:00:00'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
@@ -1576,14 +1576,19 @@ SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 (1 row)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Foreign Scan on public.t6
    Output: i64, f64
-   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((fromUnixTimestamp(toInt64(f64)) = '2034-09-20 00:04:03'))
+   Remote SQL: SELECT i64, f64 FROM functions_test.t6 WHERE ((toDateTime64(f64, 6, 'UTC') = '2034-09-20 00:04:03'))
 (3 rows)
 
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+ i64 | f64 
+-----+-----
+(0 rows)
+
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
     i64     |      f64       
 ------------+----------------
  2042323443 | 2042323443.232

--- a/test/sql/functions.sql
+++ b/test/sql/functions.sql
@@ -374,6 +374,7 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(i64) = to_times
 SELECT * FROM t6 WHERE to_timestamp(i64) = to_timestamp(2042323443);
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
 SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443);
+SELECT * FROM t6 WHERE to_timestamp(f64) = to_timestamp(2042323443.232);
 
 -- Check current_*-type functions.
 EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM t1 WHERE c < NOW();


### PR DESCRIPTION
## Summary

to_timestamp(float8) was pushed down as fromUnixTimestamp(toInt64(...)), which truncated fractional Unix timestamps. Leave the built-in for PostgreSQL evaluation so subsecond precision is preserved.

The regression coverage checks that 2042323443.232 does not match 2042323443, and does match the fractional value.

## Testing

- The extension builds and installs with -Werror.
- The to_timestamp section of make installcheck REGRESS=functions matches.
- This ClickHouse 26.7 image still has unrelated existing base64/base64url, JSON, and timeout expectation differences.