### PR TITLE
Removed outdated docs, copy edit and reformat

### DIFF
--- a/doc/pg_clickhouse.md
+++ b/doc/pg_clickhouse.md
@@ -576,7 +576,7 @@ A PostgreSQL [partitioned table] can mix local partitions with foreign
 partitions backed by ClickHouse. A common layout offloads older data to
 ClickHouse while recent data stays in PostgreSQL:
 
-```pgsql
+```sql
 CREATE TABLE events (id int, ts date, val int, amt float8)
     PARTITION BY RANGE (ts);
 
@@ -649,8 +649,8 @@ aggregates also fall back.
 
 ### PREPARE, EXECUTE, DEALLOCATE
 
- As of v0.1.2, pg_clickhouse supports parameterized queries, mainly created
- by the [PREPARE] command:
+ As of v0.1.2, pg_clickhouse supports parameterized queries, mainly created by
+ the [PREPARE] command:
 
 ```pgsql
 try=# PREPARE avg_durations_between_dates(date, date) AS
@@ -676,15 +676,6 @@ try=# EXECUTE avg_durations_between_dates('2025-12-09', '2025-12-13');
 (5 rows)
 ```
 
-> [!WARNING]
-> Parameterized execution prevents the [http driver](#create-server) from
-> properly converting DateTime time zones on ClickHouse versions prior to
-> 25.8, when the [underlying bug] was [fixed]. Note that sometimes PostgreSQL
-> will use a parameterized query plan even without using `PREPARE`. For any
-> queries on that require accurate time zone conversion, and where upgrading
-> to 25.8 or later is not an option, use the [binary driver](#create-server),
-> instead.
-
 pg_clickhouse pushes down the aggregations, as usual, as seen in the
 [EXPLAIN](#explain) verbose output:
 
@@ -703,7 +694,6 @@ Note that it has sent the full date values, not the parameter placeholders.
 This holds for the first five requests, as described in the PostgreSQL
 [PREPARE notes]. On the sixth execution, it sends ClickHouse
 `{param:type}`-style [query parameters]:
-parameters:
 
 ```pgsql
                                                                                                          QUERY PLAN
@@ -788,12 +778,16 @@ settings] to be set on subsequent queries. Example:
 SET pg_clickhouse.session_settings = 'join_use_nulls 1, final 1';
 ```
 
-The default is `join_use_nulls 1, group_by_use_nulls 1, final 1,
-transform_null_in 0`. Set it to an empty string to fall back on the
-ClickHouse server's settings — but note that pushdown correctness depends on
-some of these defaults: `join_use_nulls` for outer joins and
-`transform_null_in` for the `IN` family (see [IN and NULL
-Semantics](#in-and-null-semantics)).
+The default is
+
+```
+join_use_nulls 1, group_by_use_nulls 1, final 1, transform_null_in 0
+```
+
+Set it to an empty string to fall back on the ClickHouse server's settings ---
+but note that pushdown correctness depends on some of these defaults:
+`join_use_nulls` for outer joins and `transform_null_in` for the `IN` family
+(see [IN and NULL Semantics](#in-and-null-semantics)).
 
 ```sql
 SET pg_clickhouse.session_settings = '';
@@ -1107,16 +1101,16 @@ SELECT * FROM clickhouse_query(
 ```
 
 Execute a query against an already-configured foreign server and return its
-rows as a relation, mapping each ClickHouse result column to the PostgreSQL type
-named in the column definition list. It reuses the server's `driver`,
+rows as a relation, mapping each ClickHouse result column to the PostgreSQL
+type named in the column definition list. It reuses the server's `driver`,
 credentials, database, and the connection cache.
 
 The first argument is the name of a server created with [CREATE SERVER]. A
-column definition list (`AS name(col type, ...)`) is required: PostgreSQL needs
-the result shape before fetching rows, and it must match the columns the query
-returns. Values are converted from ClickHouse to the declared types the same way
-a foreign table column would be. Statements that return no results, such as DDL,
-have nothing to declare; run them with
+column definition list (`AS name(col type, ...)`) is required: PostgreSQL
+needs the result shape before fetching rows, and it must match the columns the
+query returns. Values are converted from ClickHouse to the declared types the
+same way a foreign table column would be. Statements that return no results,
+such as DDL, have nothing to declare; run them with
 [`clickhouse_perform`](#clickhouse_perform) instead.
 
 No role has `EXECUTE` access by default; `GRANT` to a role to allow it to use
@@ -1138,12 +1132,12 @@ CALL clickhouse_perform(
 Execute a statement against an already-configured foreign server and discard
 any result. Use it for statements that return no rows, such as DDL, where
 [`clickhouse_query`](#clickhouse_query) has no result shape to declare. It
-resolves the server the same way `clickhouse_query` does, reusing its `driver`,
-credentials, database, and the connection cache.
+resolves the server the same way `clickhouse_query` does, reusing its
+`driver`, credentials, database, and the connection cache.
 
 As a procedure it must be invoked with [CALL], not `SELECT`, and it returns no
-rows. No role has `EXECUTE` access by default; `GRANT` to a role to allow it to
-use the procedure.
+rows. No role has `EXECUTE` access by default; `GRANT` to a role to allow it
+to use the procedure.
 
 ```sql
 GRANT EXECUTE ON PROCEDURE clickhouse_perform(text, text) TO ch_admin;
@@ -1289,25 +1283,24 @@ equivalents as follows:
 ClickHouse evaluates `IN` under two-valued logic: when the probe finds no
 match it returns `0` even if a NULL is involved, where PostgreSQL computes
 NULL. To preserve PostgreSQL semantics, pg_clickhouse pushes down the `IN`
-family over a constant list or array (`IN`, `NOT IN`, `= ANY`, `= ALL`,
-`<> ANY`, `<> ALL`) unconditionally: the native or cheap form where it can
-prove neither the probe nor an array element can be NULL, or a guarded
-`CASE` form otherwise that checks for NULL values at runtime instead,
-computing PostgreSQL's exact three-valued answer (TRUE, FALSE, NULL) in
-every context, including value positions like a `SELECT` list or
-`GROUP BY`.
+family over a constant list or array (`IN`, `NOT IN`, `= ANY`, `= ALL`, `<>
+ANY`, `<> ALL`) unconditionally: the native or cheap form where it can prove
+neither the probe nor an array element can be NULL, or a guarded `CASE` form
+otherwise that checks for NULL values at runtime instead, computing
+PostgreSQL's exact three-valued answer (TRUE, FALSE, NULL) in every context,
+including value positions like a `SELECT` list or `GROUP BY`.
 
 A `NOT IN (SELECT ...)` filter over nullable columns also pushes down,
 deparsed with compensating guards that keep PostgreSQL's behavior: a set
-containing a NULL disqualifies every row, and a NULL probe passes only
-against an empty set. Each guard is omitted when a `NOT NULL` declaration
-proves it unnecessary. Unlike the array forms above, this guard only
-applies in a plain filter condition (or under `NOT`); we still do not push
-down `IN (SELECT ...)` (in a value position) nor grouped/aggregated subquery
-bodies. Declaring columns `NOT NULL` maximizes pushdown by letting the cheaper
-unguarded form ship instead; [IMPORT FOREIGN SCHEMA] does so automatically for
-non-`Nullable` ClickHouse columns. The proof follows non-NULL constants,
-`NOT NULL` columns, and basic arithmetic (`+`, `-`, `*`, unary `-`) over them.
+containing a NULL disqualifies every row, and a NULL probe passes only against
+an empty set. Each guard is omitted when a `NOT NULL` declaration proves it
+unnecessary. Unlike the array forms above, this guard only applies in a plain
+filter condition (or under `NOT`); we still do not push down `IN (SELECT ...)`
+(in a value position) nor grouped/aggregated subquery bodies. Declaring
+columns `NOT NULL` maximizes pushdown by letting the cheaper unguarded form
+ship instead; [IMPORT FOREIGN SCHEMA] does so automatically for non-`Nullable`
+ClickHouse columns. The proof follows non-NULL constants, `NOT NULL` columns,
+and basic arithmetic (`+`, `-`, `*`, unary `-`) over them.
 
 These rules assume ClickHouse's default `transform_null_in = 0`, which
 pg_clickhouse sets on every query through the default value of the
@@ -1325,8 +1318,8 @@ any of these functions cannot be pushed down they will raise an exception.
 
 ### Extension Pushdown
 
-pg_clickhouse recognizes functions from select core and third-party extensions,
-pushing them down to their ClickHouse equivalents.
+pg_clickhouse recognizes functions from select core and third-party
+extensions, pushing them down to their ClickHouse equivalents.
 
 #### re2
 
@@ -1454,9 +1447,9 @@ exception.
 
 ### Pushdown Window Functions
 
-These PostgreSQL [window functions] push down to ClickHouse with `OVER
-(PARTITION BY ... ORDER BY ...)` clauses, including frame specifications where
-applicable.
+These PostgreSQL [window functions] push down to ClickHouse with
+`OVER (PARTITION BY ... ORDER BY ...)` clauses, including frame specifications
+where applicable.
 
 *   [row_number](https://clickhouse.com/docs/sql-reference/window-functions/row_number)
 *   [rank](https://clickhouse.com/docs/sql-reference/window-functions/rank)
@@ -1575,17 +1568,17 @@ ClickHouse-compatible [RE2] regular expressions.
 
 ### `to_char()`
 
-PostgreSQL [`to_char()`] for `timestamp` and `timestamp with time zone`
-pushes down to ClickHouse [formatDateTime] only when the format argument
-is a non-NULL string constant whose every PostgreSQL keyword has a
-byte-for-byte identical ClickHouse equivalent. If the format is dynamic
-(not a `Const`), or contains any unsupported keyword or modifier, the
-call falls back to local evaluation in PostgreSQL — pushdown is never
-attempted with a partial translation, so output stays PG-compatible.
+PostgreSQL [`to_char()`] for `timestamp` and `timestamp with time zone` pushes
+down to ClickHouse [formatDateTime] only when the format argument is a
+non-NULL string constant whose every PostgreSQL keyword has a byte-for-byte
+identical ClickHouse equivalent. If the format is dynamic or contains any
+unsupported keyword or modifier, the call falls back to local evaluation in
+PostgreSQL. pg_clickhouse never pushes down a partial translation, so output
+remains compatible.
 
 Two-argument `to_char()` forms over `numeric`, `interval`, and other
-non-timestamp types never push down; ClickHouse [formatDateTime] only
-formats date-time values.
+non-timestamp types never push down; ClickHouse [formatDateTime] only formats
+date-time values.
 
 #### Translated keywords
 
@@ -1607,10 +1600,10 @@ formats date-time values.
 
 #### Quoted text and literals
 
-Text wrapped in `"..."` passes through verbatim, with any literal `%`
-doubled to `%%` to escape ClickHouse's specifier prefix. A `\"` outside
-quotes also passes through as a literal `"`. Inside `"..."`, backslash
-only escapes `"`; other backslash sequences are treated as literal text.
+Text wrapped in `"..."` passes through verbatim, with any literal `%` doubled
+to `%%` to escape ClickHouse's specifier prefix. A `\"` outside quotes also
+passes through as a literal `"`. Inside `"..."`, backslash only escapes `"`;
+other backslash sequences are treated as literal text.
 
 ## Authors
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1146,12 +1146,12 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
         /*
          * AND/OR preserve the NULL/FALSE equivalence of a truth context but
          * consume a NEGATED state (their children are not the NOT's direct
-         * operand). Under NOT the roles swap — a FALSE-for-NULL substitution
-         * below would surface as TRUE-for-NULL above — so the operand must be
-         * exact, except that one NOT directly over a truth context grants the
-         * operand EXPR_CTX_NEGATED, which a SubPlan consumes via the guarded
-         * NOT IN deparse. A second NOT above that degrades to exact (the
-         * planner collapses double negation anyway).
+         * operand). Under NOT the roles swap --- a FALSE-for-NULL
+         * substitution below would surface as TRUE-for-NULL above --- so the
+         * operand must be exact, except that one NOT directly over a truth
+         * context grants the operand EXPR_CTX_NEGATED, which a SubPlan
+         * consumes via the guarded NOT IN deparse. A second NOT above that
+         * degrades to exact (the planner collapses double negation anyway).
          */
         if (b->boolop == NOT_EXPR) {
             child_ctx = ctx == EXPR_CTX_TRUTH ? EXPR_CTX_NEGATED : EXPR_CTX_EXACT;
@@ -1447,23 +1447,23 @@ foreign_expr_walker(Node* node, foreign_glob_cxt* glob_cxt, ExprTruthCtx ctx) {
  * Postgres substitutes NULL, but ClickHouse's scalar-subquery semantics
  * differ (it can raise or yield an empty result rather than NULL), so a naive
  * push would change query results. We sidestep this entirely by only pushing
- * EXPR subqueries whose top level is a bare aggregate with no GROUP BY: such a
- * query returns exactly one row on both systems by construction, so the
+ * EXPR subqueries whose top level is a bare aggregate with no GROUP BY: such
+ * a query returns exactly one row on both systems by construction, so the
  * zero-row divergence cannot arise. A non-aggregate or grouped scalar
- * subquery is left for local execution (see the guard below, and the
- * negative case in test/sql/subplan_pushdown.sql). This could be relaxed in
- * the future by wrapping the pushed subquery so an empty result yields NULL
- * (e.g. deparsing it under an any()/singleValueOrNull() aggregate); not yet
+ * subquery is left for local execution (see the guard below, and the negative
+ * case in test/sql/subplan_pushdown.sql). This could be relaxed in the future
+ * by wrapping the pushed subquery so an empty result yields NULL (e.g.
+ * deparsing it under an any()/singleValueOrNull() aggregate); not yet
  * implemented.
  */
 /*
  * Resolve the user mapping the executor will use to scan foreignrel, for the
  * plan-time server-version probe below. Mirrors the executor's own lookup
- * (see clickhouseBeginForeignScan): the RTE's checkAsUser — set when the rel
- * is accessed on behalf of another user, e.g. through a view — wins over the
- * invoking user. Returns NULL instead of erroring when no mapping exists, so
- * the version gate degrades to "no pushdown" rather than failing a query
- * (or a bare EXPLAIN) at plan time.
+ * (see clickhouseBeginForeignScan): the RTE's checkAsUser --- set when the
+ * rel is accessed on behalf of another user, e.g. through a view --- wins
+ * over the invoking user. Returns NULL instead of erroring when no mapping
+ * exists, so the version gate degrades to "no pushdown" rather than failing a
+ * query (or a bare EXPLAIN) at plan time.
  */
 static UserMapping*
 subplan_gate_user_mapping(PlannerInfo* root, RelOptInfo* foreignrel, Oid serverid) {
@@ -3023,7 +3023,7 @@ deparseVar(Var* node, deparse_expr_cxt* context) {
     /*
      * SubPlan scope: the Var's varno indexes the subquery's own rtable
      * (context->root is the SubPlan's PlannerInfo here), and the alias
-     * namespace is q{plan_id}_{varno} — never the outer r{N}. Pass
+     * namespace is q{plan_id}_{varno}, never the outer r{N}. Pass
      * qualify_col=false to deparseColumnRef so it cannot add an r{N}
      * qualifier of its own.
      */
@@ -3540,8 +3540,8 @@ static void
 deparseParam(Param* node, deparse_expr_cxt* context) {
     /*
      * SubPlan scope: a PARAM_EXEC Param here is (usually) a correlation
-     * reference — the planner's replacement for an outer-query Var inside
-     * the subquery (SS_replace_correlation_vars). subplan->parParam and
+     * reference, the planner's replacement for an outer-query Var inside the
+     * subquery (SS_replace_correlation_vars). subplan->parParam and
      * subplan->args run in parallel: paramid -> the outer expression that
      * feeds it. Inline that expression, deparsed in the PARENT scope so it
      * picks up the outer query's aliases.
@@ -3770,9 +3770,9 @@ deparseSubPlanFrom(deparse_expr_cxt* context) {
  * deparseParam resolves back to outer-alias text via parent_ctx.
  *
  * Scope discipline: the sub-context's root is the SubPlan's own PlannerInfo,
- * so every varno resolves against the subquery's rtable, and every table
- * gets a q{plan_id}_{rtindex} alias — collision-free with the outer r{N}/
- * s{N} namespaces and with sibling SubPlans.
+ * so every varno resolves against the subquery's rtable, and every table gets
+ * a q{plan_id}_{rtindex} alias. Collision-free with the outer r{N}/ s{N}
+ * namespaces and with sibling SubPlans.
  */
 static void
 deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context, SubPlanBodyForm form) {
@@ -3854,14 +3854,14 @@ deparseSubPlanQuery(SubPlan* subplan, deparse_expr_cxt* context, SubPlanBodyForm
 }
 
 /*
- * Deparse Postgres's `x NOT IN (SELECT ..)` — arriving as NOT over an ANY
- * SubPlan — when a NULL could reach the comparison. ClickHouse's native
+ * Deparse Postgres's `x NOT IN (SELECT ..)` when it arrives as NOT over an
+ * ANY SubPlan and a NULL could reach the comparison. ClickHouse's native
  * `NOT IN` computes the plain set complement, where Postgres's three-valued
- * answer can only be TRUE if the probe is non-NULL, the subquery output
- * holds no NULL, and the probe matches nothing — except that an empty
- * result is TRUE regardless of the probe. In a truth context (the only
- * place the walker admits this form, via EXPR_CTX_NEGATED) that TRUE-set
- * is all that matters, so emit it directly:
+ * answer can only be TRUE if the probe is non-NULL, the subquery output holds
+ * no NULL, and the probe matches nothing --- except that an empty result is
+ * TRUE regardless of the probe. In a truth context (the only place the walker
+ * admits this form, via EXPR_CTX_NEGATED) that TRUE-set is all that matters,
+ * so emit it directly:
  *
  *   CASE WHEN probe IS NULL
  *        THEN NOT EXISTS (SELECT ..)                            -- empty?
@@ -6250,7 +6250,7 @@ deparseWindowFunc(WindowFunc* node, deparse_expr_cxt* context) {
                 appendStringInfoString(buf, " FOLLOWING");
             }
         } else {
-            /* No BETWEEN — single start bound */
+            /* No BETWEEN - single start bound */
             if (wc->frameOptions & FRAMEOPTION_START_UNBOUNDED_PRECEDING) {
                 appendStringInfoString(buf, "UNBOUNDED PRECEDING");
             } else if (wc->frameOptions & FRAMEOPTION_START_CURRENT_ROW) {

--- a/src/http.c
+++ b/src/http.c
@@ -168,7 +168,7 @@ ch_http_close(ch_http_connection_t* conn) {
 }
 
 /* ----------------------------------------------------------------
- * HttpStream — opaque struct.
+ * HttpStream: opaque struct.
  * ----------------------------------------------------------------
  */
 struct HttpStream {
@@ -227,7 +227,7 @@ is_overridden(const ch_http_request* req, const char* name) {
 }
 
 /* ----------------------------------------------------------------
- * write_callback — CURL write callback. Appends data to the stream
+ * write_callback: CURL write callback. Appends data to the stream
  * buffer and, when streaming, pauses receipt so the caller drains it.
  * ----------------------------------------------------------------
  */
@@ -268,7 +268,7 @@ write_callback(void* contents, size_t size, size_t nmemb, void* userp) {
 }
 
 /* ----------------------------------------------------------------
- * setup_curl — configure the CURL easy handle for this query.
+ * setup_curl: configure the CURL easy handle for this query.
  * ----------------------------------------------------------------
  */
 static void
@@ -453,7 +453,7 @@ ch_http_stream_next_chunk(void* ud, const void** data, size_t* len, char** error
 }
 
 /* ----------------------------------------------------------------
- * Public API — lifecycle
+ * Public API: lifecycle
  * ----------------------------------------------------------------
  */
 
@@ -469,7 +469,7 @@ error_status(long status) {
 }
 
 /*
- * ch_http_stream_end — clean up all owned resources.
+ * ch_http_stream_end: clean up all owned resources.
  */
 void
 ch_http_stream_end(HttpStream* stream) {
@@ -508,7 +508,7 @@ ch_http_stream_end(HttpStream* stream) {
 }
 
 /*
- * ch_http_stream_begin — allocate and initialize a streaming HTTP query.
+ * ch_http_stream_begin: allocate and initialize a streaming HTTP query.
  * Returns NULL only when an allocation or a libcurl handle init fails, other
  * failures come back on the stream as a status.
  */
@@ -571,7 +571,7 @@ fail:
 }
 
 /* ----------------------------------------------------------------
- * Public API — accessors
+ * Public API: accessors
  * ----------------------------------------------------------------
  */
 char*
@@ -605,7 +605,7 @@ ch_http_stream_request_time(HttpStream* stream) {
 }
 
 /*
- * take_body — transfer ownership of the response body.
+ * take_body: transfer ownership of the response body.
  *
  * On return, *out_data is a malloc()'d buffer the caller must free(). When
  * status is CH_HTTP_STATUS_TRANSPORT_ERROR the body is the strdup'd libcurl
@@ -636,7 +636,7 @@ take_body(HttpStream* stream, char** out_data, size_t* out_size) {
 }
 
 /*
- * ch_http_simple_query — buffer the full TabSeparated response in memory.
+ * ch_http_simple_query: buffer the full TabSeparated response in memory.
  *
  * Server default format is TabSeparated, so only its dialect needs pinning:
  * ISO timestamps, \N for NULL and LF line ends, as the text parsers expect.

--- a/src/include/http.h
+++ b/src/include/http.h
@@ -81,7 +81,7 @@ ch_http_stream_end(HttpStream* stream);
 bool
 ch_http_stream_next_chunk(void* stream, const void** data, size_t* len, char** error);
 
-/* accessors — let pglink.c read stream state without seeing the struct */
+/* accessors that let pglink.c read stream state without seeing the struct. */
 char*
 ch_http_stream_buffer(HttpStream* stream);
 size_t

--- a/test/expected/subplan_pushdown.out
+++ b/test/expected/subplan_pushdown.out
@@ -178,7 +178,7 @@ ORDER BY item_id;
 (3 rows)
 
 -- ============================================================
--- 5. NOT IN (TPC-H Q16 shape) — arrives as NOT(ANY-SubPlan)
+-- 5. NOT IN (TPC-H Q16 shape): arrives as NOT(ANY-SubPlan)
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
@@ -270,7 +270,7 @@ ORDER BY item_id;
 
 -- ============================================================
 -- 8. Negative case: multi-row correlated scalar (no aggregate) must
---    NOT push down — zero-row semantics differ between PG and CH.
+--    NOT push down; zero-row semantics differ between PG and CH.
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT s.sale_id FROM sales s
@@ -291,10 +291,10 @@ ORDER BY s.sale_id;
 
 -- ============================================================
 -- 9. Identity: the plan-time version probe must connect as the user the
---    executor will scan as — the view owner, via the RTE's checkAsUser —
---    not the invoker. regress_subplan_nomap has NO user mapping of its
---    own, so resolving the invoker instead would fail the EXPLAIN with
---    "user mapping not found".
+--    executor will scan as --- the view owner, via the RTE's checkAsUser ---
+--    not the invoker. regress_subplan_nomap has NO user mapping of its own,
+--    so resolving the invoker instead would fail the EXPLAIN with "user
+--    mapping not found".
 -- ============================================================
 CREATE ROLE regress_subplan_nomap;
 GRANT USAGE ON SCHEMA subplan_test TO regress_subplan_nomap;
@@ -338,8 +338,8 @@ DROP ROLE regress_subplan_nomap;
 --     dropped) where ClickHouse returns TRUE. Shape 5 above ships
 --     plain because both item_id columns import as NOT NULL; with a
 --     nullable column on either side the deparse compensates with
---     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
---     and a NOT EXISTS poison check for NULLs in the set — each
+--     guards --- a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set --- each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
 CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
@@ -350,8 +350,8 @@ $$);
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
--- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
--- an unguarded pushdown would return items 4..6
+-- guard (no CASE). Postgres returns no rows because the set holds a NULL,
+-- whereas an unguarded pushdown would return items 4..6
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
 WHERE item_id NOT IN (SELECT val FROM maybe_null)
@@ -400,8 +400,8 @@ ORDER BY id;
   4
 (1 row)
 
--- Both sides nullable: the full form, CASE and poison guard together.
--- The set holds a NULL, so no probe — NULL included — can qualify
+-- Both sides nullable: the full form, CASE and poison guard together. The set
+-- holds a NULL, so no probe, NULL included, can qualify
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM maybe_null m
 WHERE m.val NOT IN (SELECT val FROM maybe_null)

--- a/test/expected/subplan_pushdown_1.out
+++ b/test/expected/subplan_pushdown_1.out
@@ -178,7 +178,7 @@ ORDER BY item_id;
 (3 rows)
 
 -- ============================================================
--- 5. NOT IN (TPC-H Q16 shape) — arrives as NOT(ANY-SubPlan)
+-- 5. NOT IN (TPC-H Q16 shape): arrives as NOT(ANY-SubPlan)
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
@@ -273,7 +273,7 @@ ORDER BY item_id;
 
 -- ============================================================
 -- 8. Negative case: multi-row correlated scalar (no aggregate) must
---    NOT push down — zero-row semantics differ between PG and CH.
+--    NOT push down; zero-row semantics differ between PG and CH.
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT s.sale_id FROM sales s
@@ -294,10 +294,10 @@ ORDER BY s.sale_id;
 
 -- ============================================================
 -- 9. Identity: the plan-time version probe must connect as the user the
---    executor will scan as — the view owner, via the RTE's checkAsUser —
---    not the invoker. regress_subplan_nomap has NO user mapping of its
---    own, so resolving the invoker instead would fail the EXPLAIN with
---    "user mapping not found".
+--    executor will scan as --- the view owner, via the RTE's checkAsUser ---
+--    not the invoker. regress_subplan_nomap has NO user mapping of its own,
+--    so resolving the invoker instead would fail the EXPLAIN with "user
+--    mapping not found".
 -- ============================================================
 CREATE ROLE regress_subplan_nomap;
 GRANT USAGE ON SCHEMA subplan_test TO regress_subplan_nomap;
@@ -341,8 +341,8 @@ DROP ROLE regress_subplan_nomap;
 --     dropped) where ClickHouse returns TRUE. Shape 5 above ships
 --     plain because both item_id columns import as NOT NULL; with a
 --     nullable column on either side the deparse compensates with
---     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
---     and a NOT EXISTS poison check for NULLs in the set — each
+--     guards --- a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set --- each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
 CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
@@ -353,8 +353,8 @@ $$);
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
--- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
--- an unguarded pushdown would return items 4..6
+-- guard (no CASE). Postgres returns no rows because the set holds a NULL,
+-- whereas an unguarded pushdown would return items 4..6
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
 WHERE item_id NOT IN (SELECT val FROM maybe_null)
@@ -403,8 +403,8 @@ ORDER BY id;
   4
 (1 row)
 
--- Both sides nullable: the full form, CASE and poison guard together.
--- The set holds a NULL, so no probe — NULL included — can qualify
+-- Both sides nullable: the full form, CASE and poison guard together. The set
+-- holds a NULL, so no probe, NULL included, can qualify
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM maybe_null m
 WHERE m.val NOT IN (SELECT val FROM maybe_null)

--- a/test/expected/subplan_pushdown_2.out
+++ b/test/expected/subplan_pushdown_2.out
@@ -178,7 +178,7 @@ ORDER BY item_id;
 (3 rows)
 
 -- ============================================================
--- 5. NOT IN (TPC-H Q16 shape) — arrives as NOT(ANY-SubPlan)
+-- 5. NOT IN (TPC-H Q16 shape): arrives as NOT(ANY-SubPlan)
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
@@ -273,7 +273,7 @@ ORDER BY item_id;
 
 -- ============================================================
 -- 8. Negative case: multi-row correlated scalar (no aggregate) must
---    NOT push down — zero-row semantics differ between PG and CH.
+--    NOT push down; zero-row semantics differ between PG and CH.
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT s.sale_id FROM sales s
@@ -294,10 +294,10 @@ ORDER BY s.sale_id;
 
 -- ============================================================
 -- 9. Identity: the plan-time version probe must connect as the user the
---    executor will scan as — the view owner, via the RTE's checkAsUser —
---    not the invoker. regress_subplan_nomap has NO user mapping of its
---    own, so resolving the invoker instead would fail the EXPLAIN with
---    "user mapping not found".
+--    executor will scan as --- the view owner, via the RTE's checkAsUser ---
+--    not the invoker. regress_subplan_nomap has NO user mapping of its own,
+--    so resolving the invoker instead would fail the EXPLAIN with "user
+--    mapping not found".
 -- ============================================================
 CREATE ROLE regress_subplan_nomap;
 GRANT USAGE ON SCHEMA subplan_test TO regress_subplan_nomap;
@@ -341,8 +341,8 @@ DROP ROLE regress_subplan_nomap;
 --     dropped) where ClickHouse returns TRUE. Shape 5 above ships
 --     plain because both item_id columns import as NOT NULL; with a
 --     nullable column on either side the deparse compensates with
---     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
---     and a NOT EXISTS poison check for NULLs in the set — each
+--     guards --- a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set --- each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
 CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
@@ -353,8 +353,8 @@ $$);
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
--- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
--- an unguarded pushdown would return items 4..6
+-- guard (no CASE). Postgres returns no rows because the set holds a NULL,
+-- whereas an unguarded pushdown would return items 4..6
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
 WHERE item_id NOT IN (SELECT val FROM maybe_null)
@@ -403,8 +403,8 @@ ORDER BY id;
   4
 (1 row)
 
--- Both sides nullable: the full form, CASE and poison guard together.
--- The set holds a NULL, so no probe — NULL included — can qualify
+-- Both sides nullable: the full form, CASE and poison guard together. The set
+-- holds a NULL, so no probe, NULL included, can qualify
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM maybe_null m
 WHERE m.val NOT IN (SELECT val FROM maybe_null)

--- a/test/expected/subplan_pushdown_3.out
+++ b/test/expected/subplan_pushdown_3.out
@@ -178,7 +178,7 @@ ORDER BY item_id;
 (3 rows)
 
 -- ============================================================
--- 5. NOT IN (TPC-H Q16 shape) — arrives as NOT(ANY-SubPlan)
+-- 5. NOT IN (TPC-H Q16 shape): arrives as NOT(ANY-SubPlan)
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
@@ -273,7 +273,7 @@ ORDER BY item_id;
 
 -- ============================================================
 -- 8. Negative case: multi-row correlated scalar (no aggregate) must
---    NOT push down — zero-row semantics differ between PG and CH.
+--    NOT push down; zero-row semantics differ between PG and CH.
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT s.sale_id FROM sales s
@@ -294,10 +294,10 @@ ORDER BY s.sale_id;
 
 -- ============================================================
 -- 9. Identity: the plan-time version probe must connect as the user the
---    executor will scan as — the view owner, via the RTE's checkAsUser —
---    not the invoker. regress_subplan_nomap has NO user mapping of its
---    own, so resolving the invoker instead would fail the EXPLAIN with
---    "user mapping not found".
+--    executor will scan as --- the view owner, via the RTE's checkAsUser ---
+--    not the invoker. regress_subplan_nomap has NO user mapping of its own,
+--    so resolving the invoker instead would fail the EXPLAIN with "user
+--    mapping not found".
 -- ============================================================
 CREATE ROLE regress_subplan_nomap;
 GRANT USAGE ON SCHEMA subplan_test TO regress_subplan_nomap;
@@ -341,8 +341,8 @@ DROP ROLE regress_subplan_nomap;
 --     dropped) where ClickHouse returns TRUE. Shape 5 above ships
 --     plain because both item_id columns import as NOT NULL; with a
 --     nullable column on either side the deparse compensates with
---     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
---     and a NOT EXISTS poison check for NULLs in the set — each
+--     guards --- a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set --- each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
 CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
@@ -353,8 +353,8 @@ $$);
 CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
--- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
--- an unguarded pushdown would return items 4..6
+-- guard (no CASE). Postgres returns no rows because the set holds a NULL,
+-- whereas an unguarded pushdown would return items 4..6
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
 WHERE item_id NOT IN (SELECT val FROM maybe_null)
@@ -403,8 +403,8 @@ ORDER BY id;
   4
 (1 row)
 
--- Both sides nullable: the full form, CASE and poison guard together.
--- The set holds a NULL, so no probe — NULL included — can qualify
+-- Both sides nullable: the full form, CASE and poison guard together. The set
+-- holds a NULL, so no probe, NULL included, can qualify
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM maybe_null m
 WHERE m.val NOT IN (SELECT val FROM maybe_null)

--- a/test/sql/subplan_pushdown.sql
+++ b/test/sql/subplan_pushdown.sql
@@ -117,7 +117,7 @@ WHERE item_id IN (SELECT item_id FROM sales
 ORDER BY item_id;
 
 -- ============================================================
--- 5. NOT IN (TPC-H Q16 shape) — arrives as NOT(ANY-SubPlan)
+-- 5. NOT IN (TPC-H Q16 shape): arrives as NOT(ANY-SubPlan)
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
@@ -158,7 +158,7 @@ ORDER BY item_id;
 
 -- ============================================================
 -- 8. Negative case: multi-row correlated scalar (no aggregate) must
---    NOT push down — zero-row semantics differ between PG and CH.
+--    NOT push down; zero-row semantics differ between PG and CH.
 -- ============================================================
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT s.sale_id FROM sales s
@@ -168,10 +168,10 @@ ORDER BY s.sale_id;
 
 -- ============================================================
 -- 9. Identity: the plan-time version probe must connect as the user the
---    executor will scan as — the view owner, via the RTE's checkAsUser —
---    not the invoker. regress_subplan_nomap has NO user mapping of its
---    own, so resolving the invoker instead would fail the EXPLAIN with
---    "user mapping not found".
+--    executor will scan as --- the view owner, via the RTE's checkAsUser ---
+--    not the invoker. regress_subplan_nomap has NO user mapping of its own,
+--    so resolving the invoker instead would fail the EXPLAIN with "user
+--    mapping not found".
 -- ============================================================
 CREATE ROLE regress_subplan_nomap;
 GRANT USAGE ON SCHEMA subplan_test TO regress_subplan_nomap;
@@ -202,8 +202,8 @@ DROP ROLE regress_subplan_nomap;
 --     dropped) where ClickHouse returns TRUE. Shape 5 above ships
 --     plain because both item_id columns import as NOT NULL; with a
 --     nullable column on either side the deparse compensates with
---     guards — a probe-NULL CASE (empty set is TRUE, else dropped)
---     and a NOT EXISTS poison check for NULLs in the set — each
+--     guards --- a probe-NULL CASE (empty set is TRUE, else dropped)
+--     and a NOT EXISTS poison check for NULLs in the set --- each
 --     emitted only when the corresponding proof fails.
 -- ============================================================
 CALL clickhouse_perform('subplan_admin', 'CREATE TABLE subplan_test.maybe_null
@@ -215,8 +215,8 @@ CREATE FOREIGN TABLE maybe_null (id int NOT NULL, val int)
     SERVER subplan_svr OPTIONS (table_name 'maybe_null');
 
 -- Nullable inner column, NOT NULL probe: ships as NOT IN plus the poison
--- guard (no CASE). Postgres returns no rows — the set holds a NULL — where
--- an unguarded pushdown would return items 4..6
+-- guard (no CASE). Postgres returns no rows because the set holds a NULL,
+-- whereas an unguarded pushdown would return items 4..6
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT item_id FROM items
 WHERE item_id NOT IN (SELECT val FROM maybe_null)
@@ -238,8 +238,8 @@ SELECT id FROM maybe_null
 WHERE val NOT IN (SELECT item_id FROM sales WHERE region = 'east')
 ORDER BY id;
 
--- Both sides nullable: the full form, CASE and poison guard together.
--- The set holds a NULL, so no probe — NULL included — can qualify
+-- Both sides nullable: the full form, CASE and poison guard together. The set
+-- holds a NULL, so no probe, NULL included, can qualify
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT id FROM maybe_null m
 WHERE m.val NOT IN (SELECT val FROM maybe_null)


### PR DESCRIPTION
*   Remove outdated, now irrelevant documentation
*   Reformat and/or re-wrap some docs, code & comment blocks
*   Copy-edit docs and comments