### PR TITLE
Add pushdown for JSONB ? operator, with casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ All notable changes to this project will be documented in this file. It uses the
     go binary encoding, the HTTP driver always streams results the same as the
     binary driver. Setting `fetch_size` triggers a warning and will be removed
     in a future release. ([#328])
+*   Added pushdown for the JSONB `?` existence operator. Evaluates not only
+    ClickHouse JSON columns mapped to JSONB, but also ClickHouse String
+    columns that contain JSON, thus working on both JSON objects and JSON
+    arrays. Thanks to Kostia R for the PR ([#344])!
 
 ### 🐞 Bug Fixes
 
@@ -203,6 +207,8 @@ All notable changes to this project will be documented in this file. It uses the
     "ClickHouse/pg_clickhouse#317 Push down the array IN family unconditionally"
   [#319]: https://github.com/ClickHouse/pg_clickhouse/pull/319
     "ClickHouse/pg_clickhouse#319 Fix foreign scan RTE selection"
+  [#344]: https://github.com/ClickHouse/pg_clickhouse/pull/344
+    "ClickHouse/pg_clickhouse#344 Push down JSONB existence predicates"
   [#326]: https://github.com/ClickHouse/pg_clickhouse/pull/326
     "ClickHouse/pg_clickhouse#326 pg-clickhouse-c"
   [#328]: https://github.com/ClickHouse/pg_clickhouse/pull/328

--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -1087,7 +1087,7 @@ These functions provide the interface to query a ClickHouse database.
 
 ```sql
 SELECT clickhouse_raw_query(
-    'CREATE TABLE t1 (x String) ENGINE = Memory',
+    'CREATE TABLE t1 (elem String) ENGINE = Memory',
     'host=localhost port=8123'
 );
 ```
@@ -1347,6 +1347,11 @@ equivalents as follows:
 *   `!~*` (case insensitive regexp not match): [match](https://clickhouse.com/docs/sql-reference/functions/string-search-functions#match)
 *   `->>` (JSON/JSONB extract element as text): [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
 *   `->` (JSON/JSONB extract): [toJSONString](https://clickhouse.com/docs/sql-reference/functions/json-functions#toJSONString) + [sub-column syntax](https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns)
+*   `?` (JSONB top-level key or array of keys):
+    [JSONHas](https://clickhouse.com/docs/sql-reference/functions/json-functions#jsonhas)
+    for objects and
+    [JSONExtractArrayRaw](https://clickhouse.com/docs/sql-reference/functions/json-functions#jsonextractarrayraw)
+    for arrays.
 
 ### IN and NULL Semantics
 

--- a/src/custom_types.c
+++ b/src/custom_types.c
@@ -951,6 +951,7 @@ chfdw_check_for_custom_type(Oid typeoid) {
 #define OID_TEXT_REGEX_NE_OP 642
 #define OID_TEXT_IREGEX_NE_OP 1229
 #define OID_JSONB_FETCHVAL_OP 3211
+#define OID_JSONB_EXISTS_OP 3247
 #define OID_JSONB_FETCHVAL_TEXT_OP 3477
 #define OID_JSON_FETCHVAL_OP 3962
 #define OID_JSON_FETCHVAL_TEXT_OP 3963
@@ -982,6 +983,8 @@ classify_builtin_operator(Oid opoid) {
     case OID_JSONB_FETCHVAL_TEXT_OP:
     case OID_JSON_FETCHVAL_TEXT_OP:
         return CF_JSON_FETCHVAL_TEXT;
+    case OID_JSONB_EXISTS_OP:
+        return CF_JSON_EXISTS;
     case OID_ARRAY_CONTAINS_OP:
         return CF_ARRAY_CONTAINS;
     case OID_ARRAY_CONTAINED_OP:

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -198,6 +198,12 @@ typedef enum ExprTruthCtx {
     EXPR_CTX_EXACT,
 } ExprTruthCtx;
 
+typedef enum JsonbDocumentKind {
+    JSONB_DOCUMENT_UNSUPPORTED,
+    JSONB_DOCUMENT_NATIVE,
+    JSONB_DOCUMENT_STRING,
+} JsonbDocumentKind;
+
 /*
  * Functions to determine whether an expression can be evaluated safely on
  * remote server.
@@ -257,6 +263,13 @@ static void
 deparseSQLValueFunction(SQLValueFunction* node, deparse_expr_cxt* context);
 static void
 deparseOpExpr(OpExpr* node, deparse_expr_cxt* context);
+static void
+deparseJsonbExists(
+    Expr* document,
+    Expr* key,
+    JsonbDocumentKind document_kind,
+    deparse_expr_cxt* context
+);
 static void
 deparseOperatorName(StringInfo buf, Form_pg_operator opform);
 static void
@@ -382,6 +395,8 @@ get_relation_column_alias_ids(
     int* relno,
     int* colno
 );
+static JsonbDocumentKind
+classifyJsonbDocument(Expr* expr, Expr** document);
 
 /*
  * Examine each qual clause in input_conds, and classify them into two groups,
@@ -895,6 +910,63 @@ classify_notin_subplan(SubPlan* subplan, PlannerInfo* root, Relids relids) {
 }
 
 /*
+ * Recognize either a native ClickHouse JSON column imported as jsonb or the
+ * compatibility-view shape used for a String containing a JSON document:
+ *
+ *     jsonb_in(foreign_text_column::cstring)
+ *
+ * Arbitrary jsonb expressions stay local because their remote representation
+ * is not known.
+ */
+static JsonbDocumentKind
+classifyJsonbDocument(Expr* expr, Expr** document) {
+    while (IsA(expr, RelabelType)) {
+        expr = ((RelabelType*)expr)->arg;
+    }
+
+    if (IsA(expr, Var) && exprType((Node*)expr) == JSONBOID) {
+        *document = expr;
+        return JSONB_DOCUMENT_NATIVE;
+    }
+
+    /*
+     * Check to see if Postgres added a call to jsonb_in() to do a transparent
+     * cast. Or even if the user put it in in explicitly. In either case,
+     * we'll want to push down its behavior in deparseJsonbExists() to
+     * validate the JSON.
+     *
+     * TODO: Consider adding explicit pushdown support for jsonb_in() (and
+     * other _in functions?), rather than special case it here.
+     */
+    if (IsA(expr, FuncExpr)) {
+        FuncExpr* func = (FuncExpr*)expr;
+
+        if (func->funcid == F_JSONB_IN && list_length(func->args) == 1) {
+            Expr* input = (Expr*)linitial(func->args);
+
+            while (IsA(input, RelabelType)) {
+                input = ((RelabelType*)input)->arg;
+            }
+            if (IsA(input, CoerceViaIO)) {
+                CoerceViaIO* cast = (CoerceViaIO*)input;
+                Expr* raw         = cast->arg;
+
+                while (IsA(raw, RelabelType)) {
+                    raw = ((RelabelType*)raw)->arg;
+                }
+                if (cast->resulttype == CSTRINGOID && exprType((Node*)raw) == TEXTOID) {
+                    *document = raw;
+                    return JSONB_DOCUMENT_STRING;
+                }
+            }
+        }
+    }
+
+    *document = NULL;
+    return JSONB_DOCUMENT_UNSUPPORTED;
+}
+
+/*
  * Check if expression is safe to execute remotely, and return true if so.
  *
  * We must check that the expression contains only node types we can deparse,
@@ -1076,6 +1148,7 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
     case T_DistinctExpr: /* struct-equivalent to OpExpr */
     {
         OpExpr* oe = (OpExpr*)node;
+        CustomObjectDef* cdef;
 
         /*
          * Similarly, only shippable operators can be sent to remote.
@@ -1084,6 +1157,22 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
          */
         if (!chfdw_is_shippable(node, oe->opno, OperatorRelationId, fpinfo, NULL)) {
             return false;
+        }
+
+        cdef = chfdw_check_for_custom_operator(oe->opno, NULL);
+        if (cdef && cdef->cf_type == CF_JSON_EXISTS) {
+            Expr* document;
+            JsonbDocumentKind document_kind =
+                classifyJsonbDocument((Expr*)linitial(oe->args), &document);
+
+            if (document_kind == JSONB_DOCUMENT_UNSUPPORTED ||
+                !foreign_expr_walker((Node*)document, glob_cxt, EXPR_CTX_EXACT) ||
+                !foreign_expr_walker(
+                    (Node*)lsecond(oe->args), glob_cxt, EXPR_CTX_EXACT
+                )) {
+                return false;
+            }
+            break;
         }
 
         /*
@@ -4930,6 +5019,85 @@ findFunction(Oid typoid, char* name) {
     return result;
 }
 
+static void
+deparseJsonbDocument(
+    Expr* document,
+    JsonbDocumentKind document_kind,
+    deparse_expr_cxt* context
+) {
+    if (document_kind == JSONB_DOCUMENT_NATIVE) {
+        appendStringInfoString(context->buf, "toJSONString(");
+    }
+    deparseExpr(document, context);
+    if (document_kind == JSONB_DOCUMENT_NATIVE) {
+        appendStringInfoChar(context->buf, ')');
+    }
+}
+
+static void
+deparseJsonbNonnullDocument(
+    Expr* document,
+    JsonbDocumentKind document_kind,
+    deparse_expr_cxt* context
+) {
+    appendStringInfoString(context->buf, "ifNull(");
+    deparseJsonbDocument(document, document_kind, context);
+    appendStringInfoString(context->buf, ", 'null')");
+}
+
+static void
+deparseJsonbExists(
+    Expr* document,
+    Expr* key,
+    JsonbDocumentKind document_kind,
+    deparse_expr_cxt* context
+) {
+    StringInfo buf = context->buf;
+
+    /* First we return NULL if either the document or the key is NULL. */
+    appendStringInfoString(buf, "(if(isNull(");
+    deparseJsonbDocument(document, document_kind, context);
+    appendStringInfoString(buf, ") OR isNull(");
+    deparseExpr(key, context);
+    appendStringInfoString(buf, "), NULL, ");
+
+    if (document_kind == JSONB_DOCUMENT_STRING) {
+        /* Validate the string is valid JSON. */
+        appendStringInfoString(buf, "if(NOT isValidJSON(");
+        deparseJsonbNonnullDocument(document, document_kind, context);
+        appendStringInfoString(
+            buf, "), throwIf(1, 'invalid input syntax for type json'), "
+        );
+    }
+
+    /* Use JSONHas if the JSON is an object. */
+    appendStringInfoString(buf, "multiIf(JSONType(");
+    deparseJsonbNonnullDocument(document, document_kind, context);
+    appendStringInfoString(buf, ") = 'Object', JSONHas(");
+    deparseJsonbNonnullDocument(document, document_kind, context);
+    appendStringInfoString(buf, ", ");
+    deparseExpr(key, context);
+    /* Use arrayExists() if the JSON is an array. */
+    appendStringInfoString(buf, "), JSONType(");
+    deparseJsonbNonnullDocument(document, document_kind, context);
+    appendStringInfoString(
+        buf,
+        ") = 'Array', arrayExists(elem -> "
+        "JSONType(elem) = 'String' AND "
+        "JSONExtractString(elem) = "
+    );
+    deparseExpr(key, context);
+    appendStringInfoString(buf, ", JSONExtractArrayRaw(");
+    deparseJsonbNonnullDocument(document, document_kind, context);
+    /* Otherwise return false. */
+    appendStringInfoString(buf, ")), 0)");
+
+    if (document_kind == JSONB_DOCUMENT_STRING) {
+        appendStringInfoChar(buf, ')');
+    }
+    appendStringInfoString(buf, "))");
+}
+
 /*
  * Deparse given operator expression. To avoid problems around priority of
  * operations, we always parenthesize the arguments.
@@ -5058,6 +5226,15 @@ deparseOpExpr(OpExpr* node, deparse_expr_cxt* context) {
             appendStringInfoString(buf, ", ");
             deparseExpr(lsecond(node->args), context);
             appendStringInfoChar(buf, ')');
+            goto cleanup;
+        } break;
+        case CF_JSON_EXISTS: {
+            Expr* document;
+            JsonbDocumentKind document_kind =
+                classifyJsonbDocument(linitial(node->args), &document);
+
+            Assert(document_kind != JSONB_DOCUMENT_UNSUPPORTED);
+            deparseJsonbExists(document, lsecond(node->args), document_kind, context);
             goto cleanup;
         } break;
         case CF_JSON_FETCHVAL:

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -388,6 +388,7 @@ typedef enum {
     CF_REGEX_ICASE_NO_MATCH,   /* !~* case-insensitive regex operator */
     CF_JSON_FETCHVAL,          /* -> operator on json & jsonb */
     CF_JSON_FETCHVAL_TEXT,     /* ->> operator on json & jsonb */
+    CF_JSON_EXISTS,            /* ? operator on jsonb */
     CF_JSON_EXTRACT_PATH_TEXT, /* jsonb?_extract_path_text() →
                                 * col."k1"."k2" */
     CF_JSON_EXTRACT_PATH,      /* json?_extract_path() →

--- a/test/expected/jsonb_exists.out
+++ b/test/expected/jsonb_exists.out
@@ -1,0 +1,130 @@
+CREATE SERVER jsonb_exists_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'jsonb_exists', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CREATE SERVER jsonb_exists_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_admin;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE IF EXISTS jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', 'CREATE DATABASE jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.native_documents (
+        id Int32,
+        document JSON,
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.native_documents VALUES
+        (1, '{"key":1,"first":true}', 'xyz'),
+        (2, '{"other":2}', 'key'),
+        (3, '{"other":null}', 'abc')
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.string_documents (
+        id Int32,
+        document Nullable(String),
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.string_documents VALUES
+        (1, '{"key":1,"first":true}', 'key'),
+        (2, '["key","second",3]', 'key'),
+        (3, '{"other":2}', 'key'),
+        (4, '["other",3]', 'key'),
+        (5, NULL, 'key'),
+        (6, '"key"', '"key"')
+$$);
+CREATE FOREIGN TABLE jsonb_exists_native (
+    id integer,
+    document jsonb
+) SERVER jsonb_exists_binary OPTIONS (table_name 'native_documents');
+CREATE FOREIGN TABLE jsonb_exists_string (
+    id integer,
+    document text
+) SERVER jsonb_exists_binary OPTIONS (table_name 'string_documents');
+CREATE VIEW jsonb_exists_compatibility AS
+SELECT id, pg_catalog.jsonb_in(document::pg_catalog.cstring) AS document
+FROM jsonb_exists_string;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_native
+   Output: id
+   Remote SQL: SELECT id FROM jsonb_exists.native_documents WHERE ((if(isNull(toJSONString(document)) OR isNull('key'), NULL, multiIf(JSONType(ifNull(toJSONString(document), 'null')) = 'Object', JSONHas(ifNull(toJSONString(document), 'null'), 'key'), JSONType(ifNull(toJSONString(document), 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(toJSONString(document), 'null'))), 0)))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE ((if(isNull(document) OR isNull('key'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'key'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(document, 'null'))), 0))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE (((if(isNull(document) OR isNull('first'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'first'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'first', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))) OR (if(isNull(document) OR isNull('second'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'second'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'second', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Filter: ((jsonb_in((jsonb_exists_string.document)::cstring) || '{}'::jsonb) ? 'key'::text)
+   Remote SQL: SELECT id, document FROM jsonb_exists.string_documents ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+ id 
+----
+  1
+  2
+  6
+(3 rows)
+
+DROP VIEW jsonb_exists_compatibility;
+DROP FOREIGN TABLE jsonb_exists_string;
+DROP FOREIGN TABLE jsonb_exists_native;
+DROP USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE jsonb_exists');
+DROP SERVER jsonb_exists_binary;

--- a/test/expected/jsonb_exists_1.out
+++ b/test/expected/jsonb_exists_1.out
@@ -1,0 +1,132 @@
+CREATE SERVER jsonb_exists_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'jsonb_exists', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CREATE SERVER jsonb_exists_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_admin;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE IF EXISTS jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', 'CREATE DATABASE jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.native_documents (
+        id Int32,
+        document JSON,
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.native_documents VALUES
+        (1, '{"key":1,"first":true}', 'xyz'),
+        (2, '{"other":2}', 'key'),
+        (3, '{"other":null}', 'abc')
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.string_documents (
+        id Int32,
+        document Nullable(String),
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.string_documents VALUES
+        (1, '{"key":1,"first":true}', 'key'),
+        (2, '["key","second",3]', 'key'),
+        (3, '{"other":2}', 'key'),
+        (4, '["other",3]', 'key'),
+        (5, NULL, 'key'),
+        (6, '"key"', '"key"')
+$$);
+CREATE FOREIGN TABLE jsonb_exists_native (
+    id integer,
+    document jsonb
+) SERVER jsonb_exists_binary OPTIONS (table_name 'native_documents');
+CREATE FOREIGN TABLE jsonb_exists_string (
+    id integer,
+    document text
+) SERVER jsonb_exists_binary OPTIONS (table_name 'string_documents');
+CREATE VIEW jsonb_exists_compatibility AS
+SELECT id, pg_catalog.jsonb_in(document::pg_catalog.cstring) AS document
+FROM jsonb_exists_string;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_native
+   Output: id
+   Remote SQL: SELECT id FROM jsonb_exists.native_documents WHERE ((if(isNull(toJSONString(document)) OR isNull('key'), NULL, multiIf(JSONType(ifNull(toJSONString(document), 'null')) = 'Object', JSONHas(ifNull(toJSONString(document), 'null'), 'key'), JSONType(ifNull(toJSONString(document), 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(toJSONString(document), 'null'))), 0)))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE ((if(isNull(document) OR isNull('key'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'key'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(document, 'null'))), 0))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE (((if(isNull(document) OR isNull('first'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'first'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'first', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))) OR (if(isNull(document) OR isNull('second'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'second'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'second', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+ id 
+----
+  1
+  2
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Filter: ((jsonb_in((jsonb_exists_string.document)::cstring) || '{}'::jsonb) ? 'key'::text)
+   Remote SQL: SELECT id, document FROM jsonb_exists.string_documents ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+ id 
+----
+  1
+  2
+  6
+(3 rows)
+
+DROP VIEW jsonb_exists_compatibility;
+DROP FOREIGN TABLE jsonb_exists_string;
+DROP FOREIGN TABLE jsonb_exists_native;
+DROP USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE jsonb_exists');
+DROP SERVER jsonb_exists_binary;

--- a/test/expected/jsonb_exists_2.out
+++ b/test/expected/jsonb_exists_2.out
@@ -1,0 +1,124 @@
+CREATE SERVER jsonb_exists_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'jsonb_exists', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CREATE SERVER jsonb_exists_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_admin;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE IF EXISTS jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', 'CREATE DATABASE jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.native_documents (
+        id Int32,
+        document JSON,
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.native_documents VALUES
+        (1, '{"key":1,"first":true}', 'xyz'),
+        (2, '{"other":2}', 'key'),
+        (3, '{"other":null}', 'abc')
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.string_documents (
+        id Int32,
+        document Nullable(String),
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.string_documents VALUES
+        (1, '{"key":1,"first":true}', 'key'),
+        (2, '["key","second",3]', 'key'),
+        (3, '{"other":2}', 'key'),
+        (4, '["other",3]', 'key'),
+        (5, NULL, 'key'),
+        (6, '"key"', '"key"')
+$$);
+CREATE FOREIGN TABLE jsonb_exists_native (
+    id integer,
+    document jsonb
+) SERVER jsonb_exists_binary OPTIONS (table_name 'native_documents');
+CREATE FOREIGN TABLE jsonb_exists_string (
+    id integer,
+    document text
+) SERVER jsonb_exists_binary OPTIONS (table_name 'string_documents');
+CREATE VIEW jsonb_exists_compatibility AS
+SELECT id, pg_catalog.jsonb_in(document::pg_catalog.cstring) AS document
+FROM jsonb_exists_string;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_native
+   Output: id
+   Remote SQL: SELECT id FROM jsonb_exists.native_documents WHERE ((if(isNull(toJSONString(document)) OR isNull('key'), NULL, multiIf(JSONType(ifNull(toJSONString(document), 'null')) = 'Object', JSONHas(ifNull(toJSONString(document), 'null'), 'key'), JSONType(ifNull(toJSONString(document), 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(toJSONString(document), 'null'))), 0)))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                                                                                     
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE ((if(isNull(document) OR isNull('key'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'key'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(document, 'null'))), 0))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+ERROR:  pg_clickhouse: DB::Exception: invalid input syntax for type json: while executing 'FUNCTION throwIf(1 : 9, 'invalid input syntax for type json' : 10) -> throwIf(1, 'invalid input syntax for type json') UInt8 : 15'
+DETAIL:  Remote Query: SELECT id FROM jsonb_exists.string_documents WHERE ((if(isNull(document) OR isNull('key'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'key'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'key', JSONExtractArrayRaw(ifNull(document, 'null'))), 0))))) ORDER BY id ASC NULLS LAST
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Remote SQL: SELECT id FROM jsonb_exists.string_documents WHERE (((if(isNull(document) OR isNull('first'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'first'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'first', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))) OR (if(isNull(document) OR isNull('second'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'second'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'second', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))))) ORDER BY id ASC NULLS LAST
+(3 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+ERROR:  pg_clickhouse: DB::Exception: invalid input syntax for type json: while executing 'FUNCTION throwIf(1 : 9, 'invalid input syntax for type json' : 10) -> throwIf(1, 'invalid input syntax for type json') UInt8 : 16'
+DETAIL:  Remote Query: SELECT id FROM jsonb_exists.string_documents WHERE (((if(isNull(document) OR isNull('first'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'first'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'first', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))) OR (if(isNull(document) OR isNull('second'), NULL, if(NOT isValidJSON(ifNull(document, 'null')), throwIf(1, 'invalid input syntax for type json'), multiIf(JSONType(ifNull(document, 'null')) = 'Object', JSONHas(ifNull(document, 'null'), 'second'), JSONType(ifNull(document, 'null')) = 'Array', arrayExists(jsonb_exists_element -> JSONType(jsonb_exists_element) = 'String' AND JSONExtractString(jsonb_exists_element) = 'second', JSONExtractArrayRaw(ifNull(document, 'null'))), 0)))))) ORDER BY id ASC NULLS LAST
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Foreign Scan on public.jsonb_exists_string
+   Output: jsonb_exists_string.id
+   Filter: ((jsonb_in((jsonb_exists_string.document)::cstring) || '{}'::jsonb) ? 'key'::text)
+   Remote SQL: SELECT id, document FROM jsonb_exists.string_documents ORDER BY id ASC NULLS LAST
+(4 rows)
+
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+ id 
+----
+  1
+  2
+  6
+(3 rows)
+
+DROP VIEW jsonb_exists_compatibility;
+DROP FOREIGN TABLE jsonb_exists_string;
+DROP FOREIGN TABLE jsonb_exists_native;
+DROP USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE jsonb_exists');
+DROP SERVER jsonb_exists_binary;

--- a/test/expected/result_map.txt
+++ b/test/expected/result_map.txt
@@ -221,6 +221,19 @@ json.sql
  23.8       | json_5.out
  23.3       | json_6.out
 
+jsonb_exists.sql
+----------------
+
+ Postgres | File
+----------|------------------
+ 13+      | jsonb_exists.out
+
+ ClickHouse | File
+------------|--------------------
+ 24.8+      | jsonb_exists.out
+ 23.8-24.3  | jsonb_exists_1.out
+ 23.3       | jsonb_exists_2.out
+
 param.sql
 ---------
 

--- a/test/sql/jsonb_exists.sql
+++ b/test/sql/jsonb_exists.sql
@@ -1,0 +1,88 @@
+CREATE SERVER jsonb_exists_binary FOREIGN DATA WRAPPER clickhouse_fdw
+    OPTIONS (dbname 'jsonb_exists', driver 'binary');
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+
+CREATE SERVER jsonb_exists_admin FOREIGN DATA WRAPPER clickhouse_fdw;
+CREATE USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_admin;
+
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE IF EXISTS jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', 'CREATE DATABASE jsonb_exists');
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.native_documents (
+        id Int32,
+        document JSON,
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.native_documents VALUES
+        (1, '{"key":1,"first":true}', 'xyz'),
+        (2, '{"other":2}', 'key'),
+        (3, '{"other":null}', 'abc')
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    CREATE TABLE jsonb_exists.string_documents (
+        id Int32,
+        document Nullable(String),
+        elem String
+    ) ENGINE = MergeTree ORDER BY id
+$$);
+CALL clickhouse_perform('jsonb_exists_admin', $$
+    INSERT INTO jsonb_exists.string_documents VALUES
+        (1, '{"key":1,"first":true}', 'key'),
+        (2, '["key","second",3]', 'key'),
+        (3, '{"other":2}', 'key'),
+        (4, '["other",3]', 'key'),
+        (5, NULL, 'key'),
+        (6, '"key"', '"key"')
+$$);
+
+CREATE FOREIGN TABLE jsonb_exists_native (
+    id integer,
+    document jsonb
+) SERVER jsonb_exists_binary OPTIONS (table_name 'native_documents');
+
+CREATE FOREIGN TABLE jsonb_exists_string (
+    id integer,
+    document text
+) SERVER jsonb_exists_binary OPTIONS (table_name 'string_documents');
+
+CREATE VIEW jsonb_exists_compatibility AS
+SELECT id, pg_catalog.jsonb_in(document::pg_catalog.cstring) AS document
+FROM jsonb_exists_string;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+SELECT id FROM jsonb_exists_native WHERE document ? 'key' ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'key'
+ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+SELECT id FROM jsonb_exists_compatibility
+WHERE document ? 'first' OR document ? 'second'
+ORDER BY id;
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+SELECT id FROM jsonb_exists_compatibility
+WHERE (document || '{}'::jsonb) ? 'key'
+ORDER BY id;
+
+DROP VIEW jsonb_exists_compatibility;
+DROP FOREIGN TABLE jsonb_exists_string;
+DROP FOREIGN TABLE jsonb_exists_native;
+DROP USER MAPPING FOR CURRENT_USER SERVER jsonb_exists_binary;
+CALL clickhouse_perform('jsonb_exists_admin', 'DROP DATABASE jsonb_exists');
+DROP SERVER jsonb_exists_binary;


### PR DESCRIPTION
Added pushdown for the JSONB `?` existence operator. Evaluates not only ClickHouse JSON columns mapped to JSONB, but also ClickHouse String columns that contain JSON, thus working on both JSON objects and JSON arrays. This requires a bit of complicated ClickHouse function dispatch, but does the trick.

Test output varies on ClickHouse 24.3 and earlier because the "JSON" feature at that time required the same keys in every object in the column, so the tests do in fact find the key in every row.

Resolves #325