### PR TITLE
Emit SEMI join inner conditions in the ON clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,25 @@ All notable changes to this project will be documented in this file. It uses the
     `CALL clickhouse_perform(server, sql)` to run statements that return none;
     both take a foreign server rather than a connection string. ([#346])
 
+### 🐞 Bug Fixes
+
+*   Fixed the pushdown of an `EXISTS` subquery whose correlation condition
+    references both the outer and the inner relation. Such a condition
+    deparsed into the `WHERE` clause, where ClickHouse's `LEFT SEMI JOIN`
+    applies it to the single arbitrary matching row it surfaces instead of
+    asking whether any matching row satisfies it, so the query silently
+    returned too few rows. Placing it in the `ON` clause, where it belongs,
+    requires ClickHouse 26.3 or later: earlier analyzers reject a condition
+    spanning both sides of a join once `join_use_nulls` is on, which
+    `pg_clickhouse.session_settings` enables by default. Against an older
+    server such a join is now evaluated locally rather than returning the
+    wrong answer ([#347]).
+
   [v0.11.0]: https://github.com/ClickHouse/pg_clickhouse/compare/v0.10.0...v0.11.0
   [#346]: https://github.com/ClickHouse/pg_clickhouse/pull/346
     "ClickHouse/pg_clickhouse#346 remove clickhouse_raw_query"
+  [#347]: https://github.com/ClickHouse/pg_clickhouse/pull/347
+    "ClickHouse/pg_clickhouse#347 Place SEMI join inner conditions in the ON clause"
 
 ## [v0.10.0] — 2026-08-11
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1457,16 +1457,13 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
  * implemented.
  */
 /*
- * Resolve the user mapping the executor will use to scan foreignrel, for the
- * plan-time server-version probe below. Mirrors the executor's own lookup
- * (see clickhouseBeginForeignScan): the RTE's checkAsUser — set when the rel
- * is accessed on behalf of another user, e.g. through a view — wins over the
- * invoking user. Returns NULL instead of erroring when no mapping exists, so
- * the version gate degrades to "no pushdown" rather than failing a query
- * (or a bare EXPLAIN) at plan time.
+ * Return the user mapping that the executor would use for foreignrel.
+ * checkAsUser takes precedence over the current user when, for example, a view
+ * accesses the relation. Return NULL if no mapping exists so the planner can
+ * disable pushdown without making the query or EXPLAIN fail.
  */
-static UserMapping*
-subplan_gate_user_mapping(PlannerInfo* root, RelOptInfo* foreignrel, Oid serverid) {
+UserMapping*
+chfdw_gate_user_mapping(PlannerInfo* root, RelOptInfo* foreignrel, Oid serverid) {
     Oid userid  = InvalidOid;
     int rtindex = -1;
 
@@ -1730,7 +1727,7 @@ is_shippable_subplan(SubPlan* subplan, foreign_glob_cxt* glob_cxt, ExprTruthCtx 
      * no mapping exists it refuses the pushdown rather than erroring.
      */
     {
-        UserMapping* user = subplan_gate_user_mapping(
+        UserMapping* user = chfdw_gate_user_mapping(
             glob_cxt->root, glob_cxt->foreignrel, fpinfo->server->serverid
         );
 

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -1949,6 +1949,53 @@ extract_join_equals(List* conds, List** to) {
 }
 
 /*
+ * Move conditions that reference innerrelids from conds to *to. Return the
+ * remaining conditions.
+ *
+ * In a SEMI or ANTI join, every condition that references the inner relation
+ * is part of the ON match test. A WHERE condition can inspect only the one
+ * arbitrary row exposed by ClickHouse's LEFT SEMI JOIN; LEFT ANTI JOIN exposes
+ * no matching row. Do not rely on is_pushed_down: PostgreSQL sets it for
+ * semijoin conditions even when they belong in the remote ON clause.
+ */
+static List*
+extract_inner_conds(List* conds, Relids innerrelids, List** to) {
+    ListCell* lc;
+    List* res = NIL;
+
+    foreach (lc, conds) {
+        RestrictInfo* rinfo = lfirst_node(RestrictInfo, lc);
+
+        if (bms_overlap(rinfo->clause_relids, innerrelids)) {
+            *to = lappend(*to, rinfo);
+        } else {
+            res = lappend(res, rinfo);
+        }
+    }
+    return res;
+}
+
+static bool
+semi_join_needs_nonequi_on(
+    List* joinclauses,
+    RelOptInfo* outerrel,
+    RelOptInfo* innerrel
+) {
+    ListCell* lc;
+
+    foreach (lc, joinclauses) {
+        RestrictInfo* rinfo = lfirst_node(RestrictInfo, lc);
+
+        if (bms_overlap(rinfo->clause_relids, outerrel->relids) &&
+            bms_overlap(rinfo->clause_relids, innerrel->relids) &&
+            !is_simple_join_clause((Expr*)rinfo)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
  * Check if reltarget is safe for semi-join pushdown. Returns false if the
  * target references columns from the inner relation that aren't in outer
  * relation.
@@ -2208,17 +2255,13 @@ foreign_join_ok(
     case JOIN_SEMI:
     case JOIN_ANTI:
 
-        /*
-         * For semi/anti-join, inner's conditions go to joinclauses (ON),
-         * outer's conditions go to remote_conds (WHERE). Extract join key
-         * equalities to joinclauses for the ON clause.
-         */
         fpinfo->joinclauses =
             list_concat(fpinfo->joinclauses, list_copy(fpinfo_i->remote_conds));
         fpinfo->remote_conds =
             list_concat(fpinfo->remote_conds, list_copy(fpinfo_o->remote_conds));
-        fpinfo->remote_conds =
-            extract_join_equals(fpinfo->remote_conds, &fpinfo->joinclauses);
+        fpinfo->remote_conds = extract_inner_conds(
+            fpinfo->remote_conds, innerrel->relids, &fpinfo->joinclauses
+        );
 
         /*
          * Subquery-wrapping a join-typed input would require its
@@ -2231,6 +2274,23 @@ foreign_join_ok(
          */
         if (jointype == JOIN_ANTI && (IS_JOIN_REL(outerrel) || IS_JOIN_REL(innerrel))) {
             return false;
+        }
+
+        /*
+         * Before ClickHouse 26.3, the analyzer rejects a non-equality ON
+         * condition that spans both sides when join_use_nulls is enabled. The
+         * 23.x analyzer rejects it regardless of that setting. Keep these joins
+         * local on affected servers. Run this check last to avoid an
+         * unnecessary connection during planning.
+         */
+        if (semi_join_needs_nonequi_on(fpinfo->joinclauses, outerrel, innerrel)) {
+            UserMapping* user =
+                chfdw_gate_user_mapping(root, joinrel, fpinfo_o->server->serverid);
+
+            if (user == NULL ||
+                !chfdw_version_ge(chfdw_get_server_version(user), 26, 3)) {
+                return false;
+            }
         }
         break;
 

--- a/src/include/fdw.h
+++ b/src/include/fdw.h
@@ -101,6 +101,12 @@ chfdw_binary_connect(ch_connection_details* details);
  */
 ch_server_version
 chfdw_get_server_version(UserMapping* user);
+/*
+ * Return the user mapping that the executor would use for foreignrel. Return
+ * NULL if no mapping exists so the planner can disable pushdown.
+ */
+UserMapping*
+chfdw_gate_user_mapping(PlannerInfo* root, RelOptInfo* foreignrel, Oid serverid);
 List*
 chfdw_construct_create_tables(ImportForeignSchemaStmt* stmt, ForeignServer* server);
 char*

--- a/test/expected/where_sub.out
+++ b/test/expected/where_sub.out
@@ -42,6 +42,36 @@ SELECT class, COUNT(*) AS order_count
    Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r3 ON (((r3.created_at < r3.updated_at)) AND ((r1.id = r3.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
 (4 rows)
 
+-- Order 1's first matching line fails num <> id, but its second line passes.
+-- This catches plans that test only the arbitrary row exposed by a semi-join.
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.orders VALUES
+        (1, '2025-07-05', 'a'), (2, '2025-07-06', 'b')
+$$);
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.lines VALUES
+        (1, 1, '2025-07-01', '2025-07-02'),
+        (1, 9, '2025-07-01', '2025-07-02'),
+        (2, 2, '2025-07-01', '2025-07-02')
+$$);
+-- Check the result instead of the remote plan. ClickHouse 26.3 and later can
+-- run this join remotely; older versions run it locally. Both must return 1.
+SELECT id FROM where_sub.orders
+ WHERE EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+SELECT id FROM where_sub.orders
+ WHERE NOT EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
 CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;

--- a/test/expected/where_sub_1.out
+++ b/test/expected/where_sub_1.out
@@ -42,6 +42,36 @@ SELECT class, COUNT(*) AS order_count
    Remote SQL: SELECT r1.class, count(*) FROM  where_sub_test.orders r1 LEFT SEMI JOIN where_sub_test.lines r2 ON (((r2.created_at < r2.updated_at)) AND ((r1.id = r2.order_id))) WHERE ((r1.date >= '07-01-2025')) AND ((r1.date < '10-01-2025')) GROUP BY r1.class ORDER BY r1.class ASC NULLS LAST
 (4 rows)
 
+-- Order 1's first matching line fails num <> id, but its second line passes.
+-- This catches plans that test only the arbitrary row exposed by a semi-join.
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.orders VALUES
+        (1, '2025-07-05', 'a'), (2, '2025-07-06', 'b')
+$$);
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.lines VALUES
+        (1, 1, '2025-07-01', '2025-07-02'),
+        (1, 9, '2025-07-01', '2025-07-02'),
+        (2, 2, '2025-07-01', '2025-07-02')
+$$);
+-- Check the result instead of the remote plan. ClickHouse 26.3 and later can
+-- run this join remotely; older versions run it locally. Both must return 1.
+SELECT id FROM where_sub.orders
+ WHERE EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+SELECT id FROM where_sub.orders
+ WHERE NOT EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
 CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;

--- a/test/sql/where_sub.sql
+++ b/test/sql/where_sub.sql
@@ -41,6 +41,29 @@ SELECT class, COUNT(*) AS order_count
  GROUP BY class
  ORDER BY class;
 
+-- Order 1's first matching line fails num <> id, but its second line passes.
+-- This catches plans that test only the arbitrary row exposed by a semi-join.
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.orders VALUES
+        (1, '2025-07-05', 'a'), (2, '2025-07-06', 'b')
+$$);
+CALL clickhouse_perform('where_sub_admin', $$
+    INSERT INTO where_sub_test.lines VALUES
+        (1, 1, '2025-07-01', '2025-07-02'),
+        (1, 9, '2025-07-01', '2025-07-02'),
+        (2, 2, '2025-07-01', '2025-07-02')
+$$);
+
+-- Check the result instead of the remote plan. ClickHouse 26.3 and later can
+-- run this join remotely; older versions run it locally. Both must return 1.
+SELECT id FROM where_sub.orders
+ WHERE EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+
+SELECT id FROM where_sub.orders
+ WHERE NOT EXISTS (SELECT * FROM where_sub.lines WHERE order_id = id AND num <> id)
+ ORDER BY id;
+
 CALL clickhouse_perform('where_sub_admin', 'DROP DATABASE where_sub_test');
 DROP USER MAPPING FOR CURRENT_USER SERVER where_sub_loopback;
 DROP SERVER where_sub_loopback CASCADE;


### PR DESCRIPTION
A SEMI or ANTI join uses its ON clause as the match test, so every condition that references the inner relation must appear there. ClickHouse's LEFT SEMI JOIN exposes one arbitrary matching row to the `WHERE` clause. Testing an inner condition against that row can miss another qualifying match and return too few rows.

Do not rely on PostgreSQL's `is_pushed_down` flag to place these conditions. PostgreSQL sets it for semijoin conditions because their placement does not affect its executor, but the distinction matters to
a remote ClickHouse join. Move every condition that references the inner relation into the remote `ON` clause.

ClickHouse versions before 26.3 reject non-equality ON conditions that span both sides when join_use_nulls is enabled; 23.x rejects them regardless of that setting. Keep affected joins local on those servers. Resolve the user mapping as the executor would, and disable pushdown if no mapping is available.

Add `EXISTS` and `NOT EXISTS` tests that verify results whether the join runs remotely or locally.

## Claude Summary

An `EXISTS` whose correlation condition references **both** sides was deparsed into the `WHERE` clause instead of the join's `ON` clause, **silently returning too few rows**. ClickHouse's `LEFT SEMI JOIN` surfaces the column values of one arbitrary matching row, so the condition interrogated that row rather than asking whether *any* matching row satisfied it.

```sql
SELECT count(*) FROM orders o WHERE EXISTS (
  SELECT 1 FROM lineitem l WHERE l.l_orderkey = o.o_orderkey AND l.l_suppkey <> o.o_custkey);
```

| | pushed down | local |
|---|---:|---:|
| above query (TPC-H SF1) | 1499990 | **1499998** |
| TPC-H Q21, `EXISTS`-only shape | 56824 | **73089** |

No NULLs are involved — every column above is `NOT NULL`, verified via `attnotnull`. It is purely the scope of the existential quantifier, demonstrable in ClickHouse with no nullable types at all:

```sql
-- right side has two matches for k=1: w=10 and w=20
LEFT SEMI JOIN ... ON l.k = r.k              -- surfaces w = 10 (one arbitrary match)
  ... ON l.k = r.k          WHERE r.w <> 10  -- 0 rows  <- wrong
  ... ON l.k = r.k AND r.w <> 10             -- 1 row   <- correct
```
